### PR TITLE
Stop indirect call warning for 'require.cache' for CommonJS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
-* Omit a warning about `require.cache` when targeting CommonJS ([#812](https://github.com/evanw/esbuild/issues/812))
+* Omit warning about `require.someProperty` when targeting CommonJS ([#812](https://github.com/evanw/esbuild/issues/812))
 
-    The `require.cache` property allows introspecting the state of the `require` cache, generally without affecting what is imported/bundled. Previously esbuild generated a warning about an unexpected use of `require`. Now this warning is no longer generated for `require.cache` when the output format is `cjs`.
+    The `require.cache` property allows introspecting the state of the `require` cache, generally without affecting what is imported/bundled.
+
+    Since esbuild's static analyzer only detects direct calls to `require`, it currently warns about uses of `require` in any situation other than a direct call since that means the value is "escaping" the analyzer. This is meant to detect and warn about indirect calls such as `['fs', 'path'].map(require)`.
+
+    However, this warning is not relevant when accessing a property off of the `require` object such as `require.cache` because a property access does not result in capturing the value of `require`. Now a warning is no longer generated for `require.someProperty` when the output format is `cjs`. This allows for the use of features such as `require.cache` and `require.extensions`.
 
 ## 0.8.46
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Omit a warning about `require.cache` when targeting CommonJS ([#812](https://github.com/evanw/esbuild/issues/812))
+
+    The `require.cache` property allows introspecting the state of the `require` cache, generally without affecting what is imported/bundled. Previously esbuild generated a warning about an unexpected use of `require`. Now this warning is no longer generated for `require.cache` when the output format is `cjs`.
+
 ## 0.8.46
 
 * Fix minification of `.0` in CSS ([#804](https://github.com/evanw/esbuild/issues/804))

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -1185,6 +1185,51 @@ func TestRequireWithoutCallInsideTry(t *testing.T) {
 	})
 }
 
+func TestRequirePropertyAccessCommonJS(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				// These shouldn't warn
+				console.log(Object.keys(require.cache))
+				console.log(Object.keys(require.extensions))
+				delete require.cache['fs']
+				delete require.extensions['.json']
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			OutputFormat:  config.FormatCommonJS,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
+func TestRequirePropertyAccessES6(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				// These shouldn't warn
+				console.log(Object.keys(require.cache))
+				console.log(Object.keys(require.extensions))
+				delete require.cache['fs']
+				delete require.extensions['.json']
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			OutputFormat:  config.FormatESModule,
+			AbsOutputFile: "/out.js",
+		},
+		expectedScanLog: `entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
+entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
+entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
+entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
+`,
+	})
+}
+
 // Test a workaround for code using "await import()"
 func TestAwaitImportInsideTry(t *testing.T) {
 	default_suite.expectBundled(t, bundled{

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -3793,12 +3793,13 @@ func TestConstWithLetNoMangle(t *testing.T) {
 	})
 }
 
-func TestRequireMainCommonJS(t *testing.T) {
+func TestRequireMainCacheCommonJS(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.js": `
 				console.log('is main:', require.main === module)
 				console.log(require('./is-main'))
+				console.log('cache:', require.cache);
 			`,
 			"/is-main.js": `
 				module.exports = require.main === module
@@ -3813,11 +3814,12 @@ func TestRequireMainCommonJS(t *testing.T) {
 	})
 }
 
-func TestRequireMainIIFE(t *testing.T) {
+func TestRequireMainCacheIIFE(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.js": `
 				console.log('is main:', require.main === module)
+				console.log('cache:', require.cache);
 			`,
 		},
 		entryPaths: []string{"/entry.js"},
@@ -3827,6 +3829,7 @@ func TestRequireMainIIFE(t *testing.T) {
 			OutputFormat:  config.FormatIIFE,
 		},
 		expectedScanLog: `entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
+entry.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
 `,
 	})
 }

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1944,7 +1944,7 @@ var require_test = __commonJS((exports, module) => {
 console.log(require_test());
 
 ================================================================================
-TestRequireMainCommonJS
+TestRequireMainCacheCommonJS
 ---------- /out.js ----------
 // is-main.js
 var require_is_main = __commonJS((exports2, module2) => {
@@ -1954,14 +1954,16 @@ var require_is_main = __commonJS((exports2, module2) => {
 // entry.js
 console.log("is main:", require.main === module);
 console.log(require_is_main());
+console.log("cache:", require.cache);
 
 ================================================================================
-TestRequireMainIIFE
+TestRequireMainCacheIIFE
 ---------- /out.js ----------
 (() => {
   // entry.js
   var require_entry = __commonJS((exports, module) => {
     console.log("is main:", require.main === module);
+    console.log("cache:", require.cache);
   });
   require_entry();
 })();

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1989,6 +1989,24 @@ var src_default = 123;
 console.log(src_default);
 
 ================================================================================
+TestRequirePropertyAccessCommonJS
+---------- /out.js ----------
+// entry.js
+console.log(Object.keys(require.cache));
+console.log(Object.keys(require.extensions));
+delete require.cache["fs"];
+delete require.extensions[".json"];
+
+================================================================================
+TestRequirePropertyAccessES6
+---------- /out.js ----------
+// entry.js
+console.log(Object.keys(require.cache));
+console.log(Object.keys(require.extensions));
+delete require.cache["fs"];
+delete require.extensions[".json"];
+
+================================================================================
 TestRequireResolve
 ---------- /out.js ----------
 // entry.js


### PR DESCRIPTION
This follows/expands https://github.com/evanw/esbuild/commit/4e503ba2ada87da775d918d77e6ce035a51dce37 (#560) to suppress the warning about an indirect call to 'require' for `require.cache`, in addition to `require.main`, when building CommonJS modules. This is because manipulating/reading the cache shouldn't affect the overall bundling (AIUI).

I've validated that this suppresses the warning for the file from #812:

```shell
curl 'https://raw.githubusercontent.com/aws/aws-cdk/c6256992902fc4237ceb9f965e970e2c2ef00777/packages/%40aws-cdk/core/lib/private/runtime-info.ts' > runtime-info.ts
./esbuild --format=cjs runtime-info.ts
```

Output before:

```
 > runtime-info.ts: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
    16 │   for (const fileName of Object.keys(require.cache)) {
       ╵                                      ~~~~~~~

 > runtime-info.ts: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
    69 │   const mod = require.cache[fileName];
       ╵               ~~~~~~~

var __create = Object.create;
var __defProp = Object.defineProperty;
var __getProtoOf = Object.getPrototypeOf;
...
```

Output after:

```
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getProtoOf = Object.getPrototypeOf;
...
```

(I'm not sure if I've updated the CHANGELOG correctly.)

Fixes #812