### PR TITLE
Introduce module dependency analysis without compiling the output bundle

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -18,6 +18,7 @@ Usage:
   esbuild [options] [entry points]
 
 Options:
+  --analyse             Collect metadata about the source modules
   --bundle              Bundle all dependencies into the output files
   --define:K=V          Substitute K with V while parsing
   --external:M          Exclude module M from the bundle

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -242,6 +242,11 @@ func (service *serviceType) handleIncomingPacket(bytes []byte) (result outgoingP
 				refCount: refCount,
 			}
 
+		case "analyse":
+			return outgoingPacket{
+				bytes: service.handleAnalyseRequest(p.id, request),
+			}
+
 		case "error":
 			// This just exists so that errors during JavaScript API setup get printed
 			// nicely to the console. This matters if the JavaScript API setup code
@@ -684,6 +689,223 @@ func (service *serviceType) handleTransformRequest(id uint32, request map[string
 			"mapFS": mapFS,
 			"map":   string(result.Map),
 		},
+	})
+}
+
+func (service *serviceType) handleAnalyseRequest(id uint32, request map[string]interface{}) []byte {
+	key := request["key"].(int)
+	write := request["write"].(bool)
+	flags := decodeStringArray(request["flags"].([]interface{}))
+	flags = append(flags, "--analyse") // this is no esbuild command line, --analyse is assumed
+
+	options, err := cli.ParseAnalyseOptions(flags)
+	if err == nil && write && options.Metafile == "" {
+		err = errors.New("Either provide \"metafile\" or set \"write\" to false")
+	}
+	if err != nil {
+		return encodeErrorPacket(id, err)
+	}
+
+	// Optionally allow input from the stdin channel
+	if stdin, ok := request["stdin"].(string); ok {
+		if options.Stdin == nil {
+			options.Stdin = &api.StdinOptions{}
+		}
+		options.Stdin.Contents = stdin
+		if resolveDir, ok := request["resolveDir"].(string); ok {
+			options.Stdin.ResolveDir = resolveDir
+		}
+	}
+
+	if plugins, ok := request["plugins"]; ok {
+		plugins := plugins.([]interface{})
+
+		type filteredCallback struct {
+			filter     *regexp.Regexp
+			pluginName string
+			namespace  string
+			id         int
+		}
+
+		var onResolveCallbacks []filteredCallback
+		var onLoadCallbacks []filteredCallback
+
+		filteredCallbacks := func(pluginName string, kind string, items []interface{}) (result []filteredCallback, err error) {
+			for _, item := range items {
+				item := item.(map[string]interface{})
+				filter, err := config.CompileFilterForPlugin(pluginName, kind, item["filter"].(string))
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, filteredCallback{
+					pluginName: pluginName,
+					id:         item["id"].(int),
+					filter:     filter,
+					namespace:  item["namespace"].(string),
+				})
+			}
+			return
+		}
+
+		for _, p := range plugins {
+			p := p.(map[string]interface{})
+			pluginName := p["name"].(string)
+
+			if callbacks, err := filteredCallbacks(pluginName, "onResolve", p["onResolve"].([]interface{})); err != nil {
+				return encodeErrorPacket(id, err)
+			} else {
+				onResolveCallbacks = append(onResolveCallbacks, callbacks...)
+			}
+
+			if callbacks, err := filteredCallbacks(pluginName, "onLoad", p["onLoad"].([]interface{})); err != nil {
+				return encodeErrorPacket(id, err)
+			} else {
+				onLoadCallbacks = append(onLoadCallbacks, callbacks...)
+			}
+		}
+
+		// We want to minimize the amount of IPC traffic. Instead of adding one Go
+		// plugin for every JavaScript plugin, we just add a single Go plugin that
+		// proxies the plugin queries to the list of JavaScript plugins in the host.
+		options.Plugins = append(options.Plugins, api.Plugin{
+			Name: "JavaScript plugins",
+			Setup: func(build api.PluginBuild) {
+				build.OnResolve(api.OnResolveOptions{Filter: ".*"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
+					var ids []interface{}
+					applyPath := logger.Path{Text: args.Path, Namespace: args.Namespace}
+					for _, item := range onResolveCallbacks {
+						if config.PluginAppliesToPath(applyPath, item.filter, item.namespace) {
+							ids = append(ids, item.id)
+						}
+					}
+
+					result := api.OnResolveResult{}
+					if len(ids) == 0 {
+						return result, nil
+					}
+
+					response := service.sendRequest(map[string]interface{}{
+						"command":    "resolve",
+						"key":        key,
+						"ids":        ids,
+						"path":       args.Path,
+						"importer":   args.Importer,
+						"namespace":  args.Namespace,
+						"resolveDir": args.ResolveDir,
+					}).(map[string]interface{})
+
+					if value, ok := response["id"]; ok {
+						id := value.(int)
+						for _, item := range onResolveCallbacks {
+							if item.id == id {
+								result.PluginName = item.pluginName
+								break
+							}
+						}
+					}
+					if value, ok := response["error"]; ok {
+						return result, errors.New(value.(string))
+					}
+					if value, ok := response["pluginName"]; ok {
+						result.PluginName = value.(string)
+					}
+					if value, ok := response["path"]; ok {
+						result.Path = value.(string)
+					}
+					if value, ok := response["namespace"]; ok {
+						result.Namespace = value.(string)
+					}
+					if value, ok := response["external"]; ok {
+						result.External = value.(bool)
+					}
+					if value, ok := response["errors"]; ok {
+						result.Errors = decodeMessages(value.([]interface{}))
+					}
+					if value, ok := response["warnings"]; ok {
+						result.Warnings = decodeMessages(value.([]interface{}))
+					}
+
+					return result, nil
+				})
+
+				build.OnLoad(api.OnLoadOptions{Filter: ".*"}, func(args api.OnLoadArgs) (api.OnLoadResult, error) {
+					var ids []interface{}
+					applyPath := logger.Path{Text: args.Path, Namespace: args.Namespace}
+					for _, item := range onLoadCallbacks {
+						if config.PluginAppliesToPath(applyPath, item.filter, item.namespace) {
+							ids = append(ids, item.id)
+						}
+					}
+
+					result := api.OnLoadResult{}
+					if len(ids) == 0 {
+						return result, nil
+					}
+
+					response := service.sendRequest(map[string]interface{}{
+						"command":   "load",
+						"key":       key,
+						"ids":       ids,
+						"path":      args.Path,
+						"namespace": args.Namespace,
+					}).(map[string]interface{})
+
+					if value, ok := response["id"]; ok {
+						id := value.(int)
+						for _, item := range onLoadCallbacks {
+							if item.id == id {
+								result.PluginName = item.pluginName
+								break
+							}
+						}
+					}
+					if value, ok := response["error"]; ok {
+						return result, errors.New(value.(string))
+					}
+					if value, ok := response["pluginName"]; ok {
+						result.PluginName = value.(string)
+					}
+					if value, ok := response["contents"]; ok {
+						contents := string(value.([]byte))
+						result.Contents = &contents
+					}
+					if value, ok := response["resolveDir"]; ok {
+						result.ResolveDir = value.(string)
+					}
+					if value, ok := response["errors"]; ok {
+						result.Errors = decodeMessages(value.([]interface{}))
+					}
+					if value, ok := response["warnings"]; ok {
+						result.Warnings = decodeMessages(value.([]interface{}))
+					}
+					if value, ok := response["loader"]; ok {
+						loader, err := helpers.ParseLoader(value.(string))
+						if err != nil {
+							return api.OnLoadResult{}, err
+						}
+						result.Loader = loader
+					}
+
+					return result, nil
+				})
+			},
+		})
+	}
+
+	options.Write = write
+	result := api.Analyse(options)
+	response := map[string]interface{}{
+		"errors":   encodeMessages(result.Errors),
+		"warnings": encodeMessages(result.Warnings),
+	}
+	if !write {
+		// Pass the metadata content file back to the caller
+		response["metadata"] = result.Metadata
+	}
+
+	return encodePacket(packet{
+		id:    id,
+		value: response,
 	})
 }
 

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -18,12 +18,20 @@ export const transform: typeof types.transform = () => {
   throw new Error(`The "transform" API only works in node`);
 };
 
