### PR TITLE
fix build failed after upgrade golang.org/x/sys

### DIFF
--- a/internal/logger/logger_darwin.go
+++ b/internal/logger/logger_darwin.go
@@ -5,6 +5,7 @@ package logger
 import (
 	"os"
 	"unsafe"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -28,7 +29,7 @@ func GetTerminalInfo(file *os.File) (info TerminalInfo) {
 
 		// Get the width of the window
 		w := new(winsize)
-		if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, unix.TIOCGWINSZ, uintptr(unsafe.Pointer(w))); err == 0 {
+		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(w))); err == 0 {
 			info.Width = int(w.ws_col)
 		}
 	}

--- a/internal/logger/logger_darwin.go
+++ b/internal/logger/logger_darwin.go
@@ -4,8 +4,8 @@ package logger
 
 import (
 	"os"
-	"unsafe"
 	"syscall"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
After upgrading `golang.org/x/sys` to latest version,  `v0.0.0-20200918174421-af09f7315aff` for example,
build will failed, because of [this](https://github.com/golang/sys/commit/6fcdbc0bbc04dcd9e7dc145879ceaf9bf1c6ff03)
__unix.SYS_IOCTL__ was removed,  using `syscall.SYS_IOCTL` instead.