### PR TITLE
Fix broken edge case of async function lowering

### DIFF
--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -19,8 +19,8 @@ _e = new WeakMap();
 ================================================================================
 TestLowerAsync2016NoBundle
 ---------- /out.js ----------
-function foo(_0, ..._1) {
-  return __async(this, [_0, ..._1], function* (bar) {
+function foo(_0) {
+  return __async(this, arguments, function* (bar) {
     yield bar;
     return [this, arguments];
   });

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -19,8 +19,8 @@ _e = new WeakMap();
 ================================================================================
 TestLowerAsync2016NoBundle
 ---------- /out.js ----------
-function foo(_0) {
-  return __async(this, arguments, function* (bar) {
+function foo(_0, ..._1) {
+  return __async(this, [_0, ..._1], function* (bar) {
     yield bar;
     return [this, arguments];
   });
@@ -51,7 +51,7 @@ export default [
     }
   },
   function() {
-    return (_0) => __async(this, arguments, function* (bar) {
+    return (_0, ..._1) => __async(this, [_0, ..._1], function* (bar) {
       yield bar;
       return [this, arguments];
     });

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -8987,7 +8987,7 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 		p.pushScopeForVisitPass(js_ast.ScopeFunctionBody, e.Body.Loc)
 		e.Body.Stmts = p.visitStmtsAndPrependTempRefs(e.Body.Stmts)
 		p.popScope()
-		p.lowerFunction(&e.IsAsync, &e.Args, e.Body.Loc, &e.Body.Stmts, &e.PreferExpr, &e.HasRestArg)
+		p.lowerFunction(&e.IsAsync, &e.Args, e.Body.Loc, &e.Body.Stmts, &e.PreferExpr, &e.HasRestArg, true)
 		p.popScope()
 
 		if p.MangleSyntax && len(e.Body.Stmts) == 1 {
@@ -9133,7 +9133,7 @@ func (p *parser) visitFn(fn *js_ast.Fn, scopeLoc logger.Loc) {
 	p.pushScopeForVisitPass(js_ast.ScopeFunctionBody, fn.Body.Loc)
 	fn.Body.Stmts = p.visitStmtsAndPrependTempRefs(fn.Body.Stmts)
 	p.popScope()
-	p.lowerFunction(&fn.IsAsync, &fn.Args, fn.Body.Loc, &fn.Body.Stmts, nil, &fn.HasRestArg)
+	p.lowerFunction(&fn.IsAsync, &fn.Args, fn.Body.Loc, &fn.Body.Stmts, nil, &fn.HasRestArg, false)
 	p.popScope()
 
 	p.fnOrArrowDataVisit = oldFnOrArrowData

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -229,7 +229,7 @@ func (p *parser) lowerFunction(
 			// resulting promise, which needs more complex code to handle
 			couldThrowErrors := false
 			for _, arg := range *args {
-				if _, ok := arg.Binding.Data.(*js_ast.BIdentifier); !ok || arg.Default != nil {
+				if _, ok := arg.Binding.Data.(*js_ast.BIdentifier); !ok || (arg.Default != nil && couldPotentiallyThrow(arg.Default.Data)) {
 					couldThrowErrors = true
 					break
 				}
@@ -2083,4 +2083,12 @@ func (p *parser) maybeLowerSuperPropertyAccessInsideCall(call *js_ast.ECall) {
 	}
 	thisExpr := js_ast.Expr{Loc: call.Target.Loc, Data: &js_ast.EThis{}}
 	call.Args = append([]js_ast.Expr{thisExpr}, call.Args...)
+}
+
+func couldPotentiallyThrow(data js_ast.E) bool {
+	switch data.(type) {
+	case *js_ast.ENull, *js_ast.EUndefined, *js_ast.EBoolean, *js_ast.ENumber, *js_ast.EBigInt, *js_ast.EString, *js_ast.EFunction, *js_ast.EArrow:
+		return false
+	}
+	return true
 }

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -268,35 +268,26 @@ func (p *parser) lowerFunction(
 					*args = append(*args, js_ast.Arg{Binding: js_ast.Binding{Loc: arg.Binding.Loc, Data: &js_ast.BIdentifier{Ref: argRef}}})
 				}
 
-				// Forward all arguments from the outer function to the inner function
-				if p.fnOnlyDataVisit.argumentsRef != nil {
-					// Normal functions can just use "arguments" to forward everything
-					forwardedArgs = js_ast.Expr{Loc: bodyLoc, Data: &js_ast.EIdentifier{Ref: *p.fnOnlyDataVisit.argumentsRef}}
-				} else {
-					// Arrow functions can't use "arguments", so we need to forward
-					// the arguments manually
-
-					// If we need to forward more than the current number of arguments,
-					// add a rest argument to the set of forwarding variables
-					if usesArguments || fn.HasRestArg || len(*args) < len(fn.Args) {
-						argRef := p.newSymbol(js_ast.SymbolOther, fmt.Sprintf("_%d", len(*args)))
-						p.currentScope.Generated = append(p.currentScope.Generated, argRef)
-						*args = append(*args, js_ast.Arg{Binding: js_ast.Binding{Loc: bodyLoc, Data: &js_ast.BIdentifier{Ref: argRef}}})
-						*hasRestArg = true
-					}
-
-					// Forward all of the arguments
-					items := make([]js_ast.Expr, 0, len(*args))
-					for i, arg := range *args {
-						id := arg.Binding.Data.(*js_ast.BIdentifier)
-						item := js_ast.Expr{Loc: arg.Binding.Loc, Data: &js_ast.EIdentifier{Ref: id.Ref}}
-						if *hasRestArg && i+1 == len(*args) {
-							item.Data = &js_ast.ESpread{Value: item}
-						}
-						items = append(items, item)
-					}
-					forwardedArgs = js_ast.Expr{Loc: bodyLoc, Data: &js_ast.EArray{Items: items, IsSingleLine: true}}
+				// If we need to forward more than the current number of arguments,
+				// add a rest argument to the set of forwarding variables
+				if usesArguments || fn.HasRestArg || len(*args) < len(fn.Args) {
+					argRef := p.newSymbol(js_ast.SymbolOther, fmt.Sprintf("_%d", len(*args)))
+					p.currentScope.Generated = append(p.currentScope.Generated, argRef)
+					*args = append(*args, js_ast.Arg{Binding: js_ast.Binding{Loc: bodyLoc, Data: &js_ast.BIdentifier{Ref: argRef}}})
+					*hasRestArg = true
 				}
+
+				// Forward all of the arguments
+				items := make([]js_ast.Expr, 0, len(*args))
+				for i, arg := range *args {
+					id := arg.Binding.Data.(*js_ast.BIdentifier)
+					item := js_ast.Expr{Loc: arg.Binding.Loc, Data: &js_ast.EIdentifier{Ref: id.Ref}}
+					if *hasRestArg && i+1 == len(*args) {
+						item.Data = &js_ast.ESpread{Value: item}
+					}
+					items = append(items, item)
+				}
+				forwardedArgs = js_ast.Expr{Loc: bodyLoc, Data: &js_ast.EArray{Items: items, IsSingleLine: true}}
 			}
 		}
 

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2721,7 +2721,6 @@ func TestLowerClassInstance(t *testing.T) {
 	expectPrintedTarget(t, 2015, "class Foo extends Bar {}", `class Foo extends Bar {
 }
 `)
-
 	expectPrintedTarget(t, 2015, "class Foo extends Bar { bar() {} constructor() { super() } }", `class Foo extends Bar {
   bar() {
   }

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2655,6 +2655,20 @@ func TestLowerLogicalAssign(t *testing.T) {
 	expectPrintedTarget(t, 2020, "a()[b()] ||= c", "var _a, _b;\n(_a = a())[_b = b()] || (_a[_b] = c);\n")
 }
 
+func TestLowerAsyncFunctions(t *testing.T) {
+	// Lowered non-arrow functions with argument evaluations should merely use
+	// "arguments" rather than allocating a new array when forwarding arguments
+	expectPrintedTarget(t, 2015, "async function foo(a, b = couldThrowErrors()) {console.log(a, b);}", `function foo(_0) {
+  return __async(this, arguments, function* (a, b = couldThrowErrors()) {
+    console.log(a, b);
+  });
+}
+import {
+  __async
+} from "<runtime>";
+`)
+}
+
 func TestLowerClassSideEffectOrder(t *testing.T) {
 	// The order of computed property side effects must not change
 	expectPrintedTarget(t, 2015, `class Foo {
@@ -2707,6 +2721,7 @@ func TestLowerClassInstance(t *testing.T) {
 	expectPrintedTarget(t, 2015, "class Foo extends Bar {}", `class Foo extends Bar {
 }
 `)
+
 	expectPrintedTarget(t, 2015, "class Foo extends Bar { bar() {} constructor() { super() } }", `class Foo extends Bar {
   bar() {
   }

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2667,6 +2667,14 @@ import {
   __async
 } from "<runtime>";
 `)
+	// Skip forwarding altogether when parameter evaluation obviously cannot throw
+	expectPrintedTarget(t, 2015, "async (a, b = 123) => {console.log(a, b);}", `(a, b = 123) => __async(this, null, function* () {
+  console.log(a, b);
+});
+import {
+  __async
+} from "<runtime>";
+`)
 }
 
 func TestLowerClassSideEffectOrder(t *testing.T) {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -1032,6 +1032,20 @@ in.js:24:30: warning: Writing to getter-only property "#getter" will throw
         )
       `,
     }, { async: true }),
+    test(['in.js', '--outfile=node.js', '--target=es6'],
+    {
+      'in.js': `
+        function nonArrowWrapper() {
+          return async (x, paramWithDefault = {}) => {
+            if (x !== 123) {
+              throw 'fail';
+            }
+            console.log(paramWithDefault);
+          };
+        }
+        exports.async = () => nonArrowWrapper()(123);
+      `,
+    }, { async: true }),
     test(['in.js', '--outfile=node.js', '--target=es6'], {
       'in.js': `
         exports.async = async () => {


### PR DESCRIPTION
Fixes https://github.com/evanw/esbuild/issues/388 and adds regression test.

Also adds an optimization to skip argument forwarding altogether when it is trivial to determine that all default parameter expressions cannot throw.