### PR TITLE
Very simple SystemJS format support

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1253,14 +1253,15 @@ type AST struct {
 	HasES6Imports bool
 	HasES6Exports bool
 
-	Hashbang    string
-	Directive   string
-	Parts       []Part
-	Symbols     SymbolMap
-	ModuleScope *Scope
-	ExportsRef  Ref
-	ModuleRef   Ref
-	WrapperRef  Ref
+	Hashbang         string
+	Directive        string
+	Parts            []Part
+	Symbols          SymbolMap
+	ModuleScope      *Scope
+	ExportsRef       Ref
+	ModuleRef        Ref
+	WrapperRef       Ref
+	SystemExportsRef Ref
 
 	// These are stored at the AST level instead of on individual AST nodes so
 	// they can be manipulated efficiently without a full AST traversal

--- a/internal/bundler/bundler_systemjs_test.go
+++ b/internal/bundler/bundler_systemjs_test.go
@@ -1,0 +1,86 @@
+package bundler
+
+import (
+	"testing"
+
+	"github.com/evanw/esbuild/internal/config"
+)
+
+func TestSplittingSharedES6IntoSystemJS(t *testing.T) {
+	expectBundled(t, bundled{
+		files: map[string]string{
+			"/test.js": `
+        import './side-effect.js';
+        import * as dep from './dep.js';
+        export var p = dep.q * 10;
+        import('external');
+      `,
+			"/side-effect.js": `
+        global.sideeffect = 'side effect';
+      `,
+			"/dep.js": `export var q = 10`,
+		},
+		entryPaths: []string{"/test.js", "/dep.js"},
+		options: config.Options{
+			IsBundling:    true,
+			CodeSplitting: true,
+			OutputFormat:  config.FormatSystemJS,
+			AbsOutputDir:  "/out",
+			ExternalModules: config.ExternalModules{
+				NodeModules: map[string]bool{
+					"external": true,
+				},
+			},
+		},
+		expected: map[string]string{
+			"/out/test.js": `System.register(["./chunk.Jhw0X7kF.js"], function (__exports, __context) {
+  var q;
+  return {
+    setters: [function (__m) {
+      q = __m.q;
+    }],
+    execute: function () {
+      // /side-effect.js
+      global.sideeffect = "side effect";
+
+      // /test.js
+      var p = q * 10;
+      __context.import("external");
+      __exports({
+        p
+      });
+    }
+  };
+});
+`,
+			"/out/dep.js": `System.register(["./chunk.Jhw0X7kF.js"], function (__exports, __context) {
+  var q;
+  return {
+    setters: [function (__m) {
+      q = __m.q;
+    }],
+    execute: function () {
+      // /dep.js
+      __exports({
+        q
+      });
+    }
+  };
+});
+`,
+			"/out/chunk.Jhw0X7kF.js": `System.register([], function (__exports, __context) {
+  return {
+    setters: [],
+    execute: function () {
+      // /dep.js
+      var q = 10;
+      __exports({
+        q
+      });
+    }
+  };
+});
+`,
+		},
+	})
+}

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -363,7 +363,8 @@ func newLinkerContext(
 
 		// Entry points must be CommonJS-style if the output format doesn't support
 		// ES6 export syntax
-		if !options.OutputFormat.KeepES6ImportExportSyntax() && c.files[sourceIndex].ast.HasES6Exports {
+		if !options.OutputFormat.KeepES6ImportExportSyntax() && options.OutputFormat != config.FormatSystemJS &&
+			c.files[sourceIndex].ast.HasES6Exports {
 			fileMeta.cjsStyleExports = true
 		}
 	}
@@ -640,14 +641,16 @@ func (c *linkerContext) computeCrossChunkDependencies(chunks []chunkMeta) {
 		for _, crossChunkImport := range c.sortedCrossChunkImports(chunks, importsFromOtherChunks) {
 			switch c.options.OutputFormat {
 			case config.FormatESModule:
+			case config.FormatSystemJS:
 				var items []ast.ClauseItem
 				for _, alias := range crossChunkImport.sortedImportAliases {
 					items = append(items, ast.ClauseItem{Name: ast.LocRef{Ref: alias.ref}, Alias: alias.name})
 				}
 				importRecordIndex := uint32(len(crossChunkImportRecords))
 				crossChunkImportRecords = append(crossChunkImportRecords, ast.ImportRecord{
-					Kind: ast.ImportStmt,
-					Path: ast.Path{Text: c.relativePathBetweenChunks(chunk, chunks[crossChunkImport.chunkIndex].relPath)},
+					DoesNotUseExports: len(items) == 0,
+					Kind:              ast.ImportStmt,
+					Path:              ast.Path{Text: c.relativePathBetweenChunks(chunk, chunks[crossChunkImport.chunkIndex].relPath)},
 				})
 				if len(items) > 0 {
 					// "import {a, b} from './chunk.js'"
@@ -675,6 +678,7 @@ func (c *linkerContext) computeCrossChunkDependencies(chunks []chunkMeta) {
 	for chunkIndex := range chunks {
 		switch c.options.OutputFormat {
 		case config.FormatESModule:
+		case config.FormatSystemJS:
 			var items []ast.ClauseItem
 			for _, alias := range c.sortedCrossChunkExportRefs(chunkMetas[chunkIndex].exports) {
 				items = append(items, ast.ClauseItem{Name: ast.LocRef{Ref: alias.ref}, Alias: alias.name})
@@ -929,7 +933,8 @@ func (c *linkerContext) scanImportsAndExports() {
 		// resulting wrapper won't be invoked by other files.
 		if !fileMeta.cjsWrap && fileMeta.cjsStyleExports &&
 			(c.options.OutputFormat == config.FormatIIFE ||
-				c.options.OutputFormat == config.FormatESModule) {
+				c.options.OutputFormat == config.FormatESModule ||
+				c.options.OutputFormat == config.FormatSystemJS) {
 			fileMeta.cjsWrap = true
 		}
 
@@ -1125,7 +1130,8 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 	// export statement that's not top-level. Instead, we will export the CommonJS
 	// exports as a default export later on.
 	needsEntryPointES6ExportPart := isEntryPoint && !fileMeta.cjsWrap &&
-		c.options.OutputFormat == config.FormatESModule && len(fileMeta.sortedAndFilteredExportAliases) > 0
+		(c.options.OutputFormat == config.FormatESModule || c.options.OutputFormat == config.FormatSystemJS) &&
+		len(fileMeta.sortedAndFilteredExportAliases) > 0
 
 	// Generate a getter per export
 	properties := []ast.Property{}
@@ -1344,8 +1350,24 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 	}
 
 	if len(entryPointES6ExportItems) > 0 {
-		entryPointExportStmts = append(entryPointExportStmts,
-			ast.Stmt{Data: &ast.SExportClause{Items: entryPointES6ExportItems}})
+		if c.options.OutputFormat == config.FormatSystemJS {
+			properties := []ast.Property{}
+			for _, item := range entryPointES6ExportItems {
+				properties = append(properties, ast.Property{
+					Key:   ast.Expr{Data: &ast.EString{Value: lexer.StringToUTF16(item.Alias)}},
+					Value: &ast.Expr{Data: &ast.EIdentifier{Ref: item.Name.Ref}},
+				})
+			}
+			entryPointExportStmts = append(entryPointExportStmts, ast.Stmt{Data: &ast.SExpr{
+				Value: ast.Expr{Data: &ast.ECall{
+					Target: ast.Expr{Data: &ast.EIdentifier{Ref: file.ast.SystemExportsRef}},
+					Args:   []ast.Expr{{Data: &ast.EObject{Properties: properties}}},
+				}},
+			}})
+		} else {
+			entryPointExportStmts = append(entryPointExportStmts,
+				ast.Stmt{Data: &ast.SExportClause{Items: entryPointES6ExportItems}})
+		}
 	}
 
 	// If we're an entry point, call the require function at the end of the
@@ -1458,7 +1480,8 @@ func (c *linkerContext) matchImportsWithExportsForFile(sourceIndex uint32) {
 			nextTracker, status := c.advanceImportTracker(tracker)
 			switch status {
 			case importCommonJS, importCommonJSWithoutExports, importExternal:
-				if status == importExternal && c.options.OutputFormat.KeepES6ImportExportSyntax() {
+				if status == importExternal &&
+					(c.options.OutputFormat.KeepES6ImportExportSyntax() || c.options.OutputFormat == config.FormatSystemJS) {
 					// Imports from external modules should not be converted to CommonJS
 					// if the output format preserves the original ES6 import statements
 					break
@@ -2013,7 +2036,8 @@ func (c *linkerContext) includePart(sourceIndex uint32, partIndex uint32, entryP
 		if record.SourceIndex == nil || c.isExternalDynamicImport(record) {
 			// This is an external import, so it needs the "__toModule" wrapper as
 			// long as it's not a bare "require()"
-			if record.Kind != ast.ImportRequire && !c.options.OutputFormat.KeepES6ImportExportSyntax() {
+			if record.Kind != ast.ImportRequire &&
+				!(c.options.OutputFormat.KeepES6ImportExportSyntax() || c.options.OutputFormat == config.FormatSystemJS) {
 				record.WrapWithToModule = true
 				toModuleUses++
 			}
@@ -2656,6 +2680,9 @@ func (c *linkerContext) generateCodeForFileInChunk(
 	if c.options.OutputFormat == config.FormatIIFE {
 		indent++
 	}
+	if c.options.OutputFormat == config.FormatSystemJS {
+		indent += 3
+	}
 
 	// Convert the AST to JavaScript code
 	printOptions := printer.PrintOptions{
@@ -2736,20 +2763,25 @@ func (c *linkerContext) generateChunk(chunk chunkMeta) (results []OutputFile) {
 		if c.options.OutputFormat == config.FormatIIFE {
 			indent++
 		}
+		if c.options.OutputFormat == config.FormatSystemJS {
+			indent += 3
+		}
 		printOptions := printer.PrintOptions{
 			Indent:           indent,
 			OutputFormat:     c.options.OutputFormat,
 			RemoveWhitespace: c.options.RemoveWhitespace,
 		}
-		crossChunkPrefix = printer.Print(ast.AST{
-			ImportRecords: chunk.crossChunkImportRecords,
-			Parts:         []ast.Part{{Stmts: chunk.crossChunkPrefixStmts}},
-			Symbols:       c.symbols,
-		}, printOptions).JS
-		crossChunkSuffix = printer.Print(ast.AST{
-			Parts:   []ast.Part{{Stmts: chunk.crossChunkSuffixStmts}},
-			Symbols: c.symbols,
-		}, printOptions).JS
+		if c.options.OutputFormat != config.FormatSystemJS {
+			crossChunkPrefix = printer.Print(ast.AST{
+				ImportRecords: chunk.crossChunkImportRecords,
+				Parts:         []ast.Part{{Stmts: chunk.crossChunkPrefixStmts}},
+				Symbols:       c.symbols,
+			}, printOptions).JS
+			crossChunkSuffix = printer.Print(ast.AST{
+				Parts:   []ast.Part{{Stmts: chunk.crossChunkSuffixStmts}},
+				Symbols: c.symbols,
+			}, printOptions).JS
+		}
 	}
 	waitGroup.Wait()
 
@@ -2788,7 +2820,7 @@ func (c *linkerContext) generateChunk(chunk chunkMeta) (results []OutputFile) {
 
 	// Optionally wrap with an IIFE
 	if c.options.OutputFormat == config.FormatIIFE {
-		indent = "  "
+		indent = space + space
 		text := "(()" + space + "=>" + space + "{" + newline
 		if c.options.ModuleName != "" {
 			text = "var " + c.options.ModuleName + space + "=" + space + text
@@ -2798,7 +2830,82 @@ func (c *linkerContext) generateChunk(chunk chunkMeta) (results []OutputFile) {
 		newlineBeforeComment = false
 	}
 
-	// Put the cross-chunk prefix inside the IIFE
+	if c.options.OutputFormat == config.FormatSystemJS {
+		indent = space + space
+		text := "System.register(["
+		isFirstItem := true
+		for _, record := range chunk.crossChunkImportRecords {
+			if !isFirstItem {
+				text += "," + space
+			}
+			text += "\"" + record.Path.Text + "\""
+			isFirstItem = false
+		}
+		text += "]," + space + "function" + space + "(__exports, __context)" + space + "{" + newline
+		text += indent
+		isFirstItem = true
+		for _, stmt := range chunk.crossChunkPrefixStmts {
+			switch s := stmt.Data.(type) {
+			case *ast.SImport:
+				if s.Items != nil {
+					for _, item := range *s.Items {
+						if isFirstItem {
+							text += "var "
+						} else {
+							text += "," + space
+						}
+						text += item.Alias
+						isFirstItem = false
+					}
+				}
+			default:
+				panic(fmt.Sprintf("Unexpected import of type %T", stmt.Data))
+			}
+		}
+		if !isFirstItem {
+			text += ";" + newline + indent
+		}
+		text += "return" + space + "{" + newline
+		indent += space + space
+		text += indent + "setters:" + space + "["
+		isFirstItem = true
+		for index, record := range chunk.crossChunkImportRecords {
+			if !isFirstItem {
+				text += "," + space
+			}
+			if record.DoesNotUseExports {
+				text += "null"
+			} else {
+				text += "function" + space + "(__m)" + space + "{" + newline + indent + space + space
+				for _, stmt := range chunk.crossChunkPrefixStmts {
+					switch s := stmt.Data.(type) {
+					case *ast.SImport:
+						if s.ImportRecordIndex == uint32(index) && s.Items != nil {
+							for _, item := range *s.Items {
+								if !isFirstItem {
+									text += "," + space
+								}
+								text += item.Alias + " = __m." + c.symbols.Get(item.Name.Ref).Name
+								isFirstItem = false
+							}
+						}
+					default:
+						panic(fmt.Sprintf("Unexpected import of type %T", stmt.Data))
+					}
+				}
+				text += ";" + newline + indent + "}"
+			}
+			isFirstItem = false
+		}
+		text += "]," + newline
+		text += indent + "execute:" + space + "function" + space + "()" + space + "{" + newline
+		indent += space + space
+		prevOffset.advance(text)
+		j.AddString(text)
+		newlineBeforeComment = false
+	}
+
+	// Put the cross-chunk prefix inside the iife
 	if len(crossChunkPrefix) > 0 {
 		newlineBeforeComment = true
 		j.AddBytes(crossChunkPrefix)
@@ -2900,7 +3007,7 @@ func (c *linkerContext) generateChunk(chunk chunkMeta) (results []OutputFile) {
 		j.AddBytes(entryPointTail.JS)
 	}
 
-	// Put the cross-chunk suffix inside the IIFE
+	// Put the cross-chunk suffix inside the iife
 	if len(crossChunkSuffix) > 0 {
 		if newlineBeforeComment {
 			j.AddString(newline)
@@ -2911,6 +3018,34 @@ func (c *linkerContext) generateChunk(chunk chunkMeta) (results []OutputFile) {
 	// Optionally wrap with an IIFE
 	if c.options.OutputFormat == config.FormatIIFE {
 		j.AddString("})();" + newline)
+	}
+	if c.options.OutputFormat == config.FormatSystemJS {
+		text := ""
+		isFirstItem := true
+		for _, stmt := range chunk.crossChunkSuffixStmts {
+			switch s := stmt.Data.(type) {
+			case *ast.SExportClause:
+				if isFirstItem {
+					text += indent + "__exports({"
+				}
+				for _, item := range s.Items {
+					if !isFirstItem {
+						text += ","
+					}
+					text += newline + indent + space + space + item.Alias
+					name := c.symbols.Get(item.Name.Ref).Name
+					if item.Alias != name {
+						text += ":" + space + name
+					}
+					isFirstItem = false
+				}
+			}
+		}
+		if !isFirstItem {
+			text += newline + indent + "});" + newline
+		}
+		text += space + space + space + space + "}" + newline + space + space + "};" + newline + "});"
+		j.AddString(text)
 	}
 
 	// Make sure the file ends with a newline

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,19 @@ const (
 	//
 	FormatCommonJS
 
+	// The SystemJS module format looks like this:
+	//
+	// System.register([], function (__export, __context) {
+	//   return {
+	//     setters: [],
+	//     execute: function () {
+	//       ... bundled code ...
+	//     }
+	//   };
+	// });
+	//
+	FormatSystemJS
+
 	// The ES module format looks like this:
 	//
 	//   ... bundled code ...

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -48,6 +48,7 @@ type parser struct {
 	exportsRef               ast.Ref
 	requireRef               ast.Ref
 	moduleRef                ast.Ref
+	systemExportsRef         ast.Ref
 	importMetaRef            ast.Ref
 	findSymbolHelper         config.FindSymbol
 	symbolUses               map[ast.Ref]ast.SymbolUse
@@ -8472,6 +8473,10 @@ func newParser(log logging.Log, source logging.Source, lexer lexer.Lexer, option
 		namedExports:            make(map[string]ast.Ref),
 	}
 
+	if options.OutputFormat == config.FormatSystemJS {
+		p.systemExportsRef = p.newSymbol(ast.SymbolOther, "__exports")
+	}
+
 	p.findSymbolHelper = func(name string) ast.Ref { return p.findSymbol(name).ref }
 	p.pushScopeForParsePass(ast.ScopeEntry, ast.Loc{Start: locModuleScope})
 
@@ -8799,6 +8804,7 @@ func (p *parser) toAST(source logging.Source, parts []ast.Part, hashbang string,
 		ExportsRef:              p.exportsRef,
 		ModuleRef:               p.moduleRef,
 		WrapperRef:              wrapperRef,
+		SystemExportsRef:        p.systemExportsRef,
 		Hashbang:                hashbang,
 		Directive:               directive,
 		NamedImports:            p.namedImports,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1093,10 +1093,17 @@ func (p *printer) printRequireOrImportExpr(importRecordIndex uint32) {
 	p.printSpaceBeforeIdentifier()
 
 	// Preserve "import()" expressions that don't point inside the bundle
-	if record.SourceIndex == nil && record.Kind == ast.ImportDynamic && p.options.OutputFormat.KeepES6ImportExportSyntax() {
-		p.print("import(")
-		p.print(Quote(record.Path.Text))
-		p.print(")")
+	if record.SourceIndex == nil && record.Kind == ast.ImportDynamic {
+		if p.options.OutputFormat.KeepES6ImportExportSyntax() {
+			p.print("import(")
+			p.print(Quote(record.Path.Text))
+			p.print(")")
+		}
+		if p.options.OutputFormat == config.FormatSystemJS {
+			p.print("__context.import(")
+			p.print(Quote(record.Path.Text))
+			p.print(")")
+		}
 		return
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -129,6 +129,7 @@ const (
 	FormatDefault Format = iota
 	FormatIIFE
 	FormatCommonJS
+	FormatSystemJS
 	FormatESModule
 )
 

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -36,6 +36,8 @@ func validateFormat(value Format) config.Format {
 		return config.FormatIIFE
 	case FormatCommonJS:
 		return config.FormatCommonJS
+	case FormatSystemJS:
+		return config.FormatSystemJS
 	case FormatESModule:
 		return config.FormatESModule
 	default:
@@ -476,8 +478,8 @@ func buildImpl(buildOpts BuildOptions) BuildResult {
 	}
 
 	// Code splitting is experimental and currently only enabled for ES6 modules
-	if options.CodeSplitting && options.OutputFormat != config.FormatESModule {
-		log.AddError(nil, ast.Loc{}, "Splitting currently only works with the \"esm\" format")
+	if options.CodeSplitting && options.OutputFormat != config.FormatESModule && options.OutputFormat != config.FormatSystemJS {
+		log.AddError(nil, ast.Loc{}, "Splitting currently only works with the \"esm\" and \"systemjs\" formats")
 	}
 
 	var outputFiles []OutputFile

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -232,10 +232,12 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 				buildOpts.Format = api.FormatIIFE
 			case "cjs":
 				buildOpts.Format = api.FormatCommonJS
+			case "systemjs":
+				buildOpts.Format = api.FormatSystemJS
 			case "esm":
 				buildOpts.Format = api.FormatESModule
 			default:
-				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, esm)", value)
+				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, systemjs, esm)", value)
 			}
 
 		case strings.HasPrefix(arg, "--external:") && buildOpts != nil:


### PR DESCRIPTION
Implements https://github.com/evanw/esbuild/issues/192.

The benefit of outputting the SystemJS module format is being able to use code splitting workflows in non modules browsers.

This does not include support for live bindings, and will likely have edge cases still to be worked out.

There is repetition between chunk import/export rendering and entry point export rendering. Ideally these separate codepaths could be combined. See for example in RollupJS here how finalizers use their own import/export data structures to render to any format using this interface - https://github.com/rollup/rollup/blob/master/src/finalisers/index.ts#L11. Fully separating the finalizers also avoids cluttering the rendering code with format gating which isn't ideal here.

Very much open to feedback on this PR if you have suggestions for improvements. And let me know if you have any other questions about the format as well.