### PR TITLE
add cjsWrap info in metafile

### DIFF
--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3743,9 +3743,19 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 			if !isFirstMeta {
 				jMeta.AddString("\n      ")
 			}
+			jMeta.AddString("],\n      ")
+
+			// cjsWrap
+			if c.options.OutputFormat.KeepES6ImportExportSyntax() {
+				if chunk.isEntryPoint {
+					if fileRepr := c.files[chunk.sourceIndex].repr.(*reprJS); fileRepr.meta.cjsWrap {
+						jMeta.AddString(fmt.Sprintf("\"cjsWrap\": true,\n      "))
+					}
+				}
+			}
 
 			// Print exports
-			jMeta.AddString("],\n      \"exports\": [")
+			jMeta.AddString("\"exports\": [")
 			var aliases []string
 			if c.options.OutputFormat.KeepES6ImportExportSyntax() {
 				if chunk.isEntryPoint {

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -843,6 +843,7 @@ body {
     assert.deepStrictEqual(json.inputs[makePath(entry)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].exports, ['default'])
+    assert.deepStrictEqual(json.outputs[makePath(outfile)].cjsWrap, true)
   },
 
   async metafileESMInFormatIIFE({ esbuild, testDir }) {


### PR DESCRIPTION
close #680

Add the new `cjsWrap` information in the metafile

`cjsWrap` means that the output bundle exports have been wrapped in a default export, tools like [bundless](https://github.com/remorses/bundless) can use this information to rewrite named imports

```json
{
  "outputs": {
    "react/index.js": {
      "cjsWrap": true,
      "exports": ["default"],
      "imports": [
        ...
      ],
    
    }
}
```