### PR TITLE
the executable path should be bin/eslint

### DIFF
--- a/lib/install.ts
+++ b/lib/install.ts
@@ -238,7 +238,7 @@ function installOnUnix(name: string): void {
   // Yarn 2. Normal package managers can just run the binary directly for
   // maximum speed.
   if (isYarnBerryOrNewer()) {
-    installWithWrapper(name, "esbuild");
+    installWithWrapper(name, "bin/esbuild");
   } else {
     installDirectly(name);
   }


### PR DESCRIPTION
The fact that we are on Yarn Berry or newer doesn't change the executable path in the package.
Hence it should match the one used in `installDirectly` which is `"bin/eslint"`.

Otherwise we get an error with
```
# This file contains the result of Yarn building a package (esbuild@npm:0.8.3)
# Script name: postinstall

Trying to install "esbuild-darwin-64" using npm
Failed to install "esbuild-darwin-64" using npm: ENOENT: no such file or directory, open '/Users/mathieudutour/Projects/gitbook-x/node_modules/esbuild/.install/node_modules/esbuild-darwin-64/esbuild'
Trying to download "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.8.3.tgz"
Failed to download "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.8.3.tgz": Could not find "package/esbuild" in archive
Install unsuccessful
```