### PR TITLE
Inline and erase local const enums

### DIFF
--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -219,8 +219,12 @@ func TestTSLocalMinifiedConstEnumMerging(t *testing.T) {
 			`,
 			"/premature-use.ts": `
 				const enum Foo {BAR=1, BAZ=2};
+				function falsePositiveWarningInsideFunction() {
+					console.log(Foo.BAR, Foo.BAZ, Foo.ZOO);
+				}
 				console.log(Foo.BAR, Foo.BAZ, Foo.BOO);
-				const enum Foo {BOO=3};
+				const enum Foo {BOO=3, ZOO=4};
+				falsePositiveWarningInsideFunction();
 			`,
 		},
 		entryPaths: []string{"/valid-use.ts", "/premature-use.ts"},
@@ -230,7 +234,8 @@ func TestTSLocalMinifiedConstEnumMerging(t *testing.T) {
 			MangleSyntax: true,
 			AbsOutputDir: "/",
 		},
-		expectedScanLog: `premature-use.ts: warning: Unknown member BOO on enum Foo
+		expectedScanLog: `premature-use.ts: warning: Unknown member ZOO on enum Foo
+premature-use.ts: warning: Unknown member BOO on enum Foo
 `,
 	})
 }

--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -187,6 +187,29 @@ func TestTSValidConstEnum(t *testing.T) {
 	})
 }
 
