### PR TITLE
Pass config.Options always by reference

### DIFF
--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -88,8 +88,8 @@ func (s *suite) expectBundled(t *testing.T, args bundled) {
 			args.options.AbsOutputDir = path.Dir(args.options.AbsOutputFile)
 		}
 		log := logger.NewDeferLog()
-		resolver := resolver.NewResolver(fs, log, args.options)
-		bundle := ScanBundle(log, fs, resolver, args.entryPaths, args.options)
+		resolver := resolver.NewResolver(fs, log, &args.options)
+		bundle := ScanBundle(log, fs, resolver, args.entryPaths, &args.options)
 		msgs := log.Done()
 		assertLog(t, msgs, args.expectedScanLog)
 
@@ -100,7 +100,7 @@ func (s *suite) expectBundled(t *testing.T, args bundled) {
 
 		log = logger.NewDeferLog()
 		args.options.OmitRuntimeForTests = true
-		results := bundle.Compile(log, args.options)
+		results := bundle.Compile(log, &args.options)
 		msgs = log.Done()
 		assertLog(t, msgs, args.expectedCompileLog)
 

--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -17,7 +17,7 @@ import (
 type parser struct {
 	log           logger.Log
 	source        logger.Source
-	options       config.Options
+	options       *config.Options
 	tokens        []css_lexer.Token
 	stack         []css_lexer.T
 	index         int
@@ -26,7 +26,7 @@ type parser struct {
 	importRecords []ast.ImportRecord
 }
 
-func Parse(log logger.Log, source logger.Source, options config.Options) css_ast.AST {
+func Parse(log logger.Log, source logger.Source, options *config.Options) css_ast.AST {
 	p := parser{
 		log:       log,
 		source:    source,

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -22,7 +22,7 @@ func expectParseError(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{})
+		Parse(log, test.SourceForTest(contents), &config.Options{})
 		msgs := log.Done()
 		text := ""
 		for _, msg := range msgs {
@@ -32,7 +32,7 @@ func expectParseError(t *testing.T, contents string, expected string) {
 	})
 }
 
-func expectPrintedCommon(t *testing.T, name string, contents string, expected string, options config.Options) {
+func expectPrintedCommon(t *testing.T, name string, contents string, expected string, options *config.Options) {
 	t.Helper()
 	t.Run(name, func(t *testing.T) {
 		t.Helper()
@@ -53,19 +53,19 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 
 func expectPrinted(t *testing.T, contents string, expected string) {
 	t.Helper()
-	expectPrintedCommon(t, contents, contents, expected, config.Options{})
+	expectPrintedCommon(t, contents, contents, expected, &config.Options{})
 }
 
 func expectPrintedLower(t *testing.T, contents string, expected string) {
 	t.Helper()
-	expectPrintedCommon(t, contents+" [mangle]", contents, expected, config.Options{
+	expectPrintedCommon(t, contents+" [mangle]", contents, expected, &config.Options{
 		UnsupportedCSSFeatures: ^compat.CSSFeature(0),
 	})
 }
 
 func expectPrintedMangle(t *testing.T, contents string, expected string) {
 	t.Helper()
-	expectPrintedCommon(t, contents+" [mangle]", contents, expected, config.Options{
+	expectPrintedCommon(t, contents+" [mangle]", contents, expected, &config.Options{
 		MangleSyntax: true,
 	})
 }

--- a/internal/css_printer/css_printer_test.go
+++ b/internal/css_printer/css_printer_test.go
@@ -21,7 +21,7 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 	t.Run(name, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree := css_parser.Parse(log, test.SourceForTest(contents), config.Options{})
+		tree := css_parser.Parse(log, test.SourceForTest(contents), &config.Options{})
 		msgs := log.Done()
 		text := ""
 		for _, msg := range msgs {

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -10072,7 +10072,7 @@ func newParser(log logger.Log, source logger.Source, lexer js_lexer.Lexer, optio
 	return p
 }
 
-func Parse(log logger.Log, source logger.Source, options config.Options) (result js_ast.AST, ok bool) {
+func Parse(log logger.Log, source logger.Source, options *config.Options) (result js_ast.AST, ok bool) {
 	ok = true
 	defer func() {
 		r := recover()
@@ -10091,7 +10091,7 @@ func Parse(log logger.Log, source logger.Source, options config.Options) (result
 		options.JSX.Fragment = []string{"React", "Fragment"}
 	}
 
-	p := newParser(log, source, js_lexer.NewLexer(log, source), &options)
+	p := newParser(log, source, js_lexer.NewLexer(log, source), options)
 
 	// Consume a leading hashbang comment
 	hashbang := ""
@@ -10106,7 +10106,7 @@ func Parse(log logger.Log, source logger.Source, options config.Options) (result
 
 	// Parse the file in the first pass, but do not bind symbols
 	stmts := p.parseStmtsUpTo(js_lexer.TEndOfFile, parseStmtOpts{isModuleScope: true})
-	p.prepareForVisitPass(&options)
+	p.prepareForVisitPass(options)
 
 	// Strip off a leading "use strict" directive when not bundling
 	directive := ""
@@ -10178,12 +10178,12 @@ func Parse(log logger.Log, source logger.Source, options config.Options) (result
 	return
 }
 
-func LazyExportAST(log logger.Log, source logger.Source, options config.Options, expr js_ast.Expr, apiCall string) js_ast.AST {
+func LazyExportAST(log logger.Log, source logger.Source, options *config.Options, expr js_ast.Expr, apiCall string) js_ast.AST {
 	// Don't create a new lexer using js_lexer.NewLexer() here since that will
 	// actually attempt to parse the first token, which might cause a syntax
 	// error.
-	p := newParser(log, source, js_lexer.Lexer{}, &options)
-	p.prepareForVisitPass(&options)
+	p := newParser(log, source, js_lexer.Lexer{}, options)
+	p.prepareForVisitPass(options)
 
 	// Optionally call a runtime API function to transform the expression
 	if apiCall != "" {

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -19,7 +19,7 @@ func expectParseError(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{})
+		Parse(log, test.SourceForTest(contents), &config.Options{})
 		msgs := log.Done()
 		text := ""
 		for _, msg := range msgs {
@@ -34,7 +34,7 @@ func expectParseErrorTarget(t *testing.T, esVersion int, contents string, expect
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{
+		Parse(log, test.SourceForTest(contents), &config.Options{
 			UnsupportedJSFeatures: compat.UnsupportedJSFeatures(map[compat.Engine][]int{
 				compat.ES: {esVersion},
 			}),
@@ -53,7 +53,7 @@ func expectPrinted(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{})
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{})
 		msgs := log.Done()
 		text := ""
 		for _, msg := range msgs {
@@ -78,7 +78,7 @@ func expectPrintedMangle(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			MangleSyntax: true,
 		})
 		msgs := log.Done()
@@ -106,7 +106,7 @@ func expectPrintedTarget(t *testing.T, esVersion int, contents string, expected 
 		unsupportedFeatures := compat.UnsupportedJSFeatures(map[compat.Engine][]int{
 			compat.ES: {esVersion},
 		})
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			UnsupportedJSFeatures: unsupportedFeatures,
 		})
 		msgs := log.Done()
@@ -135,7 +135,7 @@ func expectPrintedTargetStrict(t *testing.T, esVersion int, contents string, exp
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			UnsupportedJSFeatures: compat.UnsupportedJSFeatures(map[compat.Engine][]int{
 				compat.ES: {esVersion},
 			}),
@@ -169,7 +169,7 @@ func expectParseErrorJSX(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{
+		Parse(log, test.SourceForTest(contents), &config.Options{
 			JSX: config.JSXOptions{
 				Parse: true,
 			},
@@ -188,7 +188,7 @@ func expectPrintedJSX(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			JSX: config.JSXOptions{
 				Parse: true,
 			},

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -16,7 +16,7 @@ func expectParseErrorTS(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{
+		Parse(log, test.SourceForTest(contents), &config.Options{
 			TS: config.TSOptions{
 				Parse: true,
 			},
@@ -35,7 +35,7 @@ func expectPrintedTS(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			TS: config.TSOptions{
 				Parse: true,
 			},
@@ -62,7 +62,7 @@ func expectParseErrorTSX(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		Parse(log, test.SourceForTest(contents), config.Options{
+		Parse(log, test.SourceForTest(contents), &config.Options{
 			TS: config.TSOptions{
 				Parse: true,
 			},
@@ -84,7 +84,7 @@ func expectPrintedTSX(t *testing.T, contents string, expected string) {
 	t.Run(contents, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := Parse(log, test.SourceForTest(contents), &config.Options{
 			TS: config.TSOptions{
 				Parse: true,
 			},

--- a/internal/js_printer/js_printer_test.go
+++ b/internal/js_printer/js_printer_test.go
@@ -24,7 +24,7 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 	t.Run(name, func(t *testing.T) {
 		t.Helper()
 		log := logger.NewDeferLog()
-		tree, ok := js_parser.Parse(log, test.SourceForTest(contents), config.Options{
+		tree, ok := js_parser.Parse(log, test.SourceForTest(contents), &config.Options{
 			UnsupportedJSFeatures: options.UnsupportedFeatures,
 		})
 		msgs := log.Done()

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -107,7 +107,7 @@ type Resolver interface {
 type resolver struct {
 	fs      fs.FS
 	log     logger.Log
-	options config.Options
+	options *config.Options
 	mutex   sync.Mutex
 
 	// This cache maps a directory path to information about that directory and
@@ -115,7 +115,7 @@ type resolver struct {
 	dirCache map[string]*dirInfo
 }
 
-func NewResolver(fs fs.FS, log logger.Log, options config.Options) Resolver {
+func NewResolver(fs fs.FS, log logger.Log, options *config.Options) Resolver {
 	// Bundling for node implies allowing node's builtin modules
 	if options.Platform == config.PlatformNode {
 		externalNodeModules := make(map[string]bool)

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -514,13 +514,13 @@ func buildImpl(buildOpts BuildOptions) BuildResult {
 	// Stop now if there were errors
 	if !log.HasErrors() {
 		// Scan over the bundle
-		resolver := resolver.NewResolver(realFS, log, options)
-		bundle := bundler.ScanBundle(log, realFS, resolver, entryPaths, options)
+		resolver := resolver.NewResolver(realFS, log, &options)
+		bundle := bundler.ScanBundle(log, realFS, resolver, entryPaths, &options)
 
 		// Stop now if there were errors
 		if !log.HasErrors() {
 			// Compile the bundle
-			results := bundle.Compile(log, options)
+			results := bundle.Compile(log, &options)
 
 			// Stop now if there were errors
 			if !log.HasErrors() {
@@ -640,13 +640,13 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 	if !log.HasErrors() {
 		// Scan over the bundle
 		mockFS := fs.MockFS(make(map[string]string))
-		resolver := resolver.NewResolver(mockFS, log, options)
-		bundle := bundler.ScanBundle(log, mockFS, resolver, nil, options)
+		resolver := resolver.NewResolver(mockFS, log, &options)
+		bundle := bundler.ScanBundle(log, mockFS, resolver, nil, &options)
 
 		// Stop now if there were errors
 		if !log.HasErrors() {
 			// Compile the bundle
-			results = bundle.Compile(log, options)
+			results = bundle.Compile(log, &options)
 		}
 	}
 


### PR DESCRIPTION
* Make the options usage consistent throughout the source code.
* Allow hosting objects in the options, which must not be cloned, like mutexes.

When inspecting all usages of `config.Options`, I was surprised seeing some functins accepting and some strcutures nesting `*config.Options`, while the others `config.Options.`. Was there a reason behind that? Did you expect that some functions should be able to modify the options and those should not affect the caller's options?

If not, I am offering this change to pass around and nest the `config.Options` object always using a pointer to prevent the cloning. What do you think?

(I stumbled over this, when I was prototyping support for AMD.JS. I added a map to `config.Options.AMD` and included a mutex there too, to be able to synchronize accesses to the map. Locking did not work and running `go vet` discovered that `config.Options` were passed around by value, which must not happen if a mutex is there.)