### PR TITLE
Add support for custom host in serve api

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -37,7 +37,7 @@ Options:
   --outdir=...          The output directory (for multiple entry points)
   --outfile=...         The output file (for one entry point)
   --platform=...        Platform target (browser | node, default browser)
-  --serve=...           Start a local HTTP server on this port for outputs
+  --serve=...           Start a local HTTP server on this [host]:port for outputs
   --sourcemap           Emit a source map
   --splitting           Enable code splitting (currently only for esm)
   --target=...          Environment target (e.g. es2017, chrome58, firefox57,

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -508,6 +508,9 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		if port, ok := serve["port"]; ok {
 			serveOptions.Port = uint16(port.(int))
 		}
+		if host, ok := serve["host"]; ok {
+			serveOptions.Host = host.(string)
+		}
 		serveOptions.OnRequest = func(args api.ServeOnRequestArgs) {
 			service.sendRequest(map[string]interface{}{
 				"command": "serve-request",
@@ -527,6 +530,7 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		}
 		response := map[string]interface{}{
 			"port": int(result.Port),
+			"host": result.Host,
 		}
 
 		// Asynchronously wait for the server to stop, then fulfil the "wait" promise

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -565,6 +565,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
   let buildServeData = (options: types.ServeOptions, request: protocol.BuildRequest): ServeData => {
     let keys: OptionKeys = {};
     let port = getFlag(options, keys, 'port', mustBeInteger);
+    let host = getFlag(options, keys, 'host', mustBeString);
     let onRequest = getFlag(options, keys, 'onRequest', mustBeFunction);
     let serveID = nextServeID++;
     let onWait: ServeCallbacks['onWait'];
@@ -578,6 +579,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
     request.serve = { serveID };
     checkForInvalidFlags(options, keys);
     if (port !== void 0) request.serve.port = port;
+    if (host !== void 0) request.serve.host = host;
     serveCallbacks.set(serveID, {
       onRequest,
       onWait: onWait!,
@@ -653,6 +655,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
               let serveResponse = response as any as protocol.ServeResponse;
               let result: types.ServeResult = {
                 port: serveResponse.port,
+                host: serveResponse.host,
                 wait: serve.wait,
                 stop: serve.stop,
               };

--- a/lib/stdio_protocol.ts
+++ b/lib/stdio_protocol.ts
@@ -21,10 +21,12 @@ export interface BuildRequest {
 export interface ServeRequest {
   serveID: number;
   port?: number;
+  host?: string;
 }
 
 export interface ServeResponse {
   port: number;
+  host: string;
 }
 
 export interface ServeStopRequest {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -101,6 +101,7 @@ export interface BuildFailure extends Error {
 
 export interface ServeOptions {
   port?: number;
+  host?: string;
   onRequest?: (args: ServeOnRequestArgs) => void;
 }
 
@@ -114,6 +115,7 @@ export interface ServeOnRequestArgs {
 
 export interface ServeResult {
   port: number;
+  host: string;
   wait: Promise<void>;
   stop: () => void;
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -325,6 +325,7 @@ func Transform(input string, options TransformOptions) TransformResult {
 
 type ServeOptions struct {
 	Port      uint16
+	Host      string
 	OnRequest func(ServeOnRequestArgs)
 }
 
@@ -338,6 +339,7 @@ type ServeOnRequestArgs struct {
 
 type ServeResult struct {
 	Port uint16
+	Host string
 	Wait func() error
 	Stop func()
 }

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1151,6 +1151,9 @@ func serveImpl(serveOptions ServeOptions, buildOptions BuildOptions) (ServeResul
 	// Pick the port
 	var listener net.Listener
 	host := "127.0.0.1"
+	if serveOptions.Host != "" {
+		host = serveOptions.Host
+	}
 	if serveOptions.Port == 0 {
 		// Default to picking a "800X" port
 		for port := 8000; port <= 8009; port++ {
@@ -1174,9 +1177,10 @@ func serveImpl(serveOptions ServeOptions, buildOptions BuildOptions) (ServeResul
 
 	// Extract the real port in case we passed a port of "0"
 	var result ServeResult
-	if _, text, err := net.SplitHostPort(addr); err == nil {
+	if host, text, err := net.SplitHostPort(addr); err == nil {
 		if port, err := strconv.ParseInt(text, 10, 32); err == nil {
 			result.Port = uint16(port)
+			result.Host = host
 		}
 	}
 


### PR DESCRIPTION
This change would allow users to specify an alternate host when using the serve API. This is useful for developing with esbuild inside of a virtual machine/docker container or to request development assets from a remote testing device on the same network at a different IP address.