### PR TITLE
Fix broken NewExpressions containing require calls

### DIFF
--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -79,6 +79,27 @@ func TestNestedCommonJS(t *testing.T) {
 	})
 }
 
+// This test makes sure that NewExpressions containing require() calls aren't
+// broken.
+func TestNewExpressionCommonJS(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+        new (require("./foo.js")).Foo();
+			`,
+			"/foo.js": `
+        class Foo {}
+				module.exports = {Foo};
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			IsBundling:    true,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
 func TestCommonJSFromES6(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1204,6 +1204,19 @@ TestNestedScopeBug
 })();
 
 ================================================================================
+TestNewExpressionCommonJS
+---------- /out.js ----------
+// /foo.js
+var require_foo = __commonJS((exports, module) => {
+  class Foo {
+  }
+  module.exports = {Foo};
+});
+
+// /entry.js
+new (require_foo()).Foo();
+
+================================================================================
 TestNodeModules
 ---------- /Users/user/project/out.js ----------
 // /Users/user/project/node_modules/demo-pkg/index.js

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1226,6 +1226,7 @@ const (
 	forbidCall = 1 << iota
 	forbidIn
 	hasNonOptionalChainParent
+	wrapRequireCall
 )
 
 func (p *printer) printUndefined(level ast.L) {
@@ -1290,7 +1291,7 @@ func (p *printer) printExpr(expr ast.Expr, level ast.L, flags int) {
 		p.printSpaceBeforeIdentifier()
 		p.print("new")
 		p.printSpace()
-		p.printExpr(e.Target, ast.LNew, forbidCall)
+		p.printExpr(e.Target, ast.LNew, forbidCall|wrapRequireCall)
 
 		// TODO: Omit this while minifying
 		p.print("(")
@@ -1363,7 +1364,7 @@ func (p *printer) printExpr(expr ast.Expr, level ast.L, flags int) {
 		}
 
 	case *ast.ERequire:
-		wrap := level >= ast.LNew
+		wrap := level >= ast.LNew || (flags&wrapRequireCall) != 0
 		if wrap {
 			p.print("(")
 		}


### PR DESCRIPTION
Fixes https://github.com/evanw/esbuild/issues/339 and adds a regression test.

This flag could probably be unset when not strictly necessary, but the extra wrapping parens will at worst be merely redundant.