### PR TITLE
Add support for banner and footer

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -31,6 +31,8 @@ Options:
                         is browser and cjs when platform is node)
   --splitting           Enable code splitting (currently only for esm)
   --global-name=...     The name of the global for the IIFE format
+	--banner=...          Text to be prepended to each output file
+	--footer=...          Text to be appended to each output file
 
   --minify              Sets all --minify-* flags
   --minify-whitespace   Remove whitespace

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3400,6 +3400,13 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func([]ast
 			}
 		}
 
+		if len(c.options.Banner) > 0 {
+			prevOffset.advanceString(c.options.Banner)
+			prevOffset.advanceString("\n")
+			j.AddString(c.options.Banner)
+			j.AddString("\n")
+		}
+
 		// Optionally wrap with an IIFE
 		if c.options.OutputFormat == config.FormatIIFE {
 			var text string
@@ -3631,6 +3638,11 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func([]ast
 		sort.Strings(commentList)
 		for _, text := range commentList {
 			j.AddString(text)
+			j.AddString("\n")
+		}
+
+		if len(c.options.Footer) > 0 {
+			j.AddString(c.options.Footer)
 			j.AddString("\n")
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,8 @@ type Options struct {
 	PublicPath        string
 	InjectAbsPaths    []string
 	InjectedFiles     []InjectedFile
+	Banner            string
+	Footer            string
 
 	Plugins []Plugin
 

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -89,6 +89,8 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   let pure = getFlag(options, keys, 'pure', mustBeArray);
   let avoidTDZ = getFlag(options, keys, 'avoidTDZ', mustBeBoolean);
   let keepNames = getFlag(options, keys, 'keepNames', mustBeBoolean);
+  let banner = getFlag(options, keys, 'banner', mustBeString);
+  let footer = getFlag(options, keys, 'footer', mustBeString);
 
   if (target) {
     if (Array.isArray(target)) flags.push(`--target=${Array.from(target).map(validateTarget).join(',')}`)
@@ -114,6 +116,9 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   if (pure) for (let fn of pure) flags.push(`--pure:${fn}`);
   if (avoidTDZ) flags.push(`--avoid-tdz`);
   if (keepNames) flags.push(`--keep-names`);
+
+  if (banner) flags.push(`--banner=${banner}`);
+  if (footer) flags.push(`--footer=${footer}`);
 }
 
 function flagsForBuildOptions(options: types.BuildOptions, isTTY: boolean, logLevelDefault: types.LogLevel):

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,8 @@ interface CommonOptions {
   pure?: string[];
   avoidTDZ?: boolean;
   keepNames?: boolean;
+  banner?: string;
+  footer?: string;
 
   color?: boolean;
   logLevel?: LogLevel;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -230,6 +230,8 @@ type BuildOptions struct {
 	OutExtensions     map[string]string
 	PublicPath        string
 	Inject            []string
+	Banner            string
+	Footer            string
 
 	EntryPoints []string
 	Stdin       *StdinOptions
@@ -282,6 +284,8 @@ type TransformOptions struct {
 	JSXFactory  string
 	JSXFragment string
 	TsconfigRaw string
+	Footer      string
+	Banner      string
 
 	Define    map[string]string
 	Pure      []string

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -494,6 +494,8 @@ func buildImpl(buildOpts BuildOptions) BuildResult {
 		AvoidTDZ:          buildOpts.AvoidTDZ,
 		KeepNames:         buildOpts.KeepNames,
 		InjectAbsPaths:    make([]string, len(buildOpts.Inject)),
+		Banner:            buildOpts.Banner,
+		Footer:            buildOpts.Footer,
 	}
 	for i, path := range buildOpts.Inject {
 		options.InjectAbsPaths[i] = validatePath(log, realFS, path)
@@ -728,6 +730,8 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 			Contents:   input,
 			SourceFile: transformOpts.Sourcefile,
 		},
+		Banner: transformOpts.Banner,
+		Footer: transformOpts.Footer,
 	}
 	if options.SourceMap == config.SourceMapLinkedWithComment {
 		// Linked source maps don't make sense because there's no output file name

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -302,6 +302,22 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 				transformOpts.JSXFragment = value
 			}
 
+		case strings.HasPrefix(arg, "--banner="):
+			value := arg[len("--banner="):]
+			if buildOpts != nil {
+				buildOpts.Banner = value
+			} else {
+				transformOpts.Banner = value
+			}
+
+		case strings.HasPrefix(arg, "--footer="):
+			value := arg[len("--footer="):]
+			if buildOpts != nil {
+				buildOpts.Footer = value
+			} else {
+				transformOpts.Footer = value
+			}
+
 		case strings.HasPrefix(arg, "--error-limit="):
 			value := arg[len("--error-limit="):]
 			limit, err := strconv.Atoi(value)

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -1808,6 +1808,32 @@
     )
   }
 
+  // Test injecting banner and footer
+  tests.push(
+    test(['in.js', '--outfile=node.js', '--banner=const bannerDefined = true;'], {
+      'in.js': `if (!bannerDefined) throw 'fail'`
+    }),
+    test(['in.js', '--outfile=node.js', '--footer=function footer() { }'], {
+      'in.js': `footer()`
+    }),
+    test(['a.js', 'b.js', '--outdir=out', '--bundle', '--format=cjs', '--banner=const bannerDefined = true;', '--footer=function footer() { }'], {
+      'a.js': `
+        module.exports = { banner: bannerDefined, footer };
+      `,
+      'b.js': `
+        module.exports = { banner: bannerDefined, footer };
+      `,
+      'node.js': `
+        const a = require('./out/a');
+        const b = require('./out/b');
+
+        if (!a.banner || !b.banner) throw 'fail';
+        a.footer();
+        b.footer();
+      `
+    }),
+  )
+
   // Test writing to stdout
   tests.push(
     // These should succeed

--- a/scripts/verify-source-map.js
+++ b/scripts/verify-source-map.js
@@ -376,6 +376,11 @@ async function main() {
           entryPoints: ['entry.js'],
           crlf,
         }),
+        check('banner-footer' + suffix, testCaseES6, toSearchBundle, {
+          flags: flags.concat('--outfile=out.js', '--bundle', '--banner="/* LICENSE abc */"', '--footer="/* end of file banner */"'),
+          entryPoints: ['a.js'],
+          crlf,
+        }),
       )
     }
   }


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/evanw/esbuild/issues/482.

It adds support for `banner` and `footer` options, that allow for prepending/appending a user-provided string to each output file.
Similar to [rollup's options](https://rollupjs.org/guide/en/#outputbanneroutputfooter).

I do not have full confidence that I have done everything correctly, as this is my first ever PR in go, which I began learning yesterday 😅 

Things I did (hopefully correctly):
* add `Banner` and `Footer` options to configs
* add emitting those in the linker
* take account of the banner in the sourcemap
* add test cases for sourcemaps when `banner` and `footer` are specified
* add end-to-end test cases when `banner` and `footer` are specified
* add handling those options in the JS service

I'm looking for any feedback you have 🙂 

## Example

`test.js`:

```js
console.log('hello world');
```

```sh
14:11 $ ./esbuild test.js --sourcemap --banner="/* Hello world */" --footer="/* footer */"
/* Hello world */
console.log("hello world");
/* footer */
//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidGVzdC5qcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiY29uc29sZS5sb2coJ2hlbGxvIHdvcmxkJyk7XG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQUEsUUFBUSxJQUFJOyIsCiAgIm5hbWVzIjogW10KfQo=
```

[Sourcemap visualization](https://sokra.github.io/source-map-visualization/#base64,LyogSGVsbG8gd29ybGQgKi8KY29uc29sZS5sb2coImhlbGxvIHdvcmxkIik7Ci8qIGZvb3RlciAqLwovLyMgc291cmNlTWFwcGluZ1VSTD1vdXQuanMubWFwCg==,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwic291cmNlc0NvbnRlbnQiOlsiY29uc29sZS5sb2coJ2hlbGxvIHdvcmxkJyk7XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxRQUFRLElBQUk7IiwibmFtZXMiOltdLCJmaWxlIjoiZXhhbXBsZS5qcyJ9,Y29uc29sZS5sb2coJ2hlbGxvIHdvcmxkJyk7Cg==)