### PR TITLE
Fix parsing of awaited tagged template expressions

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -2093,7 +2093,7 @@ func (p *parser) parsePrefix(level ast.L, errors *deferredErrors, flags exprFlag
 					if p.fnOptsParse.arrowArgErrors != nil {
 						p.fnOptsParse.arrowArgErrors.invalidExprAwait = nameRange
 					}
-					return ast.Expr{Loc: loc, Data: &ast.EAwait{Value: p.parseExpr(ast.LPrefix)}}
+					return ast.Expr{Loc: loc, Data: &ast.EAwait{Value: p.parseExpr(ast.LLowest)}}
 				}
 			}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1045,6 +1045,15 @@ func TestAsync(t *testing.T) {
 	expectParseError(t, "async (...x,) => {}", "<stdin>: error: Unexpected \",\" after rest pattern\n")
 	expectParseError(t, "async => await 0", "<stdin>: error: Expected \";\" but found \"0\"\n")
 
+	expectPrinted(t, "async () => { await foo`bar` }", "async () => {\n  await foo`bar`;\n};\n")
+	expectPrinted(t, "async () => { await foo`bar${baz}` }", "async () => {\n  await foo`bar${baz}`;\n};\n")
+	expectPrinted(t, "async () => { (await foo)`bar` }", "async () => {\n  (await foo)`bar`;\n};\n")
+	expectPrinted(t, "async () => { (await foo)`bar${baz}` }", "async () => {\n  (await foo)`bar${baz}`;\n};\n")
+	expectPrinted(t, "async () => { await a, b }", "async () => {\n  await a, b;\n};\n")
+	expectPrinted(t, "async () => { (await a), b }", "async () => {\n  await a, b;\n};\n")
+	expectPrinted(t, "async () => { await foo.bar }", "async () => {\n  await foo.bar;\n};\n")
+	expectPrinted(t, "async () => { (await foo).bar  }", "async () => {\n  (await foo).bar;\n};\n")
+
 	expectPrinted(t, "(async x => y), z", "async (x) => y, z;\n")
 	expectPrinted(t, "(async x => y, z)", "async (x) => y, z;\n")
 	expectPrinted(t, "(async x => (y, z))", "async (x) => (y, z);\n")

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1796,7 +1796,7 @@ func (p *printer) printExpr(expr ast.Expr, level ast.L, flags int) {
 		p.printSpaceBeforeIdentifier()
 		p.print("await")
 		p.printSpace()
-		p.printExpr(e.Value, ast.LPrefix, 0)
+		p.printExpr(e.Value, ast.LLowest, 0)
 
 		if wrap {
 			p.print(")")


### PR DESCRIPTION
Fixes https://github.com/evanw/esbuild/issues/372

Before this, the parser would incorrectly parse `` await foo`bar` `` as `Template(Await(...))` instead of `Await(Template(...))`

I assume `LPrefix` was used before because of the location of `await` in the [precedence table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table) (17), but it seems this doesn't match up with the observed behavior of other parsers.

In addition to tagged templates (with and without substitutions), I added test cases for `await` with both the lowest (comma) and highest (grouping and property access) operators.