### PR TITLE
feat: support custom npm registry tarball download

### DIFF
--- a/lib/install.ts
+++ b/lib/install.ts
@@ -20,7 +20,8 @@ async function installBinaryFromPackage(name: string, fromPath: string, toPath: 
 
   // Download the package from npm
   let officialRegistry = 'registry.npmjs.org';
-  let urls = [`https://${officialRegistry}/${name}/-/${name}-${version}.tgz`];
+  const registryUrlFormat = process.env.npm_config_registry_format || `https://${officialRegistry}/{name}/-/{name}-{version}.tgz`;
+  let urls = [registryUrlFormat].map(registryUrl => registryUrl.replace(/\{name\}/g, name).replace(/\{version\}/g, version));
   let debug = false;
 
   // Try downloading from a custom registry first if one is configured


### PR DESCRIPTION
Hello, when downloading esbuild using a private npm source (such as [cnpm](https://cnpmjs.org/)), if the download `tarball` format of the private source is different from that of npm, the download will fail.



![image](https://user-images.githubusercontent.com/13595509/88987338-2c05d400-d308-11ea-8f0f-c7d61268d0b7.png)

