### PR TITLE
re-enable the "worker_threads" sync workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
     - name: Register Test
       run: node scripts/register-test.js
 
+    - name: Register Test (ESBUILD_WORKER_THREADS)
+      if: matrix.os != 'windows-latest'
+      run: ESBUILD_WORKER_THREADS=1 node scripts/register-test.js
+
     - name: Verify Source Map
       run: node scripts/verify-source-map.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
     This was tripping up esbuild's TypeScript parser because the `>=` token was split into a `>` token and a `=` token because the `>` token is needed to close the type parameter list, but the `=` token was not being combined with the following `>` token to form a `=>` token. This is normally not an issue because there is normally a space in between the `>` and the `=>` tokens here. The issue only happened when the spaces were removed. This bug has been fixed. Now after the `>=` token is split, esbuild will expand the `=` token into the following characters if possible, which can result in a `=>`, `==`, or `===` token.
 
+* Enable faster synchronous transforms under a flag ([#1000](https://github.com/evanw/esbuild/issues/1000))
+
+    Currently the synchronous JavaScript API calls `transformSync` and `buildSync` spawn a new child process on every call. This is due to limitations with node's `child_process` API. Doing this means `transformSync` and `buildSync` are much slower than `transform` and `build`, which share the same child process across calls.
+
+    There was previously a workaround for this limitation that uses node's `worker_threads` API and atomics to block the main thread while asynchronous communication happens in a worker, but that was reverted due to a bug in node's `worker_threads` implementation. Now that this bug has been fixed by node, I am re-enabling this workaround. This should result in `transformSync` and `buildSync` being much faster.
+
+    This approach is experimental and is currently only enabled if the `ESBUILD_WORKER_THREADS` environment variable is present. If this use case matters to you, please try it out and let me know if you find any problems with it.
+
 ## 0.9.5
 
 * Fix parsing of the `[dir]` placeholder ([#1013](https://github.com/evanw/esbuild/issues/1013))

--- a/scripts/register-test.js
+++ b/scripts/register-test.js
@@ -12,7 +12,13 @@ fs.mkdirSync(rootTestDir)
 
 const entry = path.join(rootTestDir, 'entry.ts')
 fs.writeFileSync(entry, `
-  console.log('worked' as string)
+  console.log('in entry.ts' as string)
+  require('./other.ts')
+`)
+
+const other = path.join(rootTestDir, 'other.ts')
+fs.writeFileSync(other, `
+  console.log('in other.ts' as string)
 `)
 
 const register = path.join(rootTestDir, 'register.js')
@@ -42,7 +48,7 @@ async function main() {
   })
   await Promise.race([promise, wait])
   clearTimeout(timeout)
-  assert.strictEqual(result, `worked\n`)
+  assert.strictEqual(result, `in entry.ts\nin other.ts\n`)
 }
 
 main().then(


### PR DESCRIPTION
Fixes #1000. This is an experiment, and is only active when the `ESBUILD_WORKER_THREADS` environment variable is present.