### PR TITLE
Make `npm install`-able on platforms supported by Go

### DIFF
--- a/lib/api-node.ts
+++ b/lib/api-node.ts
@@ -13,13 +13,6 @@ let esbuildCommandAndArgs = (): [string, string[]] => {
   let platform = process.platform;
   let arch = os.arch();
 
-  if (
-    (platform === 'darwin' && arch === 'x64') ||
-    (platform === 'linux' && (arch === 'x64' || arch === 'arm64' || (arch === 'ppc64' && os.endianness() === 'LE')))
-  ) {
-    return [path.join(__dirname, '..', 'bin', 'esbuild'), []];
-  }
-
   if (platform === 'win32' && arch === 'x64') {
     if (WASM) {
       return ['node', [path.join(__dirname, '..', 'bin', 'esbuild')]];
@@ -28,7 +21,7 @@ let esbuildCommandAndArgs = (): [string, string[]] => {
     }
   }
 
-  throw new Error(`Unsupported platform: ${platform} ${arch}`);
+  return [path.join(__dirname, '..', 'bin', 'esbuild'), []];
 };
 
 // Return true if stderr is a TTY


### PR DESCRIPTION
Although my platform is supported by Go, `npm install` fails because of a prebuilt binary is missing for the platform.
I think adding every platform supported by Go to the installation script and npm registry every time would be cost.

This adds install time compilation of `esbuild` binary.

I'm not sure this patch is the right way to build binary on-the-fly in npm ecosystem, but it seems to work on my platform (FreeBSD in this case) at least.