### PR TITLE
Automatically create GitHub Release on pushed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Extract changelog
+        run: |
+          CHANGELOG=$(awk -v ver=$(cat version.txt) '/## / { if (p) { exit }; if ($2 == ver) { p=1; next} } p' CHANGELOG.md)
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          echo "$CHANGELOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ env.CHANGELOG }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Fixes https://github.com/evanw/esbuild/issues/535

Adapted from https://github.com/actions/create-release#example-workflow---create-a-release

This job is trigged when a git tag matching `v*` is pushed. The relevant section of `CHANGELOG.md` is automatically extracted and used as the body of the created GitHub Release (if no changelog entry is found, an empty body is used). This ensures there is always corresponding GitHub Release for every newly published version.

The heredoc is needed to set the multiline changelog environment variable `CHANGELOG` that is consumed in the subsequent step that actually creates the release. This is based on the documentation at https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#multiline-strings