+func TestTSImportConstEnum(t *testing.T) {
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/common.ts": `
+				export const enum Foo {
+					A = 1,
+					B = 'a',
+				}
+			`,
+			"/entry.ts": `
+				import { Foo } from './common';
+				
+				let usage = bar(Foo.A, Foo.B)
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
 func TestTSDeclareEnum(t *testing.T) {
 	ts_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -229,10 +229,10 @@ func TestTSLocalMinifiedConstEnumMerging(t *testing.T) {
 		},
 		entryPaths: []string{"/valid-use.ts", "/premature-use.ts"},
 		options: config.Options{
-			RemoveWhitespace: true,
+			RemoveWhitespace:  true,
 			MinifyIdentifiers: true,
-			MangleSyntax: true,
-			AbsOutputDir: "/",
+			MangleSyntax:      true,
+			AbsOutputDir:      "/",
 		},
 		expectedScanLog: `premature-use.ts: warning: Unknown member ZOO on enum Foo
 premature-use.ts: warning: Unknown member BOO on enum Foo

--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -192,6 +192,42 @@ func TestTSLocalConstEnumWithUnknownPropertyAccess(t *testing.T) {
 	})
 }
 
+func TestTSLocalConstEnumMergingWithoutWarnings(t *testing.T) {
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				const enum Foo {BAR=1, BAZ=2};
+				const enum Foo {BOO=3};
+				console.log(Foo.BAR, Foo.BAZ, Foo.BOO);
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
+func TestTSLocalMinifiedConstEnumMerging(t *testing.T) {
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				const enum Foo {BAR=1, BAZ=2};
+				const enum Foo {BOO=3};
+				console.log(Foo.BAR, Foo.BAZ, Foo.BOO);
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			RemoveWhitespace: true,
+			MinifyIdentifiers: true,
+			MangleSyntax: true,
+			AbsOutputDir: "/",
+		},
+	})
+}
+
 func TestTSInlinableLocalConstEnum(t *testing.T) {
 	ts_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -130,6 +130,63 @@ func TestTSDeclareNamespace(t *testing.T) {
 	})
 }
 
+func TestTSInvalidConstEnum(t *testing.T) {
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				const enum Foo {
+					A = 1,
+					B = A * 2,
+					C,
+					D = 'stringsWorkToo',
+					E,
+					F = {},
+					G = someIdentifier,
+					H = function () { }
+				}
+
+				let usage = bar(Foo.A, Foo.B, Foo.H, Foo.X)
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+		},
+		expectedScanLog: `entry.ts: error: Enum member must have initializer
+entry.ts: error: const enum member initializers can only contain literal values and other computed enum values
+entry.ts: error: const enum member initializers can only contain literal values and other computed enum values
+entry.ts: error: const enum member initializers can only contain literal values and other computed enum values
+entry.ts: warning: Unknown member H on enum Foo
+entry.ts: warning: Unknown member X on enum Foo
+`,
+	})
+}
+
+func TestTSValidConstEnum(t *testing.T) {
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				const enum Foo {
+					A = 1,
+					B = A * 2,
+					C,
+					D = 'stringsWorkToo',
+				}
+				
+				let usage = bar(Foo.A, Foo.B, Foo.C, Foo.D, Foo.E)
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+		},
+		expectedScanLog: `entry.ts: warning: Unknown member E on enum Foo
+`,
+	})
+}
+
 func TestTSDeclareEnum(t *testing.T) {
 	ts_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -212,19 +212,26 @@ func TestTSLocalConstEnumMergingWithoutWarnings(t *testing.T) {
 func TestTSLocalMinifiedConstEnumMerging(t *testing.T) {
 	ts_suite.expectBundled(t, bundled{
 		files: map[string]string{
-			"/entry.ts": `
+			"/valid-use.ts": `
 				const enum Foo {BAR=1, BAZ=2};
 				const enum Foo {BOO=3};
 				console.log(Foo.BAR, Foo.BAZ, Foo.BOO);
 			`,
+			"/premature-use.ts": `
+				const enum Foo {BAR=1, BAZ=2};
+				console.log(Foo.BAR, Foo.BAZ, Foo.BOO);
+				const enum Foo {BOO=3};
+			`,
 		},
-		entryPaths: []string{"/entry.ts"},
+		entryPaths: []string{"/valid-use.ts", "/premature-use.ts"},
 		options: config.Options{
 			RemoveWhitespace: true,
 			MinifyIdentifiers: true,
 			MangleSyntax: true,
 			AbsOutputDir: "/",
 		},
+		expectedScanLog: `premature-use.ts: warning: Unknown member BOO on enum Foo
+`,
 	})
 }
 

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -2512,9 +2512,9 @@ var require_es6_ns_export_async_function = __commonJS((exports) => {
 var require_es6_ns_export_enum = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    let Foo3;
-    (function(Foo4) {
-    })(Foo3 = ns3.Foo || (ns3.Foo = {}));
+    let Foo2;
+    (function(Foo3) {
+    })(Foo2 = ns3.Foo || (ns3.Foo = {}));
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2523,9 +2523,6 @@ var require_es6_ns_export_enum = __commonJS((exports) => {
 var require_es6_ns_export_const_enum = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    let Foo3;
-    (function(Foo4) {
-    })(Foo3 = ns3.Foo || (ns3.Foo = {}));
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2544,9 +2541,9 @@ var require_es6_ns_export_namespace = __commonJS((exports) => {
 var require_es6_ns_export_class = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    class Foo3 {
+    class Foo2 {
     }
-    ns3.Foo = Foo3;
+    ns3.Foo = Foo2;
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2555,9 +2552,9 @@ var require_es6_ns_export_class = __commonJS((exports) => {
 var require_es6_ns_export_abstract_class = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    class Foo3 {
+    class Foo2 {
     }
-    ns3.Foo = Foo3;
+    ns3.Foo = Foo2;
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2593,14 +2590,11 @@ console.log(void 0);
 
 // es6-export-enum.ts
 var Foo;
-(function(Foo3) {
+(function(Foo2) {
 })(Foo || (Foo = {}));
 console.log(void 0);
 
 // es6-export-const-enum.ts
-var Foo2;
-(function(Foo3) {
-})(Foo2 || (Foo2 = {}));
 console.log(void 0);
 
 // es6-export-module.ts

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -2512,9 +2512,9 @@ var require_es6_ns_export_async_function = __commonJS((exports) => {
 var require_es6_ns_export_enum = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    let Foo2;
-    (function(Foo3) {
-    })(Foo2 = ns3.Foo || (ns3.Foo = {}));
+    let Foo3;
+    (function(Foo4) {
+    })(Foo3 = ns3.Foo || (ns3.Foo = {}));
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2523,6 +2523,9 @@ var require_es6_ns_export_enum = __commonJS((exports) => {
 var require_es6_ns_export_const_enum = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
+    let Foo3;
+    (function(Foo4) {
+    })(Foo3 = ns3.Foo || (ns3.Foo = {}));
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2541,9 +2544,9 @@ var require_es6_ns_export_namespace = __commonJS((exports) => {
 var require_es6_ns_export_class = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    class Foo2 {
+    class Foo3 {
     }
-    ns3.Foo = Foo2;
+    ns3.Foo = Foo3;
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2552,9 +2555,9 @@ var require_es6_ns_export_class = __commonJS((exports) => {
 var require_es6_ns_export_abstract_class = __commonJS((exports) => {
   var ns2;
   (function(ns3) {
-    class Foo2 {
+    class Foo3 {
     }
-    ns3.Foo = Foo2;
+    ns3.Foo = Foo3;
   })(ns2 || (ns2 = {}));
   console.log(exports);
 });
@@ -2590,11 +2593,14 @@ console.log(void 0);
 
 // es6-export-enum.ts
 var Foo;
-(function(Foo2) {
+(function(Foo3) {
 })(Foo || (Foo = {}));
 console.log(void 0);
 
 // es6-export-const-enum.ts
+var Foo2;
+(function(Foo3) {
+})(Foo2 || (Foo2 = {}));
 console.log(void 0);
 
 // es6-export-module.ts

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -240,18 +240,22 @@ TestTSImportConstEnumInsideNamespace
 // common.ts
 var NS;
 (function(NS2) {
-  let Foo2;
-  (function(Foo3) {
-    Foo3[Foo3["A"] = 1] = "A";
-    Foo3["B"] = "a";
-    Foo3[Foo3["FromBase"] = 1] = "FromBase";
-  })(Foo2 = NS2.Foo || (NS2.Foo = {}));
-  let usageInsideNamespace = bar(1, 1, Foo2.invalid);
+  let Base;
+  /* @__PURE__ */ (function(Base2) {
+    Base2["A"] = "from base enum";
+  })(Base || (Base = {}));
+  let Foo;
+  (function(Foo2) {
+    Foo2[Foo2["A"] = 1] = "A";
+    Foo2["B"] = "a";
+    Foo2["FromBase"] = "from base enum";
+  })(Foo = NS2.Foo || (NS2.Foo = {}));
+  let usageInsideNamespace = bar("from base enum", 1, Foo.invalid);
 })(NS || (NS = {}));
 var usageInBaseModule = bar(NS.Foo.A, NS.Foo.FromBase, NS.Foo.invalid);
 
 // entry.ts
-var usage = bar(NS.Foo.A, NS.Foo.B, Foo.FromBase);
+var usageWithoutInliningValues = bar(NS.Foo.A, NS.Foo.B, NS.Foo.FromBase);
 var noErrorsShownFor = bar(NS.invalidMember, NS.Foo.invalid);
 
 ================================================================================
@@ -302,6 +306,46 @@ var e = class {
 console.log(a, b, c, d, e, real);
 
 ================================================================================
+TestTSInlinableLocalConstEnum
+---------- /out.js ----------
+// common.ts
+var usage = bar(1, 2, 3, "stringsWorkToo");
+
+// entry.ts
+usage();
+
+================================================================================
+TestTSInlinableLocalConstEnumInsideNamespace
+---------- /out.js ----------
+// common.ts
+var NS;
+(function(NS2) {
+  let Foo;
+  /* @__PURE__ */ (function(Foo2) {
+    Foo2[Foo2.A = 1] = "A", Foo2[Foo2.B = 2] = "B", Foo2[Foo2.C = 3] = "C", Foo2.D = "stringsWorkToo";
+  })(Foo || (Foo = {})), NS2.usage = bar(1, 2, 3, "stringsWorkToo");
+})(NS || (NS = {}));
+
+// entry.ts
+NS.usage();
+
+================================================================================
+TestTSLocalConstEnumWithUnknownPropertyAccess
+---------- /out.js ----------
+// common.ts
+var Foo;
+/* @__PURE__ */ (function(Foo2) {
+  Foo2[Foo2["A"] = 1] = "A";
+  Foo2[Foo2["B"] = 2] = "B";
+  Foo2[Foo2["C"] = 3] = "C";
+  Foo2["D"] = "stringsWorkToo";
+})(Foo || (Foo = {}));
+var usage = bar(1, 2, 3, "stringsWorkToo", Foo.E);
+
+// entry.ts
+usage();
+
+================================================================================
 TestTSMinifiedBundleCommonJS
 ---------- /out.js ----------
 var n=e(r=>{r.foo=function(){return 123}});var u=e((j,t)=>{t.exports={test:!0}});var{foo:c}=n();console.log(c(),u());
@@ -338,12 +382,6 @@ var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||(e.Bar={}))})(Foo||(
 
 ---------- /b.js ----------
 export var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||(e.Bar={}))})(Foo||(Foo={}));
-
-================================================================================
-TestTSValidConstEnum
----------- /out.js ----------
-// entry.ts
-var usage = bar(1, 2, 3, "stringsWorkToo", Foo.E);
 
 ================================================================================
 TestTypeScriptDecorators

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -307,6 +307,12 @@ var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||(e.Bar={}))})(Foo||(
 export var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||(e.Bar={}))})(Foo||(Foo={}));
 
 ================================================================================
+TestTSValidConstEnum
+---------- /out.js ----------
+// entry.ts
+var usage = bar(1, 2, 3, "stringsWorkToo", Foo.E);
+
+================================================================================
 TestTypeScriptDecorators
 ---------- /out.js ----------
 // all.ts

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -330,6 +330,12 @@ var NS;
 NS.usage();
 
 ================================================================================
+TestTSLocalConstEnumMergingWithoutWarnings
+---------- /out.js ----------
+// entry.ts
+console.log(1, 2, 3);
+
+================================================================================
 TestTSLocalConstEnumWithUnknownPropertyAccess
 ---------- /out.js ----------
 // common.ts
@@ -344,6 +350,11 @@ var usage = bar(1, 2, 3, "stringsWorkToo", Foo.E);
 
 // entry.ts
 usage();
+
+================================================================================
+TestTSLocalMinifiedConstEnumMerging
+---------- /entry.js ----------
+var Foo;(function(B){B[B.BAR=1]="BAR",B[B.BAZ=2]="BAZ"})(Foo||(Foo={})),function(B){B[B.BOO=3]="BOO"}(Foo||(Foo={})),console.log(1,2,3);
 
 ================================================================================
 TestTSMinifiedBundleCommonJS

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -222,6 +222,39 @@ console.log("correct");
 console.log("correct");
 
 ================================================================================
+TestTSImportConstEnum
+---------- /out.js ----------
+// common.ts
+var Foo;
+(function(Foo2) {
+  Foo2[Foo2["A"] = 1] = "A";
+  Foo2["B"] = "a";
+})(Foo || (Foo = {}));
+
+// entry.ts
+var usage = bar(Foo.A, Foo.B);
+
+================================================================================
+TestTSImportConstEnumInsideNamespace
+---------- /out.js ----------
+// common.ts
+var NS;
+(function(NS2) {
+  let Foo2;
+  (function(Foo3) {
+    Foo3[Foo3["A"] = 1] = "A";
+    Foo3["B"] = "a";
+    Foo3[Foo3["FromBase"] = 1] = "FromBase";
+  })(Foo2 = NS2.Foo || (NS2.Foo = {}));
+  let usageInsideNamespace = bar(1, 1, Foo2.invalid);
+})(NS || (NS = {}));
+var usageInBaseModule = bar(NS.Foo.A, NS.Foo.FromBase, NS.Foo.invalid);
+
+// entry.ts
+var usage = bar(NS.Foo.A, NS.Foo.B, Foo.FromBase);
+var noErrorsShownFor = bar(NS.invalidMember, NS.Foo.invalid);
+
+================================================================================
 TestTSImportEmptyNamespace
 ---------- /out.js ----------
 // entry.ts

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -357,7 +357,7 @@ TestTSLocalMinifiedConstEnumMerging
 var Foo;(function(B){B[B.BAR=1]="BAR",B[B.BAZ=2]="BAZ"})(Foo||(Foo={})),function(B){B[B.BOO=3]="BOO"}(Foo||(Foo={})),console.log(1,2,3);
 
 ---------- /premature-use.js ----------
-var Foo;(function(B){B[B.BAR=1]="BAR",B[B.BAZ=2]="BAZ"})(Foo||(Foo={})),console.log(1,2,Foo.BOO),function(B){B[B.BOO=3]="BOO"}(Foo||(Foo={}));
+var Foo;(function(n){n[n.BAR=1]="BAR",n[n.BAZ=2]="BAZ"})(Foo||(Foo={}));function falsePositiveWarningInsideFunction(){console.log(1,2,Foo.ZOO)}console.log(1,2,Foo.BOO),function(n){n[n.BOO=3]="BOO",n[n.ZOO=4]="ZOO"}(Foo||(Foo={})),falsePositiveWarningInsideFunction();
 
 ================================================================================
 TestTSMinifiedBundleCommonJS

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -353,8 +353,11 @@ usage();
 
 ================================================================================
 TestTSLocalMinifiedConstEnumMerging
----------- /entry.js ----------
+---------- /valid-use.js ----------
 var Foo;(function(B){B[B.BAR=1]="BAR",B[B.BAZ=2]="BAZ"})(Foo||(Foo={})),function(B){B[B.BOO=3]="BOO"}(Foo||(Foo={})),console.log(1,2,3);
+
+---------- /premature-use.js ----------
+var Foo;(function(B){B[B.BAR=1]="BAR",B[B.BAZ=2]="BAZ"})(Foo||(Foo={})),console.log(1,2,Foo.BOO),function(B){B[B.BOO=3]="BOO"}(Foo||(Foo={}));
 
 ================================================================================
 TestTSMinifiedBundleCommonJS

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1006,6 +1006,7 @@ type SEnum struct {
 	Arg      Ref
 	Values   []EnumValue
 	IsExport bool
+	IsConst  bool
 }
 
 type SNamespace struct {

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -9491,8 +9491,11 @@ func (p *parser) maybeRewritePropertyAccess(
 		// If this is a known enum value, inline the value of the enum
 		if p.options.ts.Parse && optionalChain == js_ast.OptionalChainNone {
 			if enumValueMap, ok := p.knownEnumValues[id.Ref]; ok {
-				if number, ok := enumValueMap[name]; ok {
-					return js_ast.Expr{Loc: loc, Data: &js_ast.ENumber{Value: number}}, true
+				if enumValue, ok := enumValueMap[name]; ok {
+					return js_ast.Expr{Loc: loc, Data: enumValue}, true
+				} else {
+					r := js_lexer.RangeOfIdentifier(p.source, loc)
+					p.log.AddRangeWarning(&p.source, r, fmt.Sprintf("Unknown member %s on enum %s", name, p.symbols[id.Ref.InnerIndex].OriginalName))
 				}
 			}
 		}
@@ -11603,8 +11606,11 @@ func (p *parser) handleIdentifier(loc logger.Loc, e *js_ast.EIdentifier, opts id
 
 			// If this is a known enum value, inline the value of the enum
 			if enumValueMap, ok := p.knownEnumValues[nsRef]; ok {
-				if number, ok := enumValueMap[name]; ok {
-					return js_ast.Expr{Loc: loc, Data: &js_ast.ENumber{Value: number}}
+				if enumValue, ok := enumValueMap[name]; ok {
+					return js_ast.Expr{Loc: loc, Data: enumValue}
+				} else {
+					r := js_lexer.RangeOfIdentifier(p.source, loc)
+					p.log.AddRangeWarning(&p.source, r, fmt.Sprintf("Unknown member %s on enum %s", name, p.symbols[nsRef.InnerIndex].OriginalName))
 				}
 			}
 

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -8614,7 +8614,7 @@ func (p *parser) visitAndAppendStmt(stmts []js_ast.Stmt, stmt js_ast.Stmt) []js_
 					nextNumericValue = e.Value + 1
 				case *js_ast.EString:
 					hasStringValue = true
-					if s.IsConst {
+					if s.IsConst && !s.IsExport {
 						valuesSoFar[name] = e
 					}
 				default:

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -8676,7 +8676,7 @@ func (p *parser) visitAndAppendStmt(stmts []js_ast.Stmt, stmt js_ast.Stmt) []js_
 
 		p.shouldFoldNumericConstants = oldShouldFoldNumericConstants
 
-		if !s.IsConst {
+		if !s.IsConst || s.IsExport {
 			// Generate statements from expressions
 			valueStmts := []js_ast.Stmt{}
 			if len(valueExprs) > 0 {

--- a/internal/js_parser/ts_parser.go
+++ b/internal/js_parser/ts_parser.go
@@ -764,7 +764,7 @@ func (p *parser) parseTypeScriptDecorators() []js_ast.Expr {
 	return tsDecorators
 }
 
-func (p *parser) parseTypeScriptEnumStmt(loc logger.Loc, opts parseStmtOpts) js_ast.Stmt {
+func (p *parser) parseTypeScriptEnumStmt(loc logger.Loc, opts parseStmtOpts, isConst bool) js_ast.Stmt {
 	p.lexer.Expect(js_lexer.TEnum)
 	nameLoc := p.lexer.Loc()
 	nameText := p.lexer.Identifier
@@ -826,6 +826,7 @@ func (p *parser) parseTypeScriptEnumStmt(loc logger.Loc, opts parseStmtOpts) js_
 		Arg:      argRef,
 		Values:   values,
 		IsExport: opts.isExport,
+		IsConst:  isConst,
 	}}
 }
 


### PR DESCRIPTION
The aim of this PR is to partially address https://github.com/evanw/esbuild/issues/128

This PR changes the behavior of handling const enums:
1. For unexported const enums:
    1. Inline and erase if they are used only as known property access
    2. Inline values, but do not erase the enum if it is used in some other way than known property access (e.g. using the enum object in a function call)
2. For exported const enums and const enums inside namespaces:
    1. Preserve them, i.e. keep the existing logic

Changes in this PR:
1. Detect `const enum`s (`IsConst` field on `SEnum`)
1. Display errors when non-literals are used in a `const enum`
1. Add warnings when an unknown member of an enum is referenced (this is for both `const` and regular enums)
1. Mark local const enums as `CanBeRemovedIfUnused` and `DoesNotAffectTreeShaking`. Combined with calling not calling `recordUsage` on the enum, this lets the existing mangler (I think) erase the declaration if it is not used in any other way.

    I thought this way is probably the most elegant.

Keep in mind this is one of my first contributions to esbuild, and one of my first lines of go code, so please point out any mistakes/suggestions 😄 