### PR TITLE
Fix Metafile types to account for non-JS assets

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -246,11 +246,11 @@ export interface Metadata {
           bytesInOutput: number
         }
       }
-      imports: {
+      imports?: {
         path: string
         kind: MetadataImportKind
       }[]
-      exports: string[]
+      exports?: string[]
     }
   }
 }


### PR DESCRIPTION
In the metafile output, some non-JS output assets don’t have `imports` and/or `exports` fields in the metafile. This change fixes the TS types accordingly.

<img width="722" alt="Screen Shot 2021-01-30 at 13 07" src="https://user-images.githubusercontent.com/2953267/106353534-61619d80-62fc-11eb-93b5-aee8d6908dbf.png">
