### PR TITLE
update webpack 5 benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ require/webpack/node_modules:
 require/webpack5/node_modules:
 	mkdir -p require/webpack5
 	echo '{}' > require/webpack5/package.json
-	cd require/webpack5 && npm install webpack@5.0.0-rc.4 webpack-cli@4.0.0-rc.1 ts-loader@8.0.4 typescript@4.0.3
+	cd require/webpack5 && npm install webpack@5.14.0 webpack-cli@4.3.1 ts-loader@8.0.14 typescript@4.1.3
 
 require/rollup/node_modules:
 	mkdir -p require/rollup
@@ -564,7 +564,7 @@ bench-three-webpack5: | require/webpack5/node_modules bench/three
 	mkdir -p require/webpack5/bench/three bench/three/webpack5
 	ln -s ../../../../bench/three/src require/webpack5/bench/three/src
 	ln -s ../../../../bench/three/webpack5 require/webpack5/bench/three/out
-	cd require/webpack5/bench/three && time -p ../../node_modules/.bin/webpack ./src/entry.js $(THREE_WEBPACK5_FLAGS) -o out/entry.webpack5.js
+	cd require/webpack5/bench/three && time -p ../../node_modules/.bin/webpack --entry ./src/entry.js $(THREE_WEBPACK5_FLAGS) -o out/entry.webpack5.js
 	du -h bench/three/webpack5/entry.webpack5.js*
 
 bench-three-parcel: | require/parcel/node_modules bench/three

--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ demo-three-webpack5: | require/webpack5/node_modules demo/three
 	mkdir -p require/webpack5/demo/three demo/three/webpack5
 	ln -s ../../../../demo/three/src require/webpack5/demo/three/src
 	ln -s ../../../../demo/three/webpack5 require/webpack5/demo/three/out
-	cd require/webpack5/demo/three && time -p ../../node_modules/.bin/webpack ./src/Three.js $(THREE_WEBPACK5_FLAGS) -o out/Three.webpack5.js
+	cd require/webpack5/demo/three && time -p ../../node_modules/.bin/webpack --entry ./src/Three.js $(THREE_WEBPACK5_FLAGS) -o out/Three.webpack5.js
 	du -h demo/three/webpack5/Three.webpack5.js*
 
 THREE_PARCEL_FLAGS += --global THREE


### PR DESCRIPTION
Hi there, would be great if you can upgrade the benchmark for webpack 5 as it has been released for a while https://webpack.js.org/blog/2020-10-10-webpack-5-release/, and the performance had been improved compared to the current one in my test:

![image](https://user-images.githubusercontent.com/1091472/104729097-e2545d00-5772-11eb-82c2-d71090ea844f.png)

And here's the data for esbuild and rollup:

![image](https://user-images.githubusercontent.com/1091472/104729160-fdbf6800-5772-11eb-885f-2800b35b3c0c.png)