+export const analyse: typeof types.analyse = () => {
+  throw new Error(`The "analyse" API only works in node`);
+};
+
 export const buildSync: typeof types.buildSync = () => {
   throw new Error(`The "buildSync" API only works in node`);
 };
 
 export const transformSync: typeof types.transformSync = () => {
   throw new Error(`The "transformSync" API only works in node`);
+};
+
+export const analyseSync: typeof types.analyseSync = () => {
+  throw new Error(`The "analyseSync" API only works in node`);
 };
 
 export const startService: typeof types.startService = options => {
@@ -79,6 +87,9 @@ export const startService: typeof types.startService = options => {
             readFile(_, callback) { callback(new Error('Internal error'), null); },
             writeFile(_, callback) { callback(null); },
           }, (err, res) => err ? reject(err) : resolve(res!))),
+      analyse() {
+        throw new Error(`The "analyse" API only works in node`)
+      },
       serve() {
         throw new Error(`The "serve" API only works in node`)
       },

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -92,6 +92,14 @@ export let transform: typeof types.transform = (input, options) => {
   });
 };
 
+export let analyse: typeof types.analyse = (options: types.AnalyseOptions): any => {
+  return startService().then(service => {
+    let promise = service.analyse(options);
+    promise.then(service.stop, service.stop); // Kill the service afterwards
+    return promise;
+  });
+};
+
 export let buildSync: typeof types.buildSync = (options: types.BuildOptions): any => {
   let result: types.BuildResult;
   runServiceSync(service => service.buildOrServe(null, options, isTTY(), (err, res) => {
@@ -126,6 +134,15 @@ export let transformSync: typeof types.transformSync = (input, options) => {
       }
     },
   }, (err, res) => {
+    if (err) throw err;
+    result = res!;
+  }));
+  return result!;
+};
+
+export let analyseSync: typeof types.analyseSync = options => {
+  let result: types.AnalyseResult;
+  runServiceSync(service => service.analyse(options, isTTY(), (err, res) => {
     if (err) throw err;
     result = res!;
   }));
@@ -192,6 +209,10 @@ export let startService: typeof types.startService = options => {
             }
           },
         }, (err, res) => err ? reject(err) : resolve(res!))),
+    analyse: options =>
+      new Promise((resolve, reject) =>
+        service.analyse(options, isTTY(), (err, res) =>
+          err ? reject(err) : resolve(res!))),
     stop() { child.kill(); },
   });
 };

