### PR TITLE
fix #786: avoid absolute paths for disabled modules

### DIFF
--- a/internal/bundler/snapshots/snapshots_packagejson.txt
+++ b/internal/bundler/snapshots/snapshots_packagejson.txt
@@ -50,7 +50,7 @@ var index;
 ================================================================================
 TestPackageJsonBrowserMapModuleDisabled
 ---------- /Users/user/project/out.js ----------
-// (disabled):/Users/user/project/node_modules/node-pkg/index.js
+// (disabled):Users/user/project/node_modules/node-pkg/index.js
 var require_node_pkg = __commonJS(() => {
 });
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -448,9 +448,9 @@ func (r *resolver) resolveWithoutSymlinks(sourceDir string, importPath string, k
 					if remapped == nil {
 						// "browser": {"module": false}
 						if absolute, ok := r.loadNodeModules(importPath, kind, sourceDirInfo); ok {
-							absolute.Primary = logger.Path{Text: absolute.Primary.Text, Flags: logger.PathDisabled}
+							absolute.Primary = logger.Path{Text: absolute.Primary.Text, Namespace: "file", Flags: logger.PathDisabled}
 							if absolute.HasSecondary() {
-								absolute.Secondary = logger.Path{Text: absolute.Secondary.Text, Flags: logger.PathDisabled}
+								absolute.Secondary = logger.Path{Text: absolute.Secondary.Text, Namespace: "file", Flags: logger.PathDisabled}
 							}
 							return &ResolveResult{PathPair: absolute}
 						} else {

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -263,6 +263,29 @@ let buildTests = {
     assert.strictEqual(json.sourcesContent[1], content)
   },
 
+  async sourceMapWithDisabledModule({ esbuild, testDir }) {
+    const input = path.join(testDir, 'in.js')
+    const disabledModule = path.join('node_modules', 'disabled', 'index.js')
+    const disabled = path.join(testDir, disabledModule)
+    const packageJSON = path.join(testDir, 'package.json')
+    const output = path.join(testDir, 'out.js')
+    const content = 'exports.foo = require("disabled")'
+    await mkdirAsync(path.dirname(disabled), { recursive: true })
+    await writeFileAsync(input, content)
+    await writeFileAsync(disabled, 'module.exports = 123')
+    await writeFileAsync(packageJSON, `{"browser": {"disabled": false}}`)
+    await esbuild.build({ entryPoints: [input], outfile: output, sourcemap: true, bundle: true })
+    const result = require(output)
+    assert.strictEqual(result.foo, void 0)
+    const resultMap = await readFileAsync(output + '.map', 'utf8')
+    const json = JSON.parse(resultMap)
+    assert.strictEqual(json.version, 3)
+    assert.strictEqual(json.sources[0], disabledModule)
+    assert.strictEqual(json.sources[1], path.basename(input))
+    assert.strictEqual(json.sourcesContent[0], '')
+    assert.strictEqual(json.sourcesContent[1], content)
+  },
+
   async resolveExtensionOrder({ esbuild, testDir }) {
     const input = path.join(testDir, 'in.js');
     const inputBare = path.join(testDir, 'module.js')

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -265,8 +265,7 @@ let buildTests = {
 
   async sourceMapWithDisabledModule({ esbuild, testDir }) {
     const input = path.join(testDir, 'in.js')
-    const disabledModule = path.join('node_modules', 'disabled', 'index.js')
-    const disabled = path.join(testDir, disabledModule)
+    const disabled = path.join(testDir, 'node_modules', 'disabled', 'index.js')
     const packageJSON = path.join(testDir, 'package.json')
     const output = path.join(testDir, 'out.js')
     const content = 'exports.foo = require("disabled")'
@@ -280,7 +279,7 @@ let buildTests = {
     const resultMap = await readFileAsync(output + '.map', 'utf8')
     const json = JSON.parse(resultMap)
     assert.strictEqual(json.version, 3)
-    assert.strictEqual(json.sources[0], disabledModule)
+    assert.strictEqual(json.sources[0], path.relative(testDir, disabled).split(path.sep).join('/'))
     assert.strictEqual(json.sources[1], path.basename(input))
     assert.strictEqual(json.sourcesContent[0], '')
     assert.strictEqual(json.sourcesContent[1], content)


### PR DESCRIPTION
Use the “file” namespace for resolved remapped modules, to ensure the paths are relative in the sourcemap.

Fixes #786.

Follow-up of 419b8011e768d132de3577cb9414909beb6a9bbf (which fixed #785).
