### PR TITLE
Add Godoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # esbuild
 
+[![Godoc](https://godoc.org/github.com/evanw/esbuild?status.svg)](https://godoc.org/github.com/evanw/esbuild/pkg/api)
+
 This is a JavaScript bundler and minifier. It packages up JavaScript and TypeScript code for distribution on the web.
 
 ## Documentation


### PR DESCRIPTION
Godoc is a common way for Go devs to look at a package.  It only shows exported methods and types so you get a clear view of the API.  Having a Godoc badge provides a handy shortcut.

I made the badge point at `pkg/api` since that is the main integration point and I'm guessing will see more use than `pkg/cli`.