### PR TITLE
fix(externals): exclude external child paths from the bundle

### DIFF
--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -4846,6 +4846,44 @@ render(h(App, null), document.getElementById("app"));
 	})
 }
 
+func TestExternalModuleExclusion(t *testing.T) {
+	expectBundled(t, bundled{
+		files: map[string]string{
+			"/index.js": `
+				import { S3 } from 'aws-sdk';
+				import { DocumentClient } from 'aws-sdk/clients/dynamodb';
+				export const s3 = new S3();
+				export const dynamodb = new DocumentClient();
+			`,
+		},
+		entryPaths: []string{"/index.js"},
+		parseOptions: parser.ParseOptions{
+			IsBundling: true,
+		},
+		bundleOptions: BundleOptions{
+			IsBundling:    true,
+			AbsOutputFile: "/out.js",
+		},
+		resolveOptions: resolver.ResolveOptions{
+			ExternalModules: map[string]bool{
+				"aws-sdk": true,
+			},
+		},
+		expected: map[string]string{
+			"/out.js": `// /index.js
+import {S3} from "aws-sdk";
+import {DocumentClient} from "aws-sdk/clients/dynamodb";
+const s3 = new S3();
+const dynamodb2 = new DocumentClient();
+export {
+  dynamodb2 as dynamodb,
+  s3
+};
+`,
+		},
+	})
+}
+
 // This test case makes sure many entry points don't cause a crash
 func TestManyEntryPoints(t *testing.T) {
 	expectBundled(t, bundled{

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -128,7 +128,8 @@ func (r *resolver) resolveWithoutSymlinks(sourcePath string, importPath string) 
 		}
 	} else {
 		// Check for external modules first
-		if r.options.ExternalModules != nil && r.options.ExternalModules[importPath] {
+		importPathRoot := strings.Split(importPath, "/")[0]
+		if r.options.ExternalModules != nil && r.options.ExternalModules[importPathRoot] {
 			return "", ResolveExternal
 		}
 


### PR DESCRIPTION
As an example, if `aws-sdk` is an external, imports from `aws-sdk/clients/dynamodb` must be excluded from the bundle as well.

Does it make sense @evanw ?