### PR TITLE
Mark test helpers

### DIFF
--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -31,6 +31,7 @@ func es(version int) compat.Feature {
 }
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
 	if a != b {
 		stringA := fmt.Sprintf("%v", a)
 		stringB := fmt.Sprintf("%v", b)
@@ -43,6 +44,7 @@ func assertEqual(t *testing.T, a interface{}, b interface{}) {
 }
 
 func assertLog(t *testing.T, msgs []logger.Msg, expected string) {
+	t.Helper()
 	text := ""
 	for _, msg := range msgs {
 		text += msg.String(logger.StderrOptions{}, logger.TerminalInfo{})
@@ -76,8 +78,10 @@ type suite struct {
 }
 
 func (s *suite) expectBundled(t *testing.T, args bundled) {
+	t.Helper()
 	testName := t.Name()
 	t.Run("", func(t *testing.T) {
+		t.Helper()
 		fs := fs.MockFS(args.files)
 		args.options.ExtensionOrder = []string{".tsx", ".ts", ".jsx", ".js", ".json"}
 		if args.options.AbsOutputFile != "" {
@@ -129,6 +133,7 @@ var globalSuites map[*suite]bool
 var globalUpdateSnapshots bool
 
 func (s *suite) compareSnapshot(t *testing.T, testName string, generated string) {
+	t.Helper()
 	// Initialize the test suite during the first test
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -66,7 +66,9 @@ func TestRel(t *testing.T) {
 	fs := MockFS(map[string]string{})
 
 	expect := func(a string, b string, c string) {
+		t.Helper()
 		t.Run(fmt.Sprintf("Rel(%q, %q) == %q", a, b, c), func(t *testing.T) {
+			t.Helper()
 			rel, ok := fs.Rel(a, b)
 			if !ok {
 				t.Fatalf("!ok")

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func assertEqualStrings(t *testing.T, a string, b string) {
+	t.Helper()
 	pretty := func(text string) string {
 		builder := strings.Builder{}
 		builder.WriteRune('"')
@@ -36,7 +37,9 @@ func lexToken(t *testing.T, contents string) T {
 }
 
 func expectLexerError(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		func() {
 			defer func() {
@@ -57,7 +60,9 @@ func expectLexerError(t *testing.T, contents string, expected string) {
 }
 
 func expectHashbang(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		lexer := func() Lexer {
 			defer func() {
@@ -83,7 +88,9 @@ func TestHashbang(t *testing.T) {
 }
 
 func expectIdentifier(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		lexer := func() Lexer {
 			defer func() {
@@ -120,7 +127,9 @@ func TestIdentifier(t *testing.T) {
 }
 
 func expectNumber(t *testing.T, contents string, expected float64) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		lexer := func() Lexer {
 			defer func() {
@@ -325,7 +334,9 @@ func TestNumericLiteral(t *testing.T) {
 }
 
 func expectBigInteger(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		lexer := func() Lexer {
 			defer func() {
@@ -378,7 +389,9 @@ func TestBigIntegerLiteral(t *testing.T) {
 }
 
 func expectString(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		lexer := func() Lexer {
 			defer func() {

--- a/internal/parser/parser_json_test.go
+++ b/internal/parser/parser_json_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func expectParseErrorJSON(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		ParseJSON(log, test.SourceForTest(contents), ParseJSONOptions{})
 		msgs := log.Done()
@@ -27,7 +29,9 @@ func expectParseErrorJSON(t *testing.T, contents string, expected string) {
 // code may not be valid JSON. That's ok because esbuild always outputs JS
 // bundles, not JSON bundles.
 func expectPrintedJSON(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		expr, ok := ParseJSON(log, test.SourceForTest(contents), ParseJSONOptions{})
 		msgs := log.Done()
@@ -47,7 +51,9 @@ func expectPrintedJSON(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedJSONWithWarning(t *testing.T, contents string, warning string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		expr, ok := ParseJSON(log, test.SourceForTest(contents), ParseJSONOptions{})
 		msgs := log.Done()

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func expectParseError(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		Parse(log, test.SourceForTest(contents), config.Options{})
 		msgs := log.Done()
@@ -28,7 +30,9 @@ func expectParseError(t *testing.T, contents string, expected string) {
 }
 
 func expectParseErrorTarget(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		Parse(log, test.SourceForTest(contents), config.Options{
 			UnsupportedFeatures: compat.UnsupportedFeatures(map[compat.Engine][]int{
@@ -45,7 +49,9 @@ func expectParseErrorTarget(t *testing.T, esVersion int, contents string, expect
 }
 
 func expectPrinted(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{})
 		msgs := log.Done()
@@ -68,7 +74,9 @@ func expectPrinted(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedMangle(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
 			MangleSyntax: true,
@@ -91,7 +99,9 @@ func expectPrintedMangle(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedTarget(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		unsupportedFeatures := compat.UnsupportedFeatures(map[compat.Engine][]int{
 			compat.ES: {esVersion},
@@ -121,7 +131,9 @@ func expectPrintedTarget(t *testing.T, esVersion int, contents string, expected 
 }
 
 func expectPrintedTargetStrict(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
 			UnsupportedFeatures: compat.UnsupportedFeatures(map[compat.Engine][]int{
@@ -153,7 +165,9 @@ func expectPrintedTargetStrict(t *testing.T, esVersion int, contents string, exp
 }
 
 func expectParseErrorJSX(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		Parse(log, test.SourceForTest(contents), config.Options{
 			JSX: config.JSXOptions{
@@ -170,7 +184,9 @@ func expectParseErrorJSX(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedJSX(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
 			JSX: config.JSXOptions{

--- a/internal/parser/parser_ts_test.go
+++ b/internal/parser/parser_ts_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func expectParseErrorTS(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		Parse(log, test.SourceForTest(contents), config.Options{
 			TS: config.TSOptions{
@@ -29,7 +31,9 @@ func expectParseErrorTS(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedTS(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
 			TS: config.TSOptions{
@@ -54,7 +58,9 @@ func expectPrintedTS(t *testing.T, contents string, expected string) {
 }
 
 func expectParseErrorTSX(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		Parse(log, test.SourceForTest(contents), config.Options{
 			TS: config.TSOptions{
@@ -74,7 +80,9 @@ func expectParseErrorTSX(t *testing.T, contents string, expected string) {
 }
 
 func expectPrintedTSX(t *testing.T, contents string, expected string) {
+	t.Helper()
 	t.Run(contents, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
 			TS: config.TSOptions{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -13,13 +13,16 @@ import (
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
 	if a != b {
 		t.Fatalf("%s != %s", a, b)
 	}
 }
 
 func expectPrintedCommon(t *testing.T, name string, contents string, expected string, options PrintOptions) {
+	t.Helper()
 	t.Run(name, func(t *testing.T) {
+		t.Helper()
 		log := logger.NewDeferLog()
 		tree, ok := parser.Parse(log, test.SourceForTest(contents), config.Options{})
 		msgs := log.Done()
@@ -40,22 +43,26 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 }
 
 func expectPrinted(t *testing.T, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents, contents, expected, PrintOptions{})
 }
 
 func expectPrintedMinify(t *testing.T, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents+" [minified]", contents, expected, PrintOptions{
 		RemoveWhitespace: true,
 	})
 }
 
 func expectPrintedMangle(t *testing.T, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents+" [minified]", contents, expected, PrintOptions{
 		MangleSyntax: true,
 	})
 }
 
 func expectPrintedTarget(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents, contents, expected, PrintOptions{
 		UnsupportedFeatures: compat.UnsupportedFeatures(map[compat.Engine][]int{
 			compat.ES: {esVersion},
@@ -64,6 +71,7 @@ func expectPrintedTarget(t *testing.T, esVersion int, contents string, expected 
 }
 
 func expectPrintedTargetMinify(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents+" [minified]", contents, expected, PrintOptions{
 		UnsupportedFeatures: compat.UnsupportedFeatures(map[compat.Engine][]int{
 			compat.ES: {esVersion},
@@ -73,6 +81,7 @@ func expectPrintedTargetMinify(t *testing.T, esVersion int, contents string, exp
 }
 
 func expectPrintedTargetMangle(t *testing.T, esVersion int, contents string, expected string) {
+	t.Helper()
 	expectPrintedCommon(t, contents+" [minified]", contents, expected, PrintOptions{
 		UnsupportedFeatures: compat.UnsupportedFeatures(map[compat.Engine][]int{
 			compat.ES: {esVersion},

--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -7,6 +7,7 @@ import (
 )
 
 func AssertEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
 	if a != b {
 		t.Fatalf("%s != %s", a, b)
 	}


### PR DESCRIPTION
Adds [`T.Helper`](https://golang.org/pkg/testing/#T.Helper) calls to test helper functions.

By doing so, these test helpers will be skipped when printing the file and line number on test errors, thereby producing a more useful error message:

```diff
 ~/code/esbuild/internal/parser
 ❯ go test ../parser/...
 --- FAIL: TestSomeBrokenTest (0.00s)
     --- FAIL: TestSomeBrokenTest/foo (0.00s)
-        util.go:12: foo;
+        parser_test.go:692: foo;
              != bar
 FAIL
 FAIL   github.com/evanw/esbuild/internal/parser        1.470s
 FAIL
```

After this change, it is possible to simply click the filename and line number from the terminal output and be taken to the broken assertion (assuming you are in the correct directory). Otherwise, it would merely show the file and line of the test helper itself which isn't particularly useful.

I've found this change to be very convenient when doing TDD.