### PR TITLE
Multiple exports for the same concrete type result in a build error that is inconsistent with TypeScript

### DIFF
--- a/internal/bundler/bundler_importstar_ts_test.go
+++ b/internal/bundler/bundler_importstar_ts_test.go
@@ -510,10 +510,7 @@ func TestTSDuplicateExportRefs(t *testing.T) {
 			`,
 			"/re-export.ts": `
 				export * from './types1'
-				export * from './nested/re-export.ts'
-			`,
-			"/nested/re-export.ts": `
-				export * from '../types1'
+				export { Foo } from './types1'
 			`,
 			"/types1.ts": `
 				export class Foo {}

--- a/internal/bundler/bundler_importstar_ts_test.go
+++ b/internal/bundler/bundler_importstar_ts_test.go
@@ -500,3 +500,29 @@ func TestTSReExportTypeOnlyFileES6(t *testing.T) {
 		},
 	})
 }
+
+func TestTSDuplicateExportRefs(t *testing.T) {
+	importstar_ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				import * as ns from './re-export'
+				console.log(ns.Foo)
+			`,
+			"/re-export.ts": `
+				export * from './types1'
+				export * from './nested/re-export.ts'
+			`,
+			"/nested/re-export.ts": `
+				export * from '../types1'
+			`,
+			"/types1.ts": `
+				export class Foo {}
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}

--- a/internal/bundler/snapshots/snapshots_importstar_ts.txt
+++ b/internal/bundler/snapshots/snapshots_importstar_ts.txt
@@ -237,3 +237,13 @@ var foo = 123;
 
 // /entry.ts
 console.log(foo);
+
+================================================================================
+TestTSDuplicateExportRefs
+---------- /out.js ----------
+// /types1.ts
+var Foo = class {
+};
+
+// /entry.ts
+console.log(Foo);


### PR DESCRIPTION
This PR is intended to encode behaviour that I _think_ should be considered valid but which is currently considered invalid in `esbuild`.

When multiple modules re-export the same underlying type (via different paths) this appears to produce an 'ambiguous import' error: https://github.com/evanw/esbuild/blob/1f3bd9d1834c5e411b2a9ad74dfa683cbb8b81dd/internal/bundler/linker.go#L1786-L1790

I think TypeScript is taking a different approach which is to say that since the 'duplicate' exports refer to the same concrete type, they can be deduplicated instead of being treated as conflicting. In the included test, there is only one `Foo` class but it gets exported via the entrypoint through two competing paths. Perhaps the linker needs a concept of source identity beyond identifier identity.