### PR TITLE
Upgrade actions/setup-node to 1.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       id: go
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 12
 


### PR DESCRIPTION
This should resolve the CI failures resulting from the [deprecation of the `set-path` command](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).