### PR TITLE
entryPoint information in metafile

### DIFF
--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3782,9 +3782,8 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 				jMeta.AddString("\n      ")
 			}
 			if chunk.isEntryPoint {
-				file := c.files[chunk.sourceIndex]
-				facadeModuleID := file.source.PrettyPath
-				jMeta.AddString(fmt.Sprintf("],\n      \"facadeModuleId\": %s,\n      \"inputs\": {", js_printer.QuoteForJSON(facadeModuleID, c.options.ASCIIOnly)))
+				entryPoint := c.files[chunk.sourceIndex].source.PrettyPath
+				jMeta.AddString(fmt.Sprintf("],\n      \"entryPoint\": %s,\n      \"inputs\": {", js_printer.QuoteForJSON(entryPoint, c.options.ASCIIOnly)))
 			} else {
 				jMeta.AddString("],\n      \"inputs\": {")
 			}

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3781,7 +3781,13 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 			if !isFirstMeta {
 				jMeta.AddString("\n      ")
 			}
-			jMeta.AddString("],\n      \"inputs\": {")
+			if chunk.isEntryPoint {
+				file := c.files[chunk.sourceIndex]
+				facadeModuleID := file.source.PrettyPath
+				jMeta.AddString(fmt.Sprintf("],\n      \"facadeModuleId\": %s,\n      \"inputs\": {", js_printer.QuoteForJSON(facadeModuleID, c.options.ASCIIOnly)))
+			} else {
+				jMeta.AddString("],\n      \"inputs\": {")
+			}
 		}
 
 		// Concatenate the generated JavaScript chunks together

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -277,7 +277,7 @@ export interface Metadata {
         kind: MetadataImportKind
       }[]
       exports: string[]
-      facadeModuleId?: string
+      entryPoint?: string
     }
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -277,6 +277,7 @@ export interface Metadata {
         kind: MetadataImportKind
       }[]
       exports: string[]
+      facadeModuleId?: string
     }
   }
 }

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -947,6 +947,7 @@ body {
     assert.deepStrictEqual(json.inputs[makePath(nested3)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].exports, ['nested1', 'nested2', 'topLevel'])
+    assert.deepStrictEqual(json.outputs[makePath(outfile)].facadeModuleId, makePath(entry))
   },
 
   async metafileCSS({ esbuild, testDir }) {

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -824,6 +824,7 @@ body {
     assert.deepStrictEqual(json.inputs[makePath(entry)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].exports, [])
+    assert.deepStrictEqual(json.outputs[makePath(outfile)].entryPoint, makePath(entry))
   },
 
   async metafileCJSInFormatESM({ esbuild, testDir }) {

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -947,7 +947,7 @@ body {
     assert.deepStrictEqual(json.inputs[makePath(nested3)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].imports, [])
     assert.deepStrictEqual(json.outputs[makePath(outfile)].exports, ['nested1', 'nested2', 'topLevel'])
-    assert.deepStrictEqual(json.outputs[makePath(outfile)].facadeModuleId, makePath(entry))
+    assert.deepStrictEqual(json.outputs[makePath(outfile)].entryPoint, makePath(entry))
   },
 
   async metafileCSS({ esbuild, testDir }) {


### PR DESCRIPTION
Close #711

Adds a `entryPoint` field in the metafile

```json
{
  "outputs": {
    "react/index.js": {
      "entryPoint": "src/entry.js",
      "exports": ["default"],
      "imports": [
        ...
      ],
    
    }
}
```