### PR TITLE
fix: allow and pick darwin x86_64 binary on apple silicon macs

### DIFF
--- a/lib/install.ts
+++ b/lib/install.ts
@@ -265,6 +265,7 @@ const knownWindowsPackages: Record<string, string> = {
 };
 const knownUnixlikePackages: Record<string, string> = {
   'darwin x64 LE': 'esbuild-darwin-64',
+  'darwin arm64 LE': 'esbuild-darwin-64',
   'freebsd arm64 LE': 'esbuild-freebsd-arm64',
   'freebsd x64 LE': 'esbuild-freebsd-64',
   'linux arm64 LE': 'esbuild-linux-arm64',

--- a/npm/esbuild-darwin-64/package.json
+++ b/npm/esbuild-darwin-64/package.json
@@ -8,7 +8,8 @@
     "darwin"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "directories": {
     "bin": "bin"


### PR DESCRIPTION
When you try to npm install esbuild on a m1 mac, you see this error:

<img width="973" src="https://user-images.githubusercontent.com/905328/100395012-85280f00-303f-11eb-9486-72e47150479c.png">

Allow and pick darwin x86_64 binary on apple silicon macs. It'll run just fine through rosetta 2 translation, at least throwing the 8.4MB typescript.js file against it works without complaining:

<img width="1290" src="https://user-images.githubusercontent.com/905328/100394783-afc59800-303e-11eb-85f8-173bdc393574.png">

Native darwin arm64 seems not to be supported yet by golang. It's planned for go v1.16 (from https://github.com/golang/go/issues/42756)