### PR TITLE
feat: Add support for removing all comments

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -87,6 +87,7 @@ var helpText = func(colors logger.Colors) string {
   --sourcemap=external      Do not link to the source map with a comment
   --sourcemap=inline        Emit the source map with an inline data URL
   --sources-content=false   Omit "sourcesContent" in generated source maps
+  --remove-all-comments     Remove all comments in output files
   --tree-shaking=...        Set to "ignore-annotations" to work with packages
                             that have incorrect tree-shaking annotations
   --tsconfig=...            Use this tsconfig.json file instead of other ones

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -3435,6 +3435,7 @@ func (c *linkerContext) generateCodeForFileInChunkJS(
 		Indent:                       indent,
 		OutputFormat:                 c.options.OutputFormat,
 		RemoveWhitespace:             c.options.RemoveWhitespace,
+		RemoveAllComments:            c.options.RemoveAllComments,
 		MangleSyntax:                 c.options.MangleSyntax,
 		ASCIIOnly:                    c.options.ASCIIOnly,
 		ToModuleRef:                  toModuleRef,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,6 +181,7 @@ type Options struct {
 	ModuleType        ModuleType
 	PreserveSymlinks  bool
 	RemoveWhitespace  bool
+	RemoveAllComments bool
 	MinifyIdentifiers bool
 	MangleSyntax      bool
 	CodeSplitting     bool

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -106,6 +106,7 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   let minifySyntax = getFlag(options, keys, 'minifySyntax', mustBeBoolean);
   let minifyWhitespace = getFlag(options, keys, 'minifyWhitespace', mustBeBoolean);
   let minifyIdentifiers = getFlag(options, keys, 'minifyIdentifiers', mustBeBoolean);
+  let removeAllComments = getFlag(options, keys, 'removeAllComments', mustBeBoolean);
   let charset = getFlag(options, keys, 'charset', mustBeString);
   let treeShaking = getFlag(options, keys, 'treeShaking', mustBeStringOrBoolean);
   let jsxFactory = getFlag(options, keys, 'jsxFactory', mustBeString);
@@ -127,6 +128,7 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   if (minifySyntax) flags.push('--minify-syntax');
   if (minifyWhitespace) flags.push('--minify-whitespace');
   if (minifyIdentifiers) flags.push('--minify-identifiers');
+  if (removeAllComments) flags.push('--removeAllComments');
   if (charset) flags.push(`--charset=${charset}`);
   if (treeShaking !== void 0 && treeShaking !== true) flags.push(`--tree-shaking=${treeShaking}`);
 

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -18,6 +18,7 @@ interface CommonOptions {
   minifyWhitespace?: boolean;
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
+  removeAllComments?: boolean;
   charset?: Charset;
   treeShaking?: TreeShaking;
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -234,6 +234,7 @@ type BuildOptions struct {
 	MinifyWhitespace  bool
 	MinifyIdentifiers bool
 	MinifySyntax      bool
+	RemoveAllComments bool
 	Charset           Charset
 	TreeShaking       TreeShaking
 
@@ -339,6 +340,7 @@ type TransformOptions struct {
 	MinifyWhitespace  bool
 	MinifyIdentifiers bool
 	MinifySyntax      bool
+	RemoveAllComments bool
 	Charset           Charset
 	TreeShaking       TreeShaking
 

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1241,6 +1241,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 		GlobalName:              validateGlobalName(log, transformOpts.GlobalName),
 		MangleSyntax:            transformOpts.MinifySyntax,
 		RemoveWhitespace:        transformOpts.MinifyWhitespace,
+		RemoveAllComments:       transformOpts.RemoveAllComments,
 		MinifyIdentifiers:       transformOpts.MinifyIdentifiers,
 		ASCIIOnly:               validateASCIIOnly(transformOpts.Charset),
 		IgnoreDCEAnnotations:    validateIgnoreDCEAnnotations(transformOpts.TreeShaking),

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -92,6 +92,13 @@ func parseOptionsImpl(
 				transformOpts.MinifyIdentifiers = true
 			}
 
+		case arg == "--remove-all-comments":
+			if buildOpts != nil {
+				buildOpts.RemoveAllComments = true
+			} else {
+				transformOpts.RemoveAllComments = true
+			}
+
 		case strings.HasPrefix(arg, "--charset="):
 			var value *api.Charset
 			if buildOpts != nil {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -1870,6 +1870,18 @@
     }),
   )
 
+  // Test removeAllComments
+  tests.push(
+    test(['in.js', '--outfile=node.js', '--remove-all-comments'], {
+      'in.js': `
+        //! @license comment
+        /** @license */
+        const a = '/* @license */';
+        if (a.indexOf('license') == -1) throw 'fail';
+      `,
+    })
+  )
+
   // Test name preservation
   for (let flags of [[], ['--minify', '--keep-names']]) {
     tests.push(


### PR DESCRIPTION
## Motivation

This PR attempts to fix #919 by providing an option to remove all comments from the transform output, including the ones we normally preserve (pure, license, `//!`).

This change allows esbuild to match the behavior of `TerserWebpackPlugin` that supports [`extractComments: false`](https://webpack.js.org/plugins/terser-webpack-plugin/#remove-comments).

## Example

```
$ echo "/** @license */ const a = 3" | ./esbuild --remove-all-comments
const a = 3
```