### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ on:
 
 jobs:
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  esbuild:
+    name: esbuild CI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
 
     - name: Set up Go 1.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
     - name: go test
       run: go test ./internal/...
 
-    - name: npm ci
-      run: npm ci
+    - name: npm i
+      run: npm i
 
     - name: Verify Source Map
       run: node scripts/verify-source-map.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: go test
+      run: go test ./internal/...
+
+    - name: npm ci
+      run: npm ci
+
+    - name: Verify Source Map
+      run: node scripts/verify-source-map.js
+    
+    - name: E2E Tests
+      run: node scripts/end-to-end-tests.js
+    
+    - name: JS API Tests
+      run: node scripts/js-api-tests.js


### PR DESCRIPTION
Related issue: #94 

So far, this runs the following on Ubuntu, macOS and Windows:

```shell
go test ./internal/...
npm i
node scripts/verify-source-map.js
node scripts/end-to-end-tests.js
node scripts/js-api-tests.js
```

Can't use `npm ci` until npm/cli#558 is resolved.