### PR TITLE
fix name colission: use full path instead of base

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,7 +1,6 @@
 package ast
 
 import (
-	"path"
 	"strings"
 )
 
@@ -1204,17 +1203,16 @@ func MergeSymbols(symbols SymbolMap, old Ref, new Ref) Ref {
 	return new
 }
 
-func GenerateNonUniqueNameFromPath(text string) string {
+func GenerateNonUniqueNameFromPath(filePath string) string {
 	// Get the file name without the extension
-	base := path.Base(text)
-	lastDot := strings.LastIndexByte(base, '.')
+	lastDot := strings.LastIndexByte(filePath, '.')
 	if lastDot >= 0 {
-		base = base[:lastDot]
+		filePath = filePath[:lastDot]
 	}
 
 	// Convert it to an ASCII identifier
 	bytes := []byte{}
-	for _, c := range base {
+	for _, c := range filePath {
 		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (len(bytes) > 0 && c >= '0' && c <= '9') {
 			bytes = append(bytes, byte(c))
 		} else if len(bytes) > 0 && bytes[len(bytes)-1] != '_' {


### PR DESCRIPTION
`path.Base` only returns the last element of path https://golang.org/pkg/path/#Base

so if you have
```
someModule/action.js

otherModule/action.js
```

variable name for both modules gonna be

```
require_action_exports
```

which is causing collission because each module live on the same scope now

this change would need us to update all the tests, do you have a way to update it programmatically?

we probably could use the path from cwd instead full path too so it's easier to read :thinking: 