### PR TITLE
Reuse the unicode isSpace function

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -543,32 +543,10 @@ func IsIdentifierContinue(codePoint rune) bool {
 
 // See the "White Space Code Points" table in the ECMAScript standard
 func IsWhitespace(codePoint rune) bool {
-	switch codePoint {
+	switch {
 	case
-		'\u0009', // character tabulation
-		'\u000B', // line tabulation
-		'\u000C', // form feed
-		'\u0020', // space
-		'\u00A0', // no-break space
-
-		// Unicode "Space_Separator" code points
-		'\u1680', // ogham space mark
-		'\u2000', // en quad
-		'\u2001', // em quad
-		'\u2002', // en space
-		'\u2003', // em space
-		'\u2004', // three-per-em space
-		'\u2005', // four-per-em space
-		'\u2006', // six-per-em space
-		'\u2007', // figure space
-		'\u2008', // punctuation space
-		'\u2009', // thin space
-		'\u200A', // hair space
-		'\u202F', // narrow no-break space
-		'\u205F', // medium mathematical space
-		'\u3000', // ideographic space
-
-		'\uFEFF': // zero width non-breaking space
+		unicode.IsSpace(codePoint),
+		codePoint == '\uFEFF': // zero width non-breaking space
 		return true
 
 	default:


### PR DESCRIPTION
Reuse of the `unicode.IsSpace()` function of the standard Go library to check Unicode spaces, which includes spaces as defined by the ECMAScript spec.

