### PR TITLE
Fix realpath function

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -298,7 +299,7 @@ func AfterFileClose() {
 func realpath(path string) string {
 	path, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("EvalSymlinks(%q) error: %v", path, err))
 	}
 	return path
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -296,19 +296,9 @@ func AfterFileClose() {
 }
 
 func realpath(path string) string {
-	dir := filepath.Dir(path)
-	if dir == path {
-		return path
-	}
-	dir = realpath(dir)
-	path = filepath.Join(dir, filepath.Base(path))
-	BeforeFileOpen()
-	defer AfterFileClose()
-	if link, err := os.Readlink(path); err == nil {
-		if filepath.IsAbs(link) {
-			return link
-		}
-		return filepath.Join(dir, link)
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		panic(err)
 	}
 	return path
 }


### PR DESCRIPTION
Fix #627 

I use panic when there is an error in eval symlinks, this will panic when there is a cycle of symblic links, previously it would try to resolve the links forever˙