--- a/lib/stdio_protocol.ts
+++ b/lib/stdio_protocol.ts
@@ -134,6 +134,22 @@ export interface OnLoadResponse {
   loader?: string;
 }
 
+export interface AnalyseRequest {
+  command: 'analyse';
+  key: number;
+  flags: string[];
+  write: boolean;
+  stdin: string | null;
+  resolveDir: string | null;
+  plugins?: BuildPlugin[];
+}
+
+export interface AnalyseResponse {
+  errors: types.Message[];
+  warnings: types.Message[];
+  metadata: Uint8Array;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 export interface Packet {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -209,8 +209,40 @@ export interface PartialMessage {
   location?: Partial<Location> | null;
 }
 
-// This is the type information for the "metafile" JSON format
-export interface Metadata {
+export interface AnalyseOptions extends CommonOptions {
+  bundle?: boolean;
+  splitting?: boolean;
+  metafile?: string;
+  platform?: Platform;
+  external?: string[];
+  loader?: { [ext: string]: Loader };
+  resolveExtensions?: string[];
+  mainFields?: string[];
+  write?: boolean;
+  tsconfig?: string;
+
+  entryPoints?: string[];
+  stdin?: StdinOptions;
+  plugins?: Plugin[];
+}
+
+export interface Output {
+  contents: Uint8Array; // "text" as bytes
+  text: string; // "contents" as text
+}
+
+export interface AnalyseResult {
+  warnings: Message[];
+  metadata?: Output; // Only when "write: false"
+}
+
+export interface AnalyseFailure extends Error {
+  errors: Message[];
+  warnings: Message[];
+}
+
+// This is the type information for the "metafile" JSON format from analyse
+export interface AnalyseMetadata {
   inputs: {
     [path: string]: {
       bytes: number
@@ -219,6 +251,10 @@ export interface Metadata {
       }[]
     }
   }
+}
+
+// This is the type information for the "metafile" JSON format from build
+export interface Metadata extends AnalyseMetadata {
   outputs: {
     [path: string]: {
       bytes: number
@@ -241,6 +277,7 @@ export interface Service {
   build(options: BuildOptions): Promise<BuildResult>;
   serve(serveOptions: ServeOptions, buildOptions: BuildOptions): Promise<ServeResult>;
   transform(input: string, options?: TransformOptions): Promise<TransformResult>;
+  analyse(options: AnalyseOptions): Promise<AnalyseResult>;
 
   // This stops the service, which kills the long-lived child process. Any
   // pending requests will be aborted.
@@ -273,6 +310,14 @@ export declare function serve(serveOptions: ServeOptions, buildOptions: BuildOpt
 // Works in browser: no
 export declare function transform(input: string, options?: TransformOptions): Promise<TransformResult>;
 
+// This function invokes the "esbuild" command-line tool for you with the option
+// `--analyse`. It returns a promise that either resolves with a "AnalyseResult"
+// object or rejects with a "AnalyseFailure" object.
+//
+// Works in node: yes
+// Works in browser: no
+export declare function analyse(options: AnalyseOptions): Promise<AnalyseResult>;
+
 // A synchronous version of "build".
 //
 // Works in node: yes
@@ -285,6 +330,12 @@ export declare function buildSync(options: BuildOptions): BuildResult;
 // Works in node: yes
 // Works in browser: no
 export declare function transformSync(input: string, options?: TransformOptions): TransformResult;
+
+// A synchronous version of "analyse".
+//
+// Works in node: yes
+// Works in browser: no
+export declare function analyseSync(options: AnalyseOptions): AnalyseResult;
 
 // This starts "esbuild" as a long-lived child process that is then reused, so
 // you can call methods on the service many times without the overhead of

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -75,6 +75,36 @@
 //         os.Stdout.Write(result.Code)
 //     }
 //
+// Analyse API
+//
+// This function runs a module analysis operation. It takes an array of file
+// paths as entry points, parses them and all of their dependencies, and
+// collects the metadata of the modules and their dependencies. The available
+// options roughly correspond to esbuild's command-line flags.
+//
+// Example usage:
+//
+//     package main
+//
+//     import (
+//         "fmt"
+//         "io/ioutil"
+//
+//         "github.com/evanw/esbuild/pkg/api"
+//     )
+//
+//     func main() {
+//         result := api.Analyse(api.AnalyseOptions{
+//             EntryPoints: []string{"input.js"},
+//             Metafile:    "metadata.json",
+//             LogLevel:    api.LogLevelInfo,
+//         })
+//
+//         if len(result.Errors) > 0 {
+//             os.Exit(1)
+//         }
+//     }
+//
 package api
 
 type SourceMap uint8
@@ -318,6 +348,51 @@ type TransformResult struct {
 
 func Transform(input string, options TransformOptions) TransformResult {
 	return transformImpl(input, options)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Analyse API
+
+type AnalyseOptions struct {
+	Color      StderrColor
+	ErrorLimit int
+	LogLevel   LogLevel
+
+	Target  Target
+	Engines []Engine
+
+	JSXFactory  string
+	JSXFragment string
+
+	Define map[string]string
+	Pure   []string
+
+	GlobalName        string
+	Bundle            bool
+	Splitting         bool
+	Metafile          string
+	Platform          Platform
+	External          []string
+	MainFields        []string
+	Loader            map[string]Loader
+	ResolveExtensions []string
+	Tsconfig          string
+
+	EntryPoints []string
+	Stdin       *StdinOptions
+	Write       bool
+	Plugins     []Plugin
+}
+
+type AnalyseResult struct {
+	Errors   []Message
+	Warnings []Message
+
+	Metadata []byte
+}
+
+func Analyse(options AnalyseOptions) AnalyseResult {
+	return analyseImpl(options)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -849,6 +849,153 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Analyse API
+
+func analyseImpl(analyseOpts AnalyseOptions) AnalyseResult {
+	logOptions := logger.StderrOptions{
+		IncludeSource: true,
+		ErrorLimit:    analyseOpts.ErrorLimit,
+		Color:         validateColor(analyseOpts.Color),
+		LogLevel:      validateLogLevel(analyseOpts.LogLevel),
+	}
+	log := logger.NewStderrLog(logOptions)
+	realFS := fs.RealFS()
+	plugins := loadPlugins(realFS, log, analyseOpts.Plugins)
+	caches := cache.MakeCacheSet()
+
+	// Convert and validate the analyseOpts
+	jsFeatures, cssFeatures := validateFeatures(log, analyseOpts.Target, analyseOpts.Engines)
+	options := config.Options{
+		UnsupportedJSFeatures:  jsFeatures,
+		UnsupportedCSSFeatures: cssFeatures,
+		JSX: config.JSXOptions{
+			Factory:  validateJSX(log, analyseOpts.JSXFactory, "factory"),
+			Fragment: validateJSX(log, analyseOpts.JSXFragment, "fragment"),
+		},
+		Defines:           validateDefines(log, analyseOpts.Define, analyseOpts.Pure),
+		Platform:          validatePlatform(analyseOpts.Platform),
+		GlobalName:        validateGlobalName(log, analyseOpts.GlobalName),
+		CodeSplitting:     analyseOpts.Splitting,
+		AbsMetadataFile:   validatePath(log, realFS, analyseOpts.Metafile),
+		ExtensionToLoader: validateLoaders(log, analyseOpts.Loader),
+		ExtensionOrder:    validateResolveExtensions(log, analyseOpts.ResolveExtensions),
+		ExternalModules:   validateExternals(log, realFS, analyseOpts.External),
+		TsConfigOverride:  validatePath(log, realFS, analyseOpts.Tsconfig),
+		MainFields:        analyseOpts.MainFields,
+		Plugins:           plugins,
+	}
+	entryPaths := make([]string, len(analyseOpts.EntryPoints))
+	for i, entryPoint := range analyseOpts.EntryPoints {
+		entryPaths[i] = validatePath(log, realFS, entryPoint)
+	}
+	entryPathCount := len(analyseOpts.EntryPoints)
+	if analyseOpts.Stdin != nil {
+		entryPathCount++
+		options.Stdin = &config.StdinInfo{
+			Loader:        validateLoader(analyseOpts.Stdin.Loader),
+			Contents:      analyseOpts.Stdin.Contents,
+			SourceFile:    analyseOpts.Stdin.Sourcefile,
+			AbsResolveDir: validatePath(log, realFS, analyseOpts.Stdin.ResolveDir),
+		}
+	}
+
+	if options.AbsMetadataFile != "" {
+		// If the output file is specified, use it to derive the output directory
+		options.AbsOutputDir = realFS.Dir(options.AbsMetadataFile)
+	} else if options.AbsMetadataFile == "" {
+		options.AbsMetadataFile = "<stdin>"
+		options.WriteToStdout = true
+
+		// Forbid certain features when writing to stdout
+		for _, loader := range options.ExtensionToLoader {
+			if loader == config.LoaderFile {
+				log.AddError(nil, logger.Loc{}, "Cannot use the \"file\" loader without an output path")
+				break
+			}
+		}
+
+		// Use the current directory as the output directory instead of an empty
+		// string because external modules with relative paths need a base directory.
+		options.AbsOutputDir = realFS.Cwd()
+	}
+
+	if !analyseOpts.Bundle {
+		// Disallow bundle-only options when not bundling
+		if len(options.ExternalModules.NodeModules) > 0 || len(options.ExternalModules.AbsPaths) > 0 {
+			log.AddError(nil, logger.Loc{}, "Cannot use \"external\" without \"bundle\"")
+		}
+	} else if options.OutputFormat == config.FormatPreserve {
+		// If the format isn't specified, set the default format using the platform
+		switch options.Platform {
+		case config.PlatformBrowser:
+			options.OutputFormat = config.FormatIIFE
+		case config.PlatformNode:
+			options.OutputFormat = config.FormatCommonJS
+		}
+	}
+
+	// Set the output mode using other settings
+	if analyseOpts.Bundle {
+		options.Mode = config.ModeBundle
+	} else if options.OutputFormat != config.FormatPreserve {
+		options.Mode = config.ModeConvertFormat
+	}
+
+	// Code splitting is experimental and currently only enabled for ES6 modules
+	if options.CodeSplitting && options.OutputFormat != config.FormatESModule {
+		log.AddError(nil, logger.Loc{}, "Splitting currently only works with the \"esm\" format")
+	}
+
+	var metadata []byte
+
+	// Stop now if there were errors
+	if !log.HasErrors() {
+		// Scan over the bundle
+		resolver := resolver.NewResolver(realFS, log, caches, options)
+		bundle := bundler.ScanBundle(log, realFS, resolver, caches, entryPaths, options)
+
+		// Stop now if there were errors
+		if !log.HasErrors() {
+			// Analyse the bundle
+			metadata = bundle.Analyse()
+
+			// Stop now if there were errors
+			if !log.HasErrors() {
+				if analyseOpts.Write {
+					// Special-case writing to stdout
+					if options.WriteToStdout {
+						if _, err := os.Stdout.Write(metadata); err != nil {
+							log.AddError(nil, logger.Loc{}, fmt.Sprintf(
+								"Failed to write to stdout: %s", err.Error()))
+						}
+					} else {
+						fs.BeforeFileOpen()
+						defer fs.AfterFileClose()
+						if err := os.MkdirAll(filepath.Dir(options.AbsMetadataFile), 0755); err != nil {
+							log.AddError(nil, logger.Loc{}, fmt.Sprintf(
+								"Failed to create output directory: %s", err.Error()))
+						} else {
+							var mode os.FileMode = 0644
+							if err := ioutil.WriteFile(options.AbsMetadataFile, metadata, mode); err != nil {
+								log.AddError(nil, logger.Loc{}, fmt.Sprintf(
+									"Failed to write to output file: %s", err.Error()))
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	msgs := log.Done()
+	return AnalyseResult{
+		Errors:   convertMessagesToPublic(logger.Error, msgs),
+		Warnings: convertMessagesToPublic(logger.Warning, msgs),
+		Metadata: metadata,
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Plugin API
 
 type pluginImpl struct {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -46,7 +46,7 @@ func Run(osArgs []string) int {
 //
 func ParseBuildOptions(osArgs []string) (options api.BuildOptions, err error) {
 	options = newBuildOptions()
-	err = parseOptionsImpl(osArgs, &options, nil)
+	err = parseOptionsImpl(osArgs, &options, nil, nil)
 	return
 }
 
@@ -66,6 +66,26 @@ func ParseBuildOptions(osArgs []string) (options api.BuildOptions, err error) {
 //
 func ParseTransformOptions(osArgs []string) (options api.TransformOptions, err error) {
 	options = newTransformOptions()
-	err = parseOptionsImpl(osArgs, nil, &options)
+	err = parseOptionsImpl(osArgs, nil, &options, nil)
+	return
+}
+
+// This parses an array of strings into an options object suitable for passing
+// to "api.Analyse()". Use this if you need to reuse the same argument parsing
+// logic as the esbuild CLI.
+//
+// Example usage:
+//
+//     options, err := cli.ParseAnalyseOptions([]string{
+//         "input.js",
+//         "--analyse",
+//         "--metafile=...",
+//     })
+//
+//     result := api.Analyse(options)
+//
+func ParseAnalyseOptions(osArgs []string) (options api.AnalyseOptions, err error) {
+	options = newAnalyseOptions()
+	err = parseOptionsImpl(osArgs, nil, nil, &options)
 	return
 }

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -27,8 +27,16 @@ func newTransformOptions() api.TransformOptions {
 	}
 }
 
-func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpts *api.TransformOptions) error {
+func newAnalyseOptions() api.AnalyseOptions {
+	return api.AnalyseOptions{
+		Loader: make(map[string]api.Loader),
+		Define: make(map[string]string),
+	}
+}
+
+func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpts *api.TransformOptions, analyseOpts *api.AnalyseOptions) error {
 	hasBareSourceMapFlag := false
+	analyse := false
 
 	// Parse the arguments now that we know what we're parsing
 	for _, arg := range osArgs {
@@ -36,15 +44,23 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case arg == "--bundle" && buildOpts != nil:
 			buildOpts.Bundle = true
 
-		case arg == "--splitting" && buildOpts != nil:
-			buildOpts.Splitting = true
+		case arg == "--analyse" && analyseOpts != nil:
+			analyseOpts.Bundle = true
+			analyse = true
+
+		case arg == "--splitting":
+			if buildOpts != nil {
+				buildOpts.Splitting = true
+			} else {
+				analyseOpts.Splitting = true
+			}
 
 		case arg == "--minify":
 			if buildOpts != nil {
 				buildOpts.MinifySyntax = true
 				buildOpts.MinifyWhitespace = true
 				buildOpts.MinifyIdentifiers = true
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.MinifySyntax = true
 				transformOpts.MinifyWhitespace = true
 				transformOpts.MinifyIdentifiers = true
@@ -53,21 +69,21 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case arg == "--minify-syntax":
 			if buildOpts != nil {
 				buildOpts.MinifySyntax = true
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.MinifySyntax = true
 			}
 
 		case arg == "--minify-whitespace":
 			if buildOpts != nil {
 				buildOpts.MinifyWhitespace = true
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.MinifyWhitespace = true
 			}
 
 		case arg == "--minify-identifiers":
 			if buildOpts != nil {
 				buildOpts.MinifyIdentifiers = true
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.MinifyIdentifiers = true
 			}
 
@@ -120,7 +136,7 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case arg == "--sourcemap":
 			if buildOpts != nil {
 				buildOpts.Sourcemap = api.SourceMapLinked
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Sourcemap = api.SourceMapInline
 			}
 			hasBareSourceMapFlag = true
@@ -128,7 +144,7 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case arg == "--sourcemap=external":
 			if buildOpts != nil {
 				buildOpts.Sourcemap = api.SourceMapExternal
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Sourcemap = api.SourceMapExternal
 			}
 			hasBareSourceMapFlag = false
@@ -136,7 +152,7 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case arg == "--sourcemap=inline":
 			if buildOpts != nil {
 				buildOpts.Sourcemap = api.SourceMapInline
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Sourcemap = api.SourceMapInline
 			}
 			hasBareSourceMapFlag = false
@@ -147,15 +163,28 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 					buildOpts.Stdin = &api.StdinOptions{}
 				}
 				buildOpts.Stdin.Sourcefile = arg[len("--sourcefile="):]
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Sourcefile = arg[len("--sourcefile="):]
+			} else {
+				if analyseOpts.Stdin == nil {
+					analyseOpts.Stdin = &api.StdinOptions{}
+				}
+				analyseOpts.Stdin.Sourcefile = arg[len("--sourcefile="):]
 			}
 
-		case strings.HasPrefix(arg, "--resolve-extensions=") && buildOpts != nil:
-			buildOpts.ResolveExtensions = strings.Split(arg[len("--resolve-extensions="):], ",")
+		case strings.HasPrefix(arg, "--resolve-extensions="):
+			if buildOpts != nil {
+				buildOpts.ResolveExtensions = strings.Split(arg[len("--resolve-extensions="):], ",")
+			} else {
+				analyseOpts.ResolveExtensions = strings.Split(arg[len("--resolve-extensions="):], ",")
+			}
 
-		case strings.HasPrefix(arg, "--main-fields=") && buildOpts != nil:
-			buildOpts.MainFields = strings.Split(arg[len("--main-fields="):], ",")
+		case strings.HasPrefix(arg, "--main-fields="):
+			if buildOpts != nil {
+				buildOpts.MainFields = strings.Split(arg[len("--main-fields="):], ",")
+			} else {
+				analyseOpts.MainFields = strings.Split(arg[len("--main-fields="):], ",")
+			}
 
 		case strings.HasPrefix(arg, "--public-path=") && buildOpts != nil:
 			buildOpts.PublicPath = arg[len("--public-path="):]
@@ -163,12 +192,18 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case strings.HasPrefix(arg, "--global-name="):
 			if buildOpts != nil {
 				buildOpts.GlobalName = arg[len("--global-name="):]
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.GlobalName = arg[len("--global-name="):]
+			} else {
+				analyseOpts.GlobalName = arg[len("--global-name="):]
 			}
 
-		case strings.HasPrefix(arg, "--metafile=") && buildOpts != nil:
-			buildOpts.Metafile = arg[len("--metafile="):]
+		case strings.HasPrefix(arg, "--metafile="):
+			if buildOpts != nil {
+				buildOpts.Metafile = arg[len("--metafile="):]
+			} else {
+				analyseOpts.Metafile = arg[len("--metafile="):]
+			}
 
 		case strings.HasPrefix(arg, "--outfile=") && buildOpts != nil:
 			buildOpts.Outfile = arg[len("--outfile="):]
@@ -179,8 +214,12 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 		case strings.HasPrefix(arg, "--outbase=") && buildOpts != nil:
 			buildOpts.Outbase = arg[len("--outbase="):]
 
-		case strings.HasPrefix(arg, "--tsconfig=") && buildOpts != nil:
-			buildOpts.Tsconfig = arg[len("--tsconfig="):]
+		case strings.HasPrefix(arg, "--tsconfig="):
+			if buildOpts != nil {
+				buildOpts.Tsconfig = arg[len("--tsconfig="):]
+			} else {
+				analyseOpts.Tsconfig = arg[len("--tsconfig="):]
+			}
 
 		case strings.HasPrefix(arg, "--tsconfig-raw=") && transformOpts != nil:
 			transformOpts.TsconfigRaw = arg[len("--tsconfig-raw="):]
@@ -193,19 +232,23 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			}
 			if buildOpts != nil {
 				buildOpts.Define[value[:equals]] = value[equals+1:]
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Define[value[:equals]] = value[equals+1:]
+			} else {
+				analyseOpts.Define[value[:equals]] = value[equals+1:]
 			}
 
 		case strings.HasPrefix(arg, "--pure:"):
 			value := arg[len("--pure:"):]
 			if buildOpts != nil {
 				buildOpts.Pure = append(buildOpts.Pure, value)
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Pure = append(transformOpts.Pure, value)
+			} else {
+				analyseOpts.Pure = append(analyseOpts.Pure, value)
 			}
 
-		case strings.HasPrefix(arg, "--loader:") && buildOpts != nil:
+		case strings.HasPrefix(arg, "--loader:"):
 			value := arg[len("--loader:"):]
 			equals := strings.IndexByte(value, '=')
 			if equals == -1 {
@@ -216,7 +259,11 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			if err != nil {
 				return err
 			}
-			buildOpts.Loader[ext] = loader
+			if buildOpts != nil {
+				buildOpts.Loader[ext] = loader
+			} else {
+				analyseOpts.Loader[ext] = loader
+			}
 
 		case strings.HasPrefix(arg, "--loader="):
 			value := arg[len("--loader="):]
@@ -232,8 +279,13 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 					buildOpts.Stdin = &api.StdinOptions{}
 				}
 				buildOpts.Stdin.Loader = loader
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Loader = loader
+			} else {
+				if analyseOpts.Stdin == nil {
+					analyseOpts.Stdin = &api.StdinOptions{}
+				}
+				analyseOpts.Stdin.Loader = loader
 			}
 
 		case strings.HasPrefix(arg, "--target="):
@@ -244,9 +296,12 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			if buildOpts != nil {
 				buildOpts.Target = target
 				buildOpts.Engines = engines
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Target = target
 				transformOpts.Engines = engines
+			} else {
+				analyseOpts.Target = target
+				analyseOpts.Engines = engines
 			}
 
 		case strings.HasPrefix(arg, "--out-extension:") && buildOpts != nil:
@@ -260,13 +315,21 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			}
 			buildOpts.OutExtensions[value[:equals]] = value[equals+1:]
 
-		case strings.HasPrefix(arg, "--platform=") && buildOpts != nil:
+		case strings.HasPrefix(arg, "--platform="):
 			value := arg[len("--platform="):]
 			switch value {
 			case "browser":
-				buildOpts.Platform = api.PlatformBrowser
+				if buildOpts != nil {
+					buildOpts.Platform = api.PlatformBrowser
+				} else {
+					analyseOpts.Platform = api.PlatformBrowser
+				}
 			case "node":
-				buildOpts.Platform = api.PlatformNode
+				if buildOpts != nil {
+					buildOpts.Platform = api.PlatformNode
+				} else {
+					analyseOpts.Platform = api.PlatformNode
+				}
 			default:
 				return fmt.Errorf("Invalid platform: %q (valid: browser, node)", value)
 			}
@@ -296,8 +359,12 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, esm)", value)
 			}
 
-		case strings.HasPrefix(arg, "--external:") && buildOpts != nil:
-			buildOpts.External = append(buildOpts.External, arg[len("--external:"):])
+		case strings.HasPrefix(arg, "--external:"):
+			if buildOpts != nil {
+				buildOpts.External = append(buildOpts.External, arg[len("--external:"):])
+			} else {
+				analyseOpts.External = append(analyseOpts.External, arg[len("--external:"):])
+			}
 
 		case strings.HasPrefix(arg, "--inject:") && buildOpts != nil:
 			buildOpts.Inject = append(buildOpts.Inject, arg[len("--inject:"):])
@@ -306,16 +373,20 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			value := arg[len("--jsx-factory="):]
 			if buildOpts != nil {
 				buildOpts.JSXFactory = value
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.JSXFactory = value
+			} else {
+				analyseOpts.JSXFactory = value
 			}
 
 		case strings.HasPrefix(arg, "--jsx-fragment="):
 			value := arg[len("--jsx-fragment="):]
 			if buildOpts != nil {
 				buildOpts.JSXFragment = value
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.JSXFragment = value
+			} else {
+				analyseOpts.JSXFragment = value
 			}
 
 		case strings.HasPrefix(arg, "--banner="):
@@ -342,8 +413,10 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			}
 			if buildOpts != nil {
 				buildOpts.ErrorLimit = limit
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.ErrorLimit = limit
+			} else {
+				analyseOpts.ErrorLimit = limit
 			}
 
 			// Make sure this stays in sync with "PrintErrorToStderr"
@@ -360,8 +433,10 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			}
 			if buildOpts != nil {
 				buildOpts.Color = color
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.Color = color
+			} else {
+				analyseOpts.Color = color
 			}
 
 		// Make sure this stays in sync with "PrintErrorToStderr"
@@ -382,21 +457,31 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 			}
 			if buildOpts != nil {
 				buildOpts.LogLevel = logLevel
-			} else {
+			} else if transformOpts != nil {
 				transformOpts.LogLevel = logLevel
+			} else {
+				analyseOpts.LogLevel = logLevel
 			}
 
 		case strings.HasPrefix(arg, "'--"):
 			return fmt.Errorf("Unexpected single quote character before flag (use \\\" to escape double quotes): %s", arg)
 
+		case !strings.HasPrefix(arg, "-"):
+			if buildOpts != nil {
+				buildOpts.EntryPoints = append(buildOpts.EntryPoints, arg)
+			} else {
+				analyseOpts.EntryPoints = append(analyseOpts.EntryPoints, arg)
+			}
 		case !strings.HasPrefix(arg, "-") && buildOpts != nil:
 			buildOpts.EntryPoints = append(buildOpts.EntryPoints, arg)
 
 		default:
 			if buildOpts != nil {
 				return fmt.Errorf("Invalid build flag: %q", arg)
-			} else {
+			} else if transformOpts != nil {
 				return fmt.Errorf("Invalid transform flag: %q", arg)
+			} else {
+				return fmt.Errorf("Invalid analyse flag: %q", arg)
 			}
 		}
 	}
@@ -406,6 +491,10 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 	// going to be writing to stdout which can only represent a single file.
 	if buildOpts != nil && hasBareSourceMapFlag && buildOpts.Outfile == "" && buildOpts.Outdir == "" {
 		buildOpts.Sourcemap = api.SourceMapInline
+	}
+
+	if analyseOpts != nil && !analyse {
+		return fmt.Errorf("Missing --analyse flag")
 	}
 
 	return nil
@@ -463,8 +552,9 @@ outer:
 }
 
 // This returns either BuildOptions, TransformOptions, or an error
-func parseOptionsForRun(osArgs []string) (*api.BuildOptions, *api.TransformOptions, error) {
+func parseOptionsForRun(osArgs []string) (*api.BuildOptions, *api.TransformOptions, *api.AnalyseOptions, error) {
 	// If there's an entry point or we're bundling, then we're building
+	// If there's the --analyse flag set, then we're analysing
 	for _, arg := range osArgs {
 		if !strings.HasPrefix(arg, "-") || arg == "--bundle" {
 			options := newBuildOptions()
@@ -474,11 +564,24 @@ func parseOptionsForRun(osArgs []string) (*api.BuildOptions, *api.TransformOptio
 			options.LogLevel = api.LogLevelInfo
 			options.Write = true
 
-			err := parseOptionsImpl(osArgs, &options, nil)
+			err := parseOptionsImpl(osArgs, &options, nil, nil)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
-			return &options, nil, nil
+			return &options, nil, nil, nil
+		} else if !strings.HasPrefix(arg, "-") || arg == "--analyse" {
+			options := newAnalyseOptions()
+
+			// Apply defaults appropriate for the CLI
+			options.ErrorLimit = 10
+			options.LogLevel = api.LogLevelInfo
+			options.Write = true
+
+			err := parseOptionsImpl(osArgs, nil, nil, &options)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			return nil, nil, &options, nil
 		}
 	}
 
@@ -489,14 +592,14 @@ func parseOptionsForRun(osArgs []string) (*api.BuildOptions, *api.TransformOptio
 	options.ErrorLimit = 10
 	options.LogLevel = api.LogLevelInfo
 
-	err := parseOptionsImpl(osArgs, nil, &options)
+	err := parseOptionsImpl(osArgs, nil, &options, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if options.Sourcemap != api.SourceMapNone && options.Sourcemap != api.SourceMapInline {
-		return nil, nil, fmt.Errorf("Must use \"inline\" source map when transforming stdin")
+		return nil, nil, nil, fmt.Errorf("Must use \"inline\" source map when transforming stdin")
 	}
-	return nil, &options, nil
+	return nil, &options, nil, nil
 }
 
 func runImpl(osArgs []string) int {
@@ -516,7 +619,7 @@ func runImpl(osArgs []string) int {
 		}
 	}
 
-	buildOptions, transformOptions, err := parseOptionsForRun(osArgs)
+	buildOptions, transformOptions, analyseOptions, err := parseOptionsForRun(osArgs)
 
 	switch {
 	case buildOptions != nil:
@@ -568,6 +671,36 @@ func runImpl(osArgs []string) int {
 		// Write the output to stdout
 		os.Stdout.Write(result.Code)
 
+	case analyseOptions != nil:
+		// Read from stdin when there are no entry points
+		if len(analyseOptions.EntryPoints) == 0 {
+			if analyseOptions.Stdin == nil {
+				analyseOptions.Stdin = &api.StdinOptions{}
+			}
+			bytes, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
+					"Could not read from stdin: %s", err.Error()))
+				return 1
+			}
+			analyseOptions.Stdin.Contents = string(bytes)
+		} else if analyseOptions.Stdin != nil {
+			if analyseOptions.Stdin.Sourcefile != "" {
+				logger.PrintErrorToStderr(osArgs,
+					"\"sourcefile\" only applies when reading from stdin")
+			} else {
+				logger.PrintErrorToStderr(osArgs,
+					"\"loader\" without extension only applies when reading from stdin")
+			}
+			return 1
+		}
+
+		// Run the build and stop if there were errors
+		result := api.Analyse(*analyseOptions)
+		if len(result.Errors) > 0 {
+			return 1
+		}
+
 	case err != nil:
 		logger.PrintErrorToStderr(osArgs, err.Error())
 		return 1
@@ -604,7 +737,7 @@ func serveImpl(serveText string, osArgs []string) error {
 	options.ErrorLimit = 5
 	options.LogLevel = api.LogLevelInfo
 
-	if err := parseOptionsImpl(osArgs, &options, nil); err != nil {
+	if err := parseOptionsImpl(osArgs, &options, nil, nil); err != nil {
 		logger.PrintErrorToStderr(osArgs, err.Error())
 		return err
 	}


### PR DESCRIPTION
Adds an `analyse` execution mode, modelled after building a bundle, but ending after `bundler.ScanBundle` and writing the metadata out. Attempts to fix #386.

* Add the command-line flag `--analyse` to compute metadata of a bundle.
* Add the `Analyse` method to the API, which produces metadata after `bundler.ScanBundle`.
* Add the `analyse` command to the service, available only for node.
* Include only "inputs" in metadata from the module analysis.

Remarks:

* The method `parseOptionsImpl` becomes less legible with the conditions checking `buildOpts`, `transformOpts` and now `analyseOpts`.
* Many options between `esbuild --bundle` and `esbuild --analyse` are shared, which becomes visible in the copied code between methods `flagsForBuildOptions` and `flagsForAnalyseOptions` and structures `BuildOptions` and `AnalyseOptions`.
* Some flags from `AnalyseOptions` are probably not necessary. I was not sure, which flags can affect parsing and module resolving. I added all, that I suspected at least a little.