### PR TITLE
Use env variable ESBUILD_BINARY_PATH to use different binary path

### DIFF
--- a/lib/install.ts
+++ b/lib/install.ts
@@ -237,7 +237,10 @@ function installWithWrapper(name: string, fromPath: string, toPath: string): voi
     binPath,
     `#!/usr/bin/env node
 const path = require('path');
-const esbuild_exe = path.join(__dirname, '..', ${JSON.stringify(toPath)});
+let esbuild_exe = path.join(__dirname, '..', ${JSON.stringify(toPath)});
+if (process.env.ESBUILD_BINARY_PATH) {
+  esbuild_exe [path.resolve(process.env.ESBUILD_BINARY_PATH), []];
+}
 const child_process = require('child_process');
 const { status } = child_process.spawnSync(esbuild_exe, process.argv.slice(2), { stdio: 'inherit' });
 process.exitCode = status === null ? 1 : status;

--- a/lib/install.ts
+++ b/lib/install.ts
@@ -237,7 +237,7 @@ function installWithWrapper(name: string, fromPath: string, toPath: string): voi
     binPath,
     `#!/usr/bin/env node
 const path = require('path');
-let esbuild_exe = path.join(__dirname, '..', ${JSON.stringify(toPath)});
+const esbuild_exe = path.join(__dirname, '..', ${JSON.stringify(toPath)});
 const child_process = require('child_process');
 const { status } = child_process.spawnSync(esbuild_exe, process.argv.slice(2), { stdio: 'inherit' });
 process.exitCode = status === null ? 1 : status;

--- a/lib/install.ts
+++ b/lib/install.ts
@@ -238,9 +238,6 @@ function installWithWrapper(name: string, fromPath: string, toPath: string): voi
     `#!/usr/bin/env node
 const path = require('path');
 let esbuild_exe = path.join(__dirname, '..', ${JSON.stringify(toPath)});
-if (process.env.ESBUILD_BINARY_PATH) {
-  esbuild_exe [path.resolve(process.env.ESBUILD_BINARY_PATH), []];
-}
 const child_process = require('child_process');
 const { status } = child_process.spawnSync(esbuild_exe, process.argv.slice(2), { stdio: 'inherit' });
 process.exitCode = status === null ? 1 : status;

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -15,6 +15,10 @@ declare const ESBUILD_VERSION: string;
 declare const WASM: boolean;
 
 let esbuildCommandAndArgs = (): [string, string[]] => {
+  if (process.env.ESBUILD_BINARY_PATH) {
+    return [path.resolve(process.env.ESBUILD_BINARY_PATH), []];
+  }
+
   if (WASM) {
     return ['node', [path.join(__dirname, '..', 'bin', 'esbuild')]];
   }
@@ -43,10 +47,6 @@ let esbuildCommandAndArgs = (): [string, string[]] => {
   let pathForYarn2 = path.join(__dirname, 'esbuild');
   if (fs.existsSync(pathForYarn2)) {
     return [pathForYarn2, []];
-  }
-
-  if (process.env.ESBUILD_BINARY_PATH) {
-    return [path.resolve(process.env.ESBUILD_BINARY_PATH), []];
   }
 
   return [path.join(__dirname, '..', 'bin', 'esbuild'), []];

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -45,6 +45,10 @@ let esbuildCommandAndArgs = (): [string, string[]] => {
     return [pathForYarn2, []];
   }
 
+  if (process.env.ESBUILD_BINARY_PATH) {
+    return [path.resolve(process.env.ESBUILD_BINARY_PATH), []];
+  }
+
   return [path.join(__dirname, '..', 'bin', 'esbuild'), []];
 };
 


### PR DESCRIPTION
Fix #592 

I also noticed that Yarn berry custom node binary is not used in windows, is that intentional?