### PR TITLE
Update README's «Used By» section to include Kretes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Several reasons:
 * [Vite](https://github.com/vuejs/vite)
 * [Snowpack](https://github.com/pikapkg/snowpack)
 * [HUGO](https://github.com/gohugoio/hugo)
+* [Kretes](https://kretes.dev/)
 
 #### Currently supported:
 


### PR DESCRIPTION
Kretes bundles TypeScript code in development using `esbuild` similarly to Vite.  