### PR TITLE
Fix metafile changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
       bundle: true,
       metafile: true,
     })
-    console.log(metafile.outputs)
+    console.log(result.metafile.outputs)
     ```
 
 * The banner and footer options are now language-specific ([#712](https://github.com/evanw/esbuild/issues/712))


### PR DESCRIPTION
Judging from https://github.com/evanw/esbuild/pull/924/files#diff-9907e032076127f1c8fe94801ba7841bf9a433c6c9d4793f0b4665509a9755eaR850, the `metafile` is stored on the result (else this example just made a global variable out of nowhere). This is also incorrect in the [release description](https://github.com/evanw/esbuild/releases/v0.9.0).