### PR TITLE
fix: modify Edge version for destructuring

### DIFF
--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -203,7 +203,7 @@ var jsTable = map[JSFeature]map[Engine][]int{
 	},
 	Destructuring: {
 		Chrome:  {51},
-		Edge:    {18},
+		Edge:    {14},
 		ES:      {2015},
 		Firefox: {53},
 		IOS:     {10},


### PR DESCRIPTION
[Fix](https://github.com/evanw/esbuild/issues/988)

From MDN [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),  Edge support `Destructuring assignment` from version 14.