### PR TITLE
Skip install script if already installed

### DIFF
--- a/npm/esbuild/install.js
+++ b/npm/esbuild/install.js
@@ -17,6 +17,10 @@ function installPackage(package) {
       env[key] = process.env[key];
     }
   }
+  
+  if (fs.existsSync(installDir)) {
+    return;
+  }
 
   // Run "npm install" recursively to install this specific package
   fs.mkdirSync(installDir);


### PR DESCRIPTION
The install script sometimes throws error on subsequent `yarn` installs since `yarn` seems to invoke install scripts when it is shuffling things around. It also causes issue for CI where the `node_modules` directory is cached across builds.