### PR TITLE
Fix broken metafile with css import from js

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1303,19 +1303,26 @@ func (b *Bundle) generateMetadataJSON(results []OutputFile, asciiOnly bool) []by
 	j.AddString("{\n  \"inputs\": {")
 
 	// Write inputs
-	for i, item := range sorted {
-		if i > 0 {
-			j.AddString(",\n    ")
-		} else {
-			j.AddString("\n    ")
+	isFirst := true
+	for _, item := range sorted {
+		file := b.files[item.sourceIndex]
+		// Do not include this file if it is a js stub for a css file.
+		if repr, ok := file.repr.(*reprJS); ok && repr.cssSourceIndex != nil {
+			continue
 		}
-		j.AddBytes(b.files[item.sourceIndex].jsonMetadataChunk)
+		if isFirst {
+			isFirst = false
+			j.AddString("\n    ")
+		} else {
+			j.AddString(",\n    ")
+		}
+		j.AddBytes(file.jsonMetadataChunk)
 	}
 
 	j.AddString("\n  },\n  \"outputs\": {")
 
 	// Write outputs
-	isFirst := true
+	isFirst = true
 	for _, result := range results {
 		if len(result.jsonMetadataChunk) > 0 {
 			if isFirst {


### PR DESCRIPTION
When a css file is imported from js, esbuild adds a js stub for it. The stub does not have `jsonMetadataChunk` set on it, because it isn't a real file. The code that generates the metafile does not check for this, which causes it to produce invalid json. This PR adds a check to confirm a file is not a stub before attempting to include it in the "inputs" section of the metafile.