### PR TITLE
fix: ts class with decorator should use var

### DIFF
--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -2160,7 +2160,7 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 
 		// Generate the variable statement that will represent the class statement
 		stmts = append(stmts, js_ast.Stmt{Loc: classLoc, Data: &js_ast.SLocal{
-			Kind:     p.selectLocalKind(js_ast.LocalLet),
+			Kind:     p.selectLocalKind(js_ast.LocalVar),
 			IsExport: kind == classKindExportStmt,
 			Decls: []js_ast.Decl{{
 				Binding: js_ast.Binding{Loc: name.Loc, Data: &js_ast.BIdentifier{Ref: nameRef}},


### PR DESCRIPTION
A class has a Decorator:
```test.ts
@Decoratr('test')
export class Test {
  
}
```
execute:
```sh
esbuild test.ts --target=node15 --platform=node --format=cjs
```

output:
```js
// output
__markAsModule(exports);
__export(exports, {
  Test: () => Test // variable cannot be used here
});
let Test = class {
};
Test = __decorate([
  Decoratr("test")
], Test);
```

result should be like this:
```js
// output
__markAsModule(exports);
__export(exports, {
  Test: () => Test
});
var Test = class {
};
Test = __decorate([
  Decoratr("test")
], Test);
```
