### PR TITLE
Serve single page applications

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -77,6 +77,8 @@ var helpText = func(colors logger.Colors) string {
   --resolve-extensions=...  A comma-separated list of implicit extensions
                             (default ".tsx,.ts,.jsx,.mjs,.cjs,.js,.css,.json")
   --servedir=...            What to serve in addition to generated output files
+  --servespa                Serve a Single Page Application by falling back to
+                            index.html on unknown route
   --sourcefile=...          Set the source file for the source map (for stdin)
   --sourcemap=external      Do not link to the source map with a comment
   --sourcemap=inline        Emit the source map with an inline data URL

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -362,6 +362,7 @@ type ServeOptions struct {
 	Port      uint16
 	Host      string
 	Servedir  string
+	Servespa  bool
 	OnRequest func(ServeOnRequestArgs)
 }
 

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -537,7 +537,7 @@ func runImpl(osArgs []string) int {
 
 	for _, arg := range osArgs {
 		// Special-case running a server
-		if arg == "--serve" || strings.HasPrefix(arg, "--serve=") || strings.HasPrefix(arg, "--servedir=") {
+		if arg == "--serve" || strings.HasPrefix(arg, "--serve=") || strings.HasPrefix(arg, "--servedir=") || arg == "--servespa" {
 			if err := serveImpl(osArgs); err != nil {
 				logger.PrintErrorToStderr(osArgs, err.Error())
 				return 1
@@ -691,7 +691,7 @@ func serveImpl(osArgs []string) error {
 	host := ""
 	portText := "0"
 	servedir := ""
-	spa := false
+	servespa := false
 
 	// Filter out server-specific flags
 	filteredArgs := make([]string, 0, len(osArgs))
@@ -702,8 +702,8 @@ func serveImpl(osArgs []string) error {
 			portText = arg[len("--serve="):]
 		} else if strings.HasPrefix(arg, "--servedir=") {
 			servedir = arg[len("--servedir="):]
-		} else if strings.HasPrefix(arg, "--servespa") {
-			spa = true
+		} else if arg == "--servespa" {
+			servespa = true
 		} else {
 			filteredArgs = append(filteredArgs, arg)
 		}
@@ -742,7 +742,7 @@ func serveImpl(osArgs []string) error {
 		Port:     uint16(port),
 		Host:     host,
 		Servedir: servedir,
-		Servespa: spa,
+		Servespa: servespa,
 		OnRequest: func(args api.ServeOnRequestArgs) {
 			logger.PrintText(os.Stderr, logger.LevelInfo, filteredArgs, func(colors logger.Colors) string {
 				statusColor := colors.Red

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -691,6 +691,7 @@ func serveImpl(osArgs []string) error {
 	host := ""
 	portText := "0"
 	servedir := ""
+	spa := false
 
 	// Filter out server-specific flags
 	filteredArgs := make([]string, 0, len(osArgs))
@@ -701,6 +702,8 @@ func serveImpl(osArgs []string) error {
 			portText = arg[len("--serve="):]
 		} else if strings.HasPrefix(arg, "--servedir=") {
 			servedir = arg[len("--servedir="):]
+		} else if strings.HasPrefix(arg, "--servespa") {
+			spa = true
 		} else {
 			filteredArgs = append(filteredArgs, arg)
 		}
@@ -739,6 +742,7 @@ func serveImpl(osArgs []string) error {
 		Port:     uint16(port),
 		Host:     host,
 		Servedir: servedir,
+		Servespa: spa,
 		OnRequest: func(args api.ServeOnRequestArgs) {
 			logger.PrintText(os.Stderr, logger.LevelInfo, filteredArgs, func(colors logger.Colors) string {
 				statusColor := colors.Red


### PR DESCRIPTION
Introduces a boolean flag that changes the server to fallback to `/index.html` on unknown routes. Without this flag, some Single Page Applications will not work when navigating to a "fake" route. With this flag, the index page will always be served and the client-side router can be used to render a new page.

The change adds the `--servespa` flag to the CLI and adds members to both the `ServeOptions` and `apiHandler` structs. At the end of the `ServeHTTP` function, if all of the other fallback methods fail, the index page is manually loaded and sent to the client.

This small change will enable esbuild to function as a development server for SPA projects, which can greatly simplify the project setup.