### PR TITLE
Add ESBUILD_BIN_PATH

### DIFF
--- a/lib/install.ts
+++ b/lib/install.ts
@@ -221,7 +221,10 @@ function installDirectly(name: string) {
   if (process.env.ESBUILD_BIN_PATH_FOR_TESTS) {
     fs.unlinkSync(binPath);
     fs.symlinkSync(process.env.ESBUILD_BIN_PATH_FOR_TESTS, binPath);
-    validateBinaryVersion(process.env.ESBUILD_BIN_PATH_FOR_TESTS);
+    validateBinaryVersion(binPath);
+  } else if (process.env.ESBUILD_BIN_PATH) {
+    fs.copyFileSync(process.env.ESBUILD_BIN_PATH, binPath);
+    validateBinaryVersion(binPath);
   } else {
     installBinaryFromPackage(name, 'bin/esbuild', binPath)
       .catch(e => setImmediate(() => { throw e; }));


### PR DESCRIPTION
Installation already appears to support a couple modes:
- `ESBUILD_BIN_PATH_FOR_TESTS` which symlinks an `esbuild` binary into `node_modules`
- `installBinaryFromPackage` which either installs from a local cache or downloads the binary from `npm` (directly or via `npm`)

However, this doesn't match our needs exactly. In particular, we run `yarn install` in `--offline` mode inside a micro VM without network access. Thus, we need a way to tell the `esbuild` installer about a binary that we've already downloaded. Since we need the `node_modules` to be standalone, `ESBUILD_BIN_PATH_FOR_TESTS` doesn't work since it creates a symlink.

We handle a similar issue with `node-sass` by using `npm_config_sass_binary_cache`. However, the local caching logic in `esbuild` is a little more involved and I'm loathe to attempt replicating it our end (especially since we support both `darwin` and `linux` -- see the hack mentioned later).

So, there are two potential solutions:
- Support `ESBUILD_CACHE_PATH` which overrides the cache directly
- Support `ESBUILD_BIN_PATH` which acts just like `ESBUILD_BIN_PATH_FOR_TESTS` but copies the file instead

I decided on the latter since that resolves the problem directly (although I do need to test this change with our build system... opening the PR early to see if there's any appetite for this tweak).

For completeness, my current hack is:
```
mkdir -p ~/.cache/esbuild/bin/
cp external/esbuild/bin/esbuild ~/.cache/esbuild/bin/esbuild-linux-64@0.8.34
```
(within the `yarn install` Bazel action)