### PR TITLE
Initial work on CommonJS code splitting

### DIFF
--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -1476,7 +1476,7 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 	// export statement that's not top-level. Instead, we will export the CommonJS
 	// exports as a default export later on.
 	needsEntryPointExportPart := file.isEntryPoint && !repr.meta.cjsWrap &&
-		(c.options.OutputFormat == config.FormatESModule || c.options.OutputFormat == config.FormatCommonJS) &&
+		(c.options.OutputFormat == config.FormatESModule || (c.options.OutputFormat == config.FormatCommonJS && !repr.meta.cjsStyleExports)) &&
 		len(repr.meta.sortedAndFilteredExportAliases) > 0
 
 	// Generate a getter per export
@@ -1734,18 +1734,16 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 	}
 
 	if len(entryPointCJSExportItems) > 1 {
-		if !repr.meta.cjsStyleExports {
-			entryPointExportStmts = append(entryPointExportStmts,
-				js_ast.Stmt{Data: &js_ast.SExpr{
-					Value: js_ast.Assign(
-						js_ast.Expr{Data: &js_ast.EDot{
-							Target: js_ast.Expr{Data: &js_ast.EIdentifier{Ref: c.unboundModuleRef}},
-							Name:   "exports",
-						}},
-						js_ast.Expr{Data: &js_ast.EObject{Properties: entryPointCJSExportItems}},
-					),
-				}})
-		}
+		entryPointExportStmts = append(entryPointExportStmts,
+			js_ast.Stmt{Data: &js_ast.SExpr{
+				Value: js_ast.Assign(
+					js_ast.Expr{Data: &js_ast.EDot{
+						Target: js_ast.Expr{Data: &js_ast.EIdentifier{Ref: c.unboundModuleRef}},
+						Name:   "exports",
+					}},
+					js_ast.Expr{Data: &js_ast.EObject{Properties: entryPointCJSExportItems}},
+				),
+			}})
 	}
 
 	if len(entryPointES6ExportItems) > 0 {

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -532,9 +532,10 @@ func buildImpl(buildOpts BuildOptions) BuildResult {
 		options.Mode = config.ModeConvertFormat
 	}
 
-	// Code splitting is experimental and currently only enabled for ES6 modules
-	if options.CodeSplitting && options.OutputFormat != config.FormatESModule {
-		log.AddError(nil, logger.Loc{}, "Splitting currently only works with the \"esm\" format")
+	// Code splitting is experimental and currently only enabled for ES6 and CJS modules
+	if options.CodeSplitting && (options.OutputFormat != config.FormatESModule &&
+		options.OutputFormat != config.FormatCommonJS) {
+		log.AddError(nil, logger.Loc{}, "Splitting currently only works with the \"esm\" and \"cjs\" formats")
 	}
 
 	var outputFiles []OutputFile


### PR DESCRIPTION
Here is some initial work on CommonJS code splitting. Looks like I was on an outdated copy but I'd love some feedback on the approach and help resolving the few failing tests.

I know there is a better way to do the `module.exports` generation using the "__exports" runtime utility but I'm not sure on the AST API for it.