### PR TITLE
Allows NodeJS to terminate also if there is an active service.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
     - name: JS API Tests
       run: node scripts/js-api-tests.js
 
+    - name: NodeJS Unref Tests
+      run: node scripts/node-unref-tests.js
+
     - name: Plugin Tests
       run: node scripts/plugin-tests.js
 

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -161,7 +161,7 @@ export let startService: typeof types.startService = common.referenceCountedServ
     isBrowser: false,
   });
 
-  const stdin: typeof child.stdin & { unref?(): void } = child.stdin
+  const stdin: typeof child.stdin & { unref?(): void } = child.stdin;
   const stdout: typeof child.stdout & { unref?(): void } = child.stdout;
 
   stdout.on('data', readFromStdout);
@@ -169,7 +169,6 @@ export let startService: typeof types.startService = common.referenceCountedServ
 
   let refCount = 0;
   child.unref();
-
   if (stdin.unref) {
     stdin.unref();
   }

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -204,7 +204,7 @@ export let startService: typeof types.startService = common.referenceCountedServ
           if (err) {
             reject(err);
           } else {
-            (res as types.ServeResult).wait = refPromise((res as types.ServeResult).wait)
+            refPromise((res as types.ServeResult).wait)
             resolve(res as types.ServeResult);
           }
         })
@@ -238,7 +238,7 @@ export let startService: typeof types.startService = common.referenceCountedServ
           },
         }, (err, res) => err ? reject(err) : resolve(res!))));
     },
-    stop() { child.kill(); }
+    stop() { child.kill(); },
   });
 });
 

--- a/scripts/node-unref-tests.js
+++ b/scripts/node-unref-tests.js
@@ -1,0 +1,76 @@
+// This test verifies that:
+//  - a running service will not prevent NodeJS to exit if there is no compilation in progress.
+//  - the NodeJS process will continue running if there is a serve() active or a transform or build in progress.
+
+const assert = require('assert')
+const { fork } = require('child_process');
+
+// The tests to run in the child process
+async function tests() {
+  const esbuild = require('./esbuild').installForTests()
+
+  async function testTransform() {
+    const t1 = await esbuild.transform(`1+2`)
+    const t2 = await esbuild.transform(`1+3`)
+    assert.strictEqual(t1.code, `1 + 2;\n`)
+    assert.strictEqual(t2.code, `1 + 3;\n`)
+  }
+  
+  async function testServe() {
+    const server = await esbuild.serve({}, {})
+    assert.strictEqual(server.host, '127.0.0.1')
+    assert.strictEqual(typeof server.port, 'number')
+    server.stop()
+    await server.wait
+  }
+
+  const service = await esbuild.startService();
+  try {
+    await testTransform()
+    await testServe()
+  } catch (error) {
+    service.stop();
+    throw error;
+  }
+}
+
+// Called when this is the hild process to run the tests.
+function runTests() {
+  process.exitCode = 1;
+  tests().then(() => {
+    process.exitCode = 0;
+  }, (error) => {
+    console.error('❌', error)
+  });
+}
+
+// A child process need to be started to verify that a running service is not hanging node.
+function startChildProcess() {
+  const child = fork(__filename, ['__forked__'], { stdio: 'inherit', env: process.env });
+
+  const timeout = setTimeout(()=> {
+    console.error('❌ node unref test timeout - child_process.unref() broken?')
+    process.exit(1);
+  }, 6000);
+
+  child.on('error', (error) => {
+    console.error('❌', error);
+    process.exit(1);
+  })
+
+  child.on('exit', (code) => {
+    clearTimeout(timeout);
+    if (code) {
+      console.error('❌ node unref tests failed')
+      process.exit(1);
+    } else {
+      console.log(`✅ node unref tests passed`)
+    }
+  })
+}
+
+if (process.argv[2] === '__forked__') {
+  runTests();
+} else {
+  startChildProcess();
+}


### PR DESCRIPTION
Issue https://github.com/evanw/esbuild/issues/659

Curently, NodeJS will not terminate if there is an esbuild service running.

Running this, will not allow NodeJS to exit.
```
const esbuild = require('esbuild');
esbuild.startService();
```

This pull request allows the possibility to keep the esbuild service running in background ready to receive requests without the need to manually call stop() - NodeJS will terminate automatically when there is no operation in progress (transform, build or serve).

See https://nodejs.org/api/child_process.html#child_process_subprocess_unref for more technical details.

This change should not affect the normal usage, and will allow the implementation of features like experimental module loaders without hanging the NodeJS process and without resorting to restarting the child process every transformation. Will also simplify the usage of this library by bundler and build tools.

More than happy to discuss this.
And thank you again for esbuild!
