### PR TITLE
Makefile: fix build tasks on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ js-api-tests: | scripts/node_modules
 	node scripts/js-api-tests.js
 
 update-version-go:
-	echo "package main\n\nconst esbuildVersion = \"$(ESBUILD_VERSION)\"" > cmd/esbuild/version.go
+	echo -e "package main\n\nconst esbuildVersion = \"$(ESBUILD_VERSION)\"" > cmd/esbuild/version.go
 
 platform-all: update-version-go test-all
 	make -j11 \


### PR DESCRIPTION
This adds the `-e` option to `echo`, that explictly enables the interpretation of backslash-escaped characters.

Without this option, the task was literally writing `package main\n\nconst esbuildVersion =` in `cmd/esbuild/version.go` on my system (Arch Linux).

echo version:
```console
$ /bin/echo --version

echo (GNU coreutils) 8.32
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Brian Fox and Chet Ramey.
```

I can’t test on macOS, but [the option seems to be supported as well](https://ss64.com/osx/echo.html).