### PR TITLE
Add empty loader

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -216,6 +216,10 @@ func parseFile(args parseArgs) {
 			jsonMetadataChunk: jsonMetadataChunk,
 		}
 
+	case LoaderEmpty:
+		expr := ast.Expr{ast.Loc{0}, &ast.EString{lexer.StringToUTF16("")}}
+		result.file.ast = parser.ModuleExportsAST(args.log, source, args.parseOptions, expr)
+
 	default:
 		result.ok = false
 		args.log.AddRangeError(args.importSource, args.pathRange,
@@ -424,6 +428,7 @@ const (
 	LoaderBase64
 	LoaderDataURL
 	LoaderFile
+	LoaderEmpty
 )
 
 func DefaultExtensionToLoaderMap() map[string]Loader {

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -2803,6 +2803,41 @@ func testAutoDetectMimeTypeFromExtension(t *testing.T) {
 	})
 }
 
+func TestLoaderEmpty(t *testing.T) {
+	expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				console.log(require('./test.svg'))
+			`,
+
+			// Use an SVG string that has a base64-encoded SHA1 has with a "/" in it
+			"/test.svg": "<svg>$</svg>",
+		},
+		entryPaths: []string{"/entry.js"},
+		parseOptions: parser.ParseOptions{
+			IsBundling: true,
+		},
+		bundleOptions: BundleOptions{
+			IsBundling:   true,
+			AbsOutputDir: "/out/",
+			ExtensionToLoader: map[string]Loader{
+				".js":  LoaderJS,
+				".svg": LoaderEmpty,
+			},
+		},
+		expected: map[string]string{
+			"/out/entry.js": `// /test.svg
+var require_test = __commonJS((exports, module) => {
+  module.exports = "";
+});
+
+// /entry.js
+console.log(require_test());
+`,
+		},
+	})
+}
+
 func TestLoaderFile(t *testing.T) {
 	expectBundled(t, bundled{
 		files: map[string]string{

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -1,7 +1,7 @@
 export declare type Target = 'esnext' | 'es6' | 'es2015' | 'es2016' | 'es2017' | 'es2018' | 'es2019' | 'es2020';
 export declare type Platform = 'browser' | 'node';
 export declare type Format = 'iife' | 'cjs' | 'esm';
-export declare type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'json' | 'text' | 'base64' | 'file' | 'dataurl';
+export declare type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'empty';
 export declare type LogLevel = 'info' | 'warning' | 'error' | 'silent';
 
 export interface CommonOptions {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -112,6 +112,7 @@ const (
 	LoaderBase64
 	LoaderDataURL
 	LoaderFile
+	LoaderEmpty
 )
 
 type Platform uint8

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -128,6 +128,8 @@ func validateLoader(value Loader) bundler.Loader {
 		return bundler.LoaderDataURL
 	case LoaderFile:
 		return bundler.LoaderFile
+	case LoaderEmpty:
+		return bundler.LoaderEmpty
 	default:
 		panic("Invalid loader")
 		return ^bundler.Loader(0)

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -309,9 +309,11 @@ func parseLoader(text string) (api.Loader, error) {
 		return api.LoaderDataURL, nil
 	case "file":
 		return api.LoaderFile, nil
+	case "empty":
+		return api.LoaderEmpty, nil
 	default:
 		return ^api.Loader(0), fmt.Errorf("Invalid loader: %q (valid: "+
-			"js, jsx, ts, tsx, json, text, base64, dataurl, file)", text)
+			"js, jsx, ts, tsx, json, text, base64, dataurl, file, empty)", text)
 	}
 }
 

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -222,6 +222,11 @@ let transformTests = {
     assert.strictEqual(js, `module.exports = "data:application/octet-stream;base64,AAEC";\n`)
   },
 
+  async empty({ service }) {
+    const { js } = await service.transform(`\x00\x01\x02`, { loader: 'empty' })
+    assert.strictEqual(js, `module.exports = "";\n`)
+  },
+
   async sourceMapWithName({ service }) {
     const { js, jsSourceMap } = await service.transform(`let       x`, { sourcemap: true, sourcefile: 'afile.js' })
     assert.strictEqual(js, `let x;\n`)


### PR DESCRIPTION
this is useful in case we want to have an empty string as the result of importing a module, for example: while running tests we don't want to emit files or load the full contents of the imported file to the memory.