### PR TITLE
feat: support format option for transform

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -259,7 +259,7 @@ func parseFile(args parseArgs) {
 	if args.options.IsBundling {
 		result.resolveResults = make([]*resolver.ResolveResult, len(result.file.ast.ImportRecords))
 
-		if len(result.file.ast.ImportRecords) > 0 {
+		if len(result.file.ast.ImportRecords) > 0 && !(args.options.IsTransforming && args.options.OutputFormat != config.FormatIIFE) {
 			cache := make(map[string]*resolver.ResolveResult)
 
 			// Resolve relative to the parent directory of the source file with the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,7 +145,8 @@ type ExternalModules struct {
 type Options struct {
 	// true: imports are scanned and bundled along with the file
 	// false: imports are left alone and the file is passed through as-is
-	IsBundling bool
+	IsBundling     bool
+	IsTransforming bool
 
 	RemoveWhitespace  bool
 	MinifyIdentifiers bool

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -20,6 +20,8 @@ function pushCommonFlags(flags: string[], options: types.CommonOptions, isTTY: b
   if (options.minifyWhitespace) flags.push('--minify-whitespace');
   if (options.minifyIdentifiers) flags.push('--minify-identifiers');
 
+  if (options.format) flags.push(`--format=${options.format}`);
+
   if (options.jsxFactory) flags.push(`--jsx-factory=${options.jsxFactory}`);
   if (options.jsxFragment) flags.push(`--jsx-fragment=${options.jsxFragment}`);
   if (options.define) {
@@ -50,7 +52,6 @@ function flagsForBuildOptions(options: types.BuildOptions, isTTY: boolean): [str
   if (options.outfile) flags.push(`--outfile=${options.outfile}`);
   if (options.outdir) flags.push(`--outdir=${options.outdir}`);
   if (options.platform) flags.push(`--platform=${options.platform}`);
-  if (options.format) flags.push(`--format=${options.format}`);
   if (options.tsconfig) flags.push(`--tsconfig=${options.tsconfig}`);
   if (options.resolveExtensions) flags.push(`--resolve-extensions=${options.resolveExtensions.join(',')}`);
   if (options.external) for (let name of options.external) flags.push(`--external:${name}`);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,6 +9,8 @@ export interface CommonOptions {
   target?: string | string[];
   strict?: boolean | Strict[];
 
+  format?: Format;
+
   minify?: boolean;
   minifyWhitespace?: boolean;
   minifyIdentifiers?: boolean;
@@ -32,7 +34,6 @@ export interface BuildOptions extends CommonOptions {
   metafile?: string;
   outdir?: string;
   platform?: Platform;
-  format?: Format;
   color?: boolean;
   external?: string[];
   loader?: { [ext: string]: Loader };

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -271,6 +271,8 @@ type TransformOptions struct {
 	Defines       map[string]string
 	PureFunctions []string
 
+	Format     Format
+
 	Sourcefile string
 	Loader     Loader
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -271,7 +271,7 @@ type TransformOptions struct {
 	Defines       map[string]string
 	PureFunctions []string
 
-	Format     Format
+	Format Format
 
 	Sourcefile string
 	Loader     Loader

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -592,6 +592,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 
 	// Convert and validate the transformOpts
 	options := config.Options{
+		IsTransforming: true,
 		UnsupportedFeatures: validateFeatures(log, transformOpts.Target, transformOpts.Engines),
 		Strict:              validateStrict(transformOpts.Strict),
 		JSX: config.JSXOptions{
@@ -603,6 +604,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 		MangleSyntax:      transformOpts.MinifySyntax,
 		RemoveWhitespace:  transformOpts.MinifyWhitespace,
 		MinifyIdentifiers: transformOpts.MinifyIdentifiers,
+		OutputFormat:      validateFormat(transformOpts.Format),
 		AbsOutputFile:     transformOpts.Sourcefile + "-out",
 		Stdin: &config.StdinInfo{
 			Loader:     validateLoader(transformOpts.Loader),
@@ -610,6 +612,13 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 			SourceFile: transformOpts.Sourcefile,
 		},
 	}
+
+	if options.OutputFormat == config.FormatESModule {
+		options.OutputFormat = config.FormatPreserve
+	} else if options.OutputFormat != config.FormatPreserve {
+		options.IsBundling = true
+	}
+
 	if options.SourceMap == config.SourceMapLinkedWithComment {
 		// Linked source maps don't make sense because there's no output file name
 		log.AddError(nil, ast.Loc{}, "Cannot transform with linked source maps")

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -592,7 +592,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 
 	// Convert and validate the transformOpts
 	options := config.Options{
-		IsTransforming: true,
+		IsTransforming:      true,
 		UnsupportedFeatures: validateFeatures(log, transformOpts.Target, transformOpts.Engines),
 		Strict:              validateStrict(transformOpts.Strict),
 		JSX: config.JSXOptions{

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -238,15 +238,27 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 				return fmt.Errorf("Invalid platform: %q (valid: browser, node)", value)
 			}
 
-		case strings.HasPrefix(arg, "--format=") && buildOpts != nil:
+		case strings.HasPrefix(arg, "--format="):
 			value := arg[len("--format="):]
 			switch value {
 			case "iife":
+				if buildOpts != nil {
 				buildOpts.Format = api.FormatIIFE
+				} else {
+					transformOpts.Format = api.FormatIIFE
+				}
 			case "cjs":
+				if buildOpts != nil {
 				buildOpts.Format = api.FormatCommonJS
+				} else {
+					transformOpts.Format = api.FormatCommonJS
+				}
 			case "esm":
+				if buildOpts != nil {
 				buildOpts.Format = api.FormatESModule
+				} else {
+					transformOpts.Format = api.FormatESModule
+				}
 			default:
 				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, esm)", value)
 			}

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -243,19 +243,19 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			switch value {
 			case "iife":
 				if buildOpts != nil {
-				buildOpts.Format = api.FormatIIFE
+					buildOpts.Format = api.FormatIIFE
 				} else {
 					transformOpts.Format = api.FormatIIFE
 				}
 			case "cjs":
 				if buildOpts != nil {
-				buildOpts.Format = api.FormatCommonJS
+					buildOpts.Format = api.FormatCommonJS
 				} else {
 					transformOpts.Format = api.FormatCommonJS
 				}
 			case "esm":
 				if buildOpts != nil {
-				buildOpts.Format = api.FormatESModule
+					buildOpts.Format = api.FormatESModule
 				} else {
 					transformOpts.Format = api.FormatESModule
 				}

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -491,7 +491,7 @@ let transformTests = {
 
       assert.fail('iife can not import')
     } catch (error) {
-      assert.strictEqual(error.message, `Transform failed with 1 error:\n<stdin>:1:17: error: Could not resolve "path"`)
+      assert.strictEqual(error.message, `Transform failed with 1 error:\n<stdin>:1:17: error: Could not resolve "path" (set platform to "node" when building for node)`)
     }
   },
 


### PR DESCRIPTION
This allows to use `transform` to output a different format without
going through `build` which would resolve all imports.

Import handling:

- `cjs`: imports are not resolved and re-written as `require` calls
- `iife`: any import will throw