### PR TITLE
Use WebAssembly.instantiateStreaming when available

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -56,7 +56,12 @@ export const initialize: typeof types.initialize = options => {
 
 const startRunningService = async (wasmURL: string, useWorker: boolean, verifyWasmURL: boolean ): Promise<void> => {
   let wasm: ArrayBuffer | void;
-  if ('instantiateStreaming' in WebAssembly) {
+  // Per https://webassembly.org/docs/web/#webassemblyinstantiatestreaming, 
+  // Automatically use 'instantiateStreaming' when available and:
+  // - The Response is CORS-same-origin
+  // - The Response represents an ok status
+  // - The Response Matches the `application/wasm` MIME type
+  if ('instantiateStreaming' in WebAssembly && new URL(wasmURL, location.href).origin === location.origin) {
     if (verifyWasmURL) {
 
       const resp = await fetch(wasmURL, {

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -73,10 +73,12 @@ export function validateInitializeOptions(options: types.InitializeOptions): typ
   let keys: OptionKeys = Object.create(null);
   let wasmURL = getFlag(options, keys, 'wasmURL', mustBeString);
   let worker = getFlag(options, keys, 'worker', mustBeBoolean);
+  let verifyWasmURL = getFlag(options, keys, 'verifyWasmURL', mustBeBoolean);
   checkForInvalidFlags(options, keys, 'in startService() call');
   return {
     wasmURL,
     worker,
+    verifyWasmURL,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -347,6 +347,12 @@ export interface InitializeOptions {
   // to avoid blocking the UI thread. This can be disabled by setting "worker"
   // to false.
   worker?: boolean
+
+  // For supported browsers, esbuild uses WebAssembly.instantiateStreaming
+  // to speed up WASM load time. Setting this option to false skips the extra
+  // HEAD request that validates the "Content-Type" header. This option has no
+  // effect on Node or browers without WebAssembly.instantiateStreaming.
+  verifyWasmURL?: boolean
 }
 
 export let version: string;

--- a/lib/worker.ts
+++ b/lib/worker.ts
@@ -60,6 +60,12 @@ onmessage = ({ data: wasm }) => {
   let go = new (global as any).Go()
   go.argv = ['', `--service=${ESBUILD_VERSION}`]
 
-  WebAssembly.instantiate(wasm, go.importObject)
-    .then(({ instance }) => go.run(instance))
+  if ('instantiateStreaming' in WebAssembly && (global as any).ESBUILD_WASM_URL) {
+    WebAssembly.instantiateStreaming(fetch((global as any).ESBUILD_WASM_URL), go.importObject)
+      .then(({ instance }) => go.run(instance))
+  } else {
+    WebAssembly.instantiate(wasm, go.importObject)
+      .then(({ instance }) => go.run(instance))
+  }
+
 }

--- a/scripts/browser/browser-tests.js
+++ b/scripts/browser/browser-tests.js
@@ -264,6 +264,10 @@ const server = http.createServer((req, res) => {
         return
       }
     }
+  } else if (req.method === "HEAD" && req.url === "/esbuild.wasm") {
+    res.writeHead(200, { 'Content-Type': 'application/wasm' })
+    res.end()
+    return
   }
 
   console.log(`[http] ${req.method} ${req.url}`)


### PR DESCRIPTION
This makes `esbuild.initialize` automatically use `WebAssembly.instantiateStreaming` in supported browsers by default. 

For browsers that support `WebAssembly.instantiateStreaming` and if the `wasmURL` is same-origin, it adds an additional (default `true`) option, `verifyWasmURL` which sends a `HEAD` request to the `wasmUrl` to check that the `Content-Type` header is `application/wasm` and that the response is ok. If not, it fallsback to `WebAssembly.instantiate` and logs to `console.info`. **This makes it a backwards-compatible change**, incase a developer's webserver is not configured to correctly send the `application/wasm` header [such as nginx](https://github.com/nginx/nginx/blob/master/conf/mime.types) or if the `wasmUrl` is under a different origin (like a CDN).

To do this, it inlines `wasmUrl` into `global.ESBUILD_WASM_URL`. If `global.ESBUILD_WASM_URL` is truthy and `WebAssembly.instantiateStreaming` is defined, it uses that instead.

~I have not manually tested this, but the browser test failed until I made it check for `HEAD` requests to `/esbuild.wasm`, which is a good sign. I had some build environment issues I think due to having a later version of Go installed~

I added tests that cover:
- No `WebAssembly.instantiateStreaming` support
- `WebAssembly.instantiateStreaming` support, `verifyWasmURL` false
- `WebAssembly.instantiateStreaming` support, `verifyWasmURL` true
- `WebAssembly.instantiateStreaming` support, `verifyWasmURL` true, return wrong content type. It should fallback to `WebAssembly.instantiate`