### PR TITLE
Add tree shaking of unused pure binary expressions

### DIFF
--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -662,3 +662,23 @@ func TestTreeShakingReactElements(t *testing.T) {
 		},
 	})
 }
+
+func TestTreeShakingBinaryExpressions(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				let a = "a";
+				let b = a + "b";
+
+				let c = "c";
+				let d = c + "d";
+				console.log(d);
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			IsBundling:    true,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}

--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -673,6 +673,14 @@ func TestTreeShakingBinaryExpressions(t *testing.T) {
 				let c = "c";
 				let d = c + "d";
 				console.log(d);
+
+				let e = {
+					toString() {
+						console.log("effect");
+						return "e";
+					}
+				}
+				let noprune = "str" + e;
 			`,
 		},
 		entryPaths: []string{"/entry.js"},

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -227,6 +227,14 @@ TestTextLoaderRemoveUnused
 console.log("unused import");
 
 ================================================================================
+TestTreeShakingBinaryExpressions
+---------- /out.js ----------
+// /entry.js
+let c = "c";
+let d = c + "d";
+console.log(d);
+
+================================================================================
 TestTreeShakingReactElements
 ---------- /out.js ----------
 // /entry.jsx

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -233,6 +233,13 @@ TestTreeShakingBinaryExpressions
 let c = "c";
 let d = c + "d";
 console.log(d);
+let e = {
+  toString() {
+    console.log("effect");
+    return "e";
+  }
+};
+let noprune = "str" + e;
 
 ================================================================================
 TestTreeShakingReactElements

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -8910,6 +8910,9 @@ func (p *parser) exprCanBeRemovedIfUnused(expr ast.Expr) bool {
 		*ast.EString, *ast.EThis, *ast.ERegExp, *ast.EFunction, *ast.EArrow, *ast.EImportMeta:
 		return true
 
+	case *ast.EBinary:
+		return p.exprCanBeRemovedIfUnused(e.Left) && p.exprCanBeRemovedIfUnused(e.Right)
+
 	case *ast.EDot:
 		return e.CanBeRemovedIfUnused
 


### PR DESCRIPTION
Fixes https://github.com/evanw/esbuild/issues/345

- Adds logic to recursively check if the left and right sub-expressions of a binary expression would be able to pruned. If they both are, then the binary expression itself can also be pruned.
- Adds a regression test.