### PR TITLE
Fix parsing of type declaration edge case

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5325,7 +5325,7 @@ func (p *parser) parseStmt(opts parseStmtOpts) ast.Stmt {
 				if p.TS.Parse {
 					switch name {
 					case "type":
-						if p.lexer.Token == lexer.TIdentifier {
+						if p.lexer.Token == lexer.TIdentifier && !p.lexer.HasNewlineBefore {
 							// "type Foo = any"
 							p.skipTypeScriptTypeStmt(parseStmtOpts{isModuleScope: opts.isModuleScope})
 							return ast.Stmt{Loc: loc, Data: &ast.STypeScript{}}

--- a/internal/parser/parser_ts_test.go
+++ b/internal/parser/parser_ts_test.go
@@ -117,6 +117,7 @@ func TestTSTypes(t *testing.T) {
 	expectPrintedTS(t, "type x = [-1n, 0n, 1n]\n[]", "[];\n")
 	expectPrintedTS(t, "type x = {0: number, readonly 1: boolean}\n[]", "[];\n")
 	expectPrintedTS(t, "type x = {'a': number, readonly 'b': boolean}\n[]", "[];\n")
+	expectPrintedTS(t, "type\nFoo = {}", "type;\nFoo = {};\n")
 	expectPrintedTS(t, "let x: {x: 'a', y: false, z: null}", "let x;\n")
 	expectPrintedTS(t, "let x: {foo(): void}", "let x;\n")
 	expectPrintedTS(t, "let x: {['x']: number}", "let x;\n")


### PR DESCRIPTION
```ts
type
Foo = {}

// should be transformed to:

type;
Foo = {};
```
- https://www.typescriptlang.org/play?ts=4.0.2#code/C4TwDgpgUAYg9nABAXkQbwL5SA
- https://github.com/microsoft/TypeScript/blob/ee5f51bc0fc06964f2ba27217b5555a82a398673/tests/baselines/reference/asiPreventsParsingAsTypeAlias01.js
- https://github.com/microsoft/TypeScript/blob/ee5f51bc0fc06964f2ba27217b5555a82a398673/tests/baselines/reference/asiPreventsParsingAsTypeAlias02.js