### PR TITLE
Define browser main for esbuild-wasm

### DIFF
--- a/npm/esbuild-wasm/package.json
+++ b/npm/esbuild-wasm/package.json
@@ -8,6 +8,7 @@
     "node": ">=8"
   },
   "main": "lib/main.js",
+  "browser": "lib/browser.js",
   "types": "lib/main.d.ts",
   "directories": {
     "bin": "bin"


### PR DESCRIPTION
This ensures bundlers and tools will properly support a browser build.

This can be done with "exports" too, but probably makes sense to use main / browser for a few months yet at least until Node.js 12 support can be assumed.