### PR TITLE
Bound stdout shifting to prevent excessive allocations

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -438,7 +438,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       offset += length;
     }
     if (offset > 0) {
-      stdout.set(stdout.slice(offset, stdoutUsed));
+      stdout.copyWithin(0, offset, stdoutUsed);
       stdoutUsed -= offset;
     }
   };

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -438,7 +438,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       offset += length;
     }
     if (offset > 0) {
-      stdout.set(stdout.slice(offset));
+      stdout.set(stdout.slice(offset, stdoutUsed));
       stdoutUsed -= offset;
     }
   };


### PR DESCRIPTION
I noticed this when using an incremental rebuild. In my project, the `stdout` can grow to 100mb+ during the initial build. During rebuild, the `stdout` is mostly empty. But the old code used an unbounded `slice`, which allocated and shifted almost the full 100mb.