### PR TITLE
fix(esbuild): Fix minimum version error on old versions of npm

### DIFF
--- a/npm/esbuild/index.js
+++ b/npm/esbuild/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { exec } = require('child_process');
+
+exec('npm -v', (err, stdout) => {
+  if (err) throw err;
+  if (parseFloat(stdout) < 5) {
+    // NOTE: This can happen if you have a dependency which lists an old version of npm in its own dependencies.
+    console.error(
+        'ERROR] You need npm version @>=5 but you have ' +
+        stdout 
+      );
+    process.exit(1);
+  }
+});
+
+require('./install');

--- a/npm/esbuild/package.json
+++ b/npm/esbuild/package.json
@@ -4,7 +4,7 @@
   "description": "An extremely fast JavaScript bundler and minifier.",
   "repository": "https://github.com/evanw/esbuild",
   "scripts": {
-    "postinstall": "node install.js"
+    "postinstall": "node index.js"
   },
   "main": "lib/main.js",
   "types": "lib/main.d.ts",


### PR DESCRIPTION
This can happen if you have a dependency which lists an old version of npm in its own dependencies.