### PR TITLE
fix #791: onResolve is not fired on `entrypoints` when namespace equals 'file'

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -635,7 +635,7 @@ func runOnResolvePlugins(
 		ResolveDir: absResolveDir,
 		PluginData: pluginData,
 	}
-	applyPath := logger.Path{Text: path}
+	applyPath := logger.Path{Text: path, Namespace: "file"}
 	if importSource != nil {
 		resolverArgs.Importer = importSource.KeyPath
 		applyPath.Namespace = importSource.KeyPath.Namespace


### PR DESCRIPTION
Close #791 
normally `esbuild` default `namespace` is [`file`](https://esbuild.github.io/plugins/#namespaces), but in this [commit](https://github.com/evanw/esbuild/commit/05eaca4d15d8971eb51d8a9da00a2e147ee27a97), it seems it has been forgotten to set `file` as default.