### PR TITLE
Attempt wasmURL construction

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -21,8 +21,14 @@ let transformSync: typeof types.transformSync = (input, options) => {
 
 let startService: typeof types.startService = options => {
   if (!options) throw new Error('Must provide an options object to "startService"');
-  if (!options.wasmURL) throw new Error('Must provide the "wasmURL" option');
-  return fetch(options.wasmURL).then(r => r.arrayBuffer()).then(wasm => {
+	let wasmURL = options.wasmURL;
+  if (!wasmURL) {
+		if (typeof __dirname !== 'undefined')
+			wasmURL = __dirname + '/../esbuild.wasm';
+		else
+			throw new Error('Must provide the "wasmURL" option');
+	}
+  return fetch(wasmURL).then(r => r.arrayBuffer()).then(wasm => {
     let code = `{` +
       `let global={};` +
       `for(let o=self;o;o=Object.getPrototypeOf(o))` +


### PR DESCRIPTION
Most browser bundlers include support for `__dirname` as a Node.js convention as originally implemented by Browserify.

This attempts to automatically construct `wasmURL` using this in the browser if it is defined only.

If shipping an ES module browser build we would be able to rely on `import.meta.url` but because there is no feature detection for this we can't check for it if we cannot assume the module type of the output file.

An alternative could be to provide two browser builds - one CommonJS and one ES module, and then only do the `import.meta.url` case in the ES module build.