### PR TITLE
types: overload `build` definitions

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,10 +82,16 @@ export interface OutputFile {
   text: string; // "contents" as text
 }
 
+export type BuildInvalidate = () => Promise<BuildIncremental>;
+
+export interface BuildIncremental extends BuildResult {
+  rebuild: BuildInvalidate & { dispose(): void };
+}
+
 export interface BuildResult {
   warnings: Message[];
   outputFiles?: OutputFile[]; // Only when "write: false"
-  rebuild?: (() => Promise<BuildResult>) & { dispose(): void }; // Only when "incremental" is true
+  rebuild?: BuildInvalidate; // Only when "incremental" is true
 }
 
 export interface BuildFailure extends Error {
@@ -225,6 +231,8 @@ export interface Metadata {
 }
 
 export interface Service {
+  build(options: BuildOptions & { write: false }): Promise<BuildResult & { outputFiles: OutputFile[] }>;
+  build(options: BuildOptions & { incremental: true }): Promise<BuildIncremental>;
   build(options: BuildOptions): Promise<BuildResult>;
   serve(serveOptions: ServeOptions, buildOptions: BuildOptions): Promise<ServeResult>;
   transform(input: string, options?: TransformOptions): Promise<TransformResult>;
@@ -240,6 +248,8 @@ export interface Service {
 //
 // Works in node: yes
 // Works in browser: no
+export declare function build(options: BuildOptions & { write: false }): Promise<BuildResult & { outputFiles: OutputFile[] }>;
+export declare function build(options: BuildOptions & { incremental: true }): Promise<BuildIncremental>;
 export declare function build(options: BuildOptions): Promise<BuildResult>;
 
 // This function is similar to "build" but it serves the resulting files over

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -272,6 +272,7 @@ export declare function transform(input: string, options?: TransformOptions): Pr
 //
 // Works in node: yes
 // Works in browser: no
+export declare function buildSync(options: BuildOptions & { write: false }): BuildResult & { outputFiles: OutputFile[] };
 export declare function buildSync(options: BuildOptions): BuildResult;
 
 // A synchronous version of "transform".

--- a/scripts/ts-type-tests.js
+++ b/scripts/ts-type-tests.js
@@ -43,6 +43,22 @@ const tests = {
     esbuild.startService().then(service => service.transform(''))
     esbuild.startService().then(service => service.transform('', {}))
   `,
+  writeFalseOutputFiles: `
+    import * as esbuild from 'esbuild'
+    esbuild.buildSync({ write: false }).outputFiles[0]
+    esbuild.build({ write: false }).then(result => result.outputFiles[0])
+    esbuild.startService().then(service => service.build({ write: false }).then(result => result.outputFiles[0]))
+  `,
+  incrementalTrueRebuild: `
+    import * as esbuild from 'esbuild'
+    esbuild.build({ incremental: true }).then(result =>
+      result.rebuild().then(result =>
+        result.rebuild()))
+    esbuild.startService().then(service =>
+      service.build({ incremental: true }).then(result =>
+        result.rebuild().then(result =>
+          result.rebuild())))
+  `,
   allOptionsTransform: `
     export {}
     import {transform} from 'esbuild'


### PR DESCRIPTION
Adds TypeScript [overload definitions](https://www.typescriptlang.org/docs/handbook/functions.html#overloads) for `build` so that `write: false` and `incremental: true` remove the conditional existence of their relevant `BuildResult` properties.

---

Closes #559 