### PR TITLE
PR for version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@
 
     With this release, esbuild will now convert modules containing a run-time `export * as` statement to a special ESM-plus-dynamic-fallback mode. In this mode, named exports present at bundle time can still be imported directly by name, but any imports that don't match one of the explicit named imports present at bundle time will be converted to a property access on the fallback object instead of being a bundle error. These property accesses are then resolved at run-time and will be undefined if the export is missing.
 
+* Initial support for bundling with top-level await ([#253](https://github.com/evanw/esbuild/issues/253))
+
+    Top-level await is a feature that lets you use an `await` expression at the top level (outside of an `async` function). Here is an example:
+
+    ```js
+    let promise = fetch('https://www.example.com/data')
+    export let data = await promise.then(x => x.json())
+    ```
+
+    Top-level await only works in ECMAScript modules, and does not work in CommonJS modules. This means that you must use an `import` statement or an `import()` expression to import a module containing top-level await. You cannot use `require()` because it's synchronous while top-level await is asynchronous. There should be a descriptive error message when you try to do this.
+
+    This initial release only has limited support for top-level await. It is only supported with the `esm` output format, but not with the `iife` or `cjs` output formats. In addition, the compilation is not correct in that two modules that both contain top-level await and that are siblings in the import graph will be evaluated in serial instead of in parallel. Full support for top-level await will come in a future release.
+
 ## Unreleased
 
 * Add the ability to set `sourceRoot` in source maps ([#1028](https://github.com/evanw/esbuild/pull/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@
 
     This initial release only has limited support for top-level await. It is only supported with the `esm` output format, but not with the `iife` or `cjs` output formats. In addition, the compilation is not correct in that two modules that both contain top-level await and that are siblings in the import graph will be evaluated in serial instead of in parallel. Full support for top-level await will come in a future release.
 
+* Change whether certain files are interpreted as ESM or CommonJS ([#1043](https://github.com/evanw/esbuild/issues/1043))
+
+    The bundling algorithm currently doesn't contain any logic that requires flagging modules as CommonJS vs. ESM beforehand. Instead it handles a superset and then sort of decides later if the module should be treated as CommonJS vs. ESM based on whether the module uses the `module` or `exports` variables and/or the `exports` keyword.
+
+    With this release, files that follow [node's rules for module types](https://nodejs.org/api/packages.html#packages_type) will be flagged as explicitly ESM. This includes files that end in `.mjs` and files within a package containing `"type": "module"` in the enclosing `package.json` file. The CommonJS `require`, `module`, and `exports` features will be unavailable in these files. This matters most for files without any exports, since then it's otherwise ambiguous what the module type is.
+
+    In addition, files without exports should now accurately fall back to being considered CommonJS. They should now generate a `default` export of an empty object when imported using an `import` statement, since that's what happens in node when you import a CommonJS file into an ESM file in node. Previously the default export could be undefined because these export-less files were sort of treated as ESM but with missing import errors turned into warnings instead.
+
+    This is an edge case that rarely comes up in practice, since you usually never import things from a module that has no exports.
+
 ## Unreleased
 
 * Add the ability to set `sourceRoot` in source maps ([#1028](https://github.com/evanw/esbuild/pull/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
     Note that this doesn't remove support for using `require` in ESM files. Doing this still works (and can be made to work in a real ESM environment by assigning to `globalThis.require`). This also doesn't remove support for using `import` in CommonJS files. Doing this also still works.
 
+* No longer change `import()` to `require()` ([#1029](https://github.com/evanw/esbuild/issues/1029))
+
+    Previously esbuild's transform for `import()` matched TypeScript's behavior, which is to transform it into `Promise.resolve().then(() => require())` when the current output format is something other than ESM. This was done when an import is external (i.e. not bundled), either due to the expression not being a string or due to the string matching an external import path.
+
+    With this release, esbuild will no longer do this. Now `import()` expressions will be preserved in the output instead. These expressions can be handled in non-ESM code by arranging for the `import` identifier to be a function that imports ESM code. This is how node works, so it will now be possible to use `import()` with node when the output format is something other than ESM.
+
 ## Unreleased
 
 * Add the ability to set `sourceRoot` in source maps ([#1028](https://github.com/evanw/esbuild/pull/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Breaking changes
+
+* No longer support `module` or `exports` in an ESM file ([#769](https://github.com/evanw/esbuild/issues/769))
+
+    This removes support for using CommonJS exports in a file with ESM exports. Previously this worked by converting the ESM file to CommonJS and then mixing the CommonJS and ESM exports into the same `exports` object. But it turns out that supporting this is additional complexity for the bundler, so it has been removed. It's also not something that works in real JavaScript environments since modules will never support both export syntaxes at once.
+
+    Note that this doesn't remove support for using `require` in ESM files. Doing this still works (and can be made to work in a real ESM environment by assigning to `globalThis.require`). This also doesn't remove support for using `import` in CommonJS files. Doing this also still works.
+
 ## Unreleased
 
 * Add the ability to set `sourceRoot` in source maps ([#1028](https://github.com/evanw/esbuild/pull/1028))

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -77,6 +77,10 @@ type ImportRecord struct {
 	// CommonJS wrapper or not.
 	ContainsImportStar bool
 
+	// If this is true, the import contains an import for the alias "default",
+	// either via the "import x from" or "import {default as x} from" syntax.
+	ContainsDefaultAlias bool
+
 	// If true, this "export * from 'path'" statement is evaluated at run-time by
 	// calling the "__exportStar()" helper function
 	CallsRunTimeExportStarFn bool

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1023,6 +1023,15 @@ func (s *scanner) maybeParseFile(
 		optionsClone.PreserveUnusedImportsTS = true
 	}
 
+	// Set the module type preference using node's module type rules
+	if strings.HasSuffix(path.Text, ".mjs") {
+		optionsClone.ModuleType = config.ModuleESM
+	} else if strings.HasSuffix(path.Text, ".cjs") {
+		optionsClone.ModuleType = config.ModuleCommonJS
+	} else {
+		optionsClone.ModuleType = resolveResult.ModuleType
+	}
+
 	// Enable bundling for injected files so we always do tree shaking. We
 	// never want to include unnecessary code from injected files since they
 	// are essentially bundled. However, if we do this we should skip the

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -850,24 +850,6 @@ func TestDynamicImportWithExpressionCJS(t *testing.T) {
 	})
 }
 
-func TestDynamicImportWithExpressionCJSAndES5(t *testing.T) {
-	default_suite.expectBundled(t, bundled{
-		files: map[string]string{
-			"/a.js": `
-				import('foo')
-				import(foo())
-			`,
-		},
-		entryPaths: []string{"/a.js"},
-		options: config.Options{
-			Mode:                  config.ModeConvertFormat,
-			OutputFormat:          config.FormatCommonJS,
-			UnsupportedJSFeatures: es(5),
-			AbsOutputFile:         "/out.js",
-		},
-	})
-}
-
 func TestMinifiedDynamicImportWithExpressionCJS(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
@@ -882,25 +864,6 @@ func TestMinifiedDynamicImportWithExpressionCJS(t *testing.T) {
 			OutputFormat:     config.FormatCommonJS,
 			AbsOutputFile:    "/out.js",
 			RemoveWhitespace: true,
-		},
-	})
-}
-
-func TestMinifiedDynamicImportWithExpressionCJSAndES5(t *testing.T) {
-	default_suite.expectBundled(t, bundled{
-		files: map[string]string{
-			"/a.js": `
-				import('foo')
-				import(foo())
-			`,
-		},
-		entryPaths: []string{"/a.js"},
-		options: config.Options{
-			Mode:                  config.ModeConvertFormat,
-			OutputFormat:          config.FormatCommonJS,
-			UnsupportedJSFeatures: es(5),
-			AbsOutputFile:         "/out.js",
-			RemoveWhitespace:      true,
 		},
 	})
 }

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -693,10 +693,8 @@ func TestImportMissingNeitherES6NorCommonJS(t *testing.T) {
 			Mode:         config.ModeBundle,
 			AbsOutputDir: "/out",
 		},
-		expectedCompileLog: `named.js: warning: Import "default" will always be undefined because the file "foo.js" has no exports
-named.js: warning: Import "x" will always be undefined because the file "foo.js" has no exports
+		expectedCompileLog: `named.js: warning: Import "x" will always be undefined because the file "foo.js" has no exports
 named.js: warning: Import "y" will always be undefined because the file "foo.js" has no exports
-star.js: warning: Import "default" will always be undefined because the file "foo.js" has no exports
 star.js: warning: Import "x" will always be undefined because the file "foo.js" has no exports
 star.js: warning: Import "y" will always be undefined because the file "foo.js" has no exports
 `,

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -363,30 +363,6 @@ func TestExportFormsCommonJS(t *testing.T) {
 	})
 }
 
-func TestReExportDefaultCommonJS(t *testing.T) {
-	default_suite.expectBundled(t, bundled{
-		files: map[string]string{
-			"/entry.js": `
-				import {foo as entry} from './foo'
-				entry()
-			`,
-			"/foo.js": `
-				export {default as foo} from './bar'
-			`,
-			"/bar.js": `
-				export default function foo() {
-					return exports // Force this to be a CommonJS module
-				}
-			`,
-		},
-		entryPaths: []string{"/entry.js"},
-		options: config.Options{
-			Mode:          config.ModeBundle,
-			AbsOutputFile: "/out.js",
-		},
-	})
-}
-
 func TestExportChain(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
@@ -1632,10 +1608,10 @@ func TestExportFSNodeInCommonJSModule(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.js": `
-				export * as fs from 'fs'
-				export {readFileSync} from 'fs'
-
-				// Force this to be a CommonJS module
+				import * as fs from 'fs'
+				import {readFileSync} from 'fs'
+				exports.fs = fs
+				exports.readFileSync = readFileSync
 				exports.foo = 123
 			`,
 		},

--- a/internal/bundler/bundler_splitting_test.go
+++ b/internal/bundler/bundler_splitting_test.go
@@ -272,7 +272,7 @@ func TestSplittingMissingLazyExport(t *testing.T) {
 			OutputFormat:  config.FormatESModule,
 			AbsOutputDir:  "/out",
 		},
-		expectedCompileLog: `common.js: warning: Import "missing" will always be undefined because there is no matching export
+		expectedCompileLog: `common.js: warning: Import "missing" will always be undefined because the file "empty.js" has no exports
 `,
 	})
 }

--- a/internal/bundler/bundler_splitting_test.go
+++ b/internal/bundler/bundler_splitting_test.go
@@ -504,24 +504,3 @@ func TestSplittingHybridESMAndCJSIssue617(t *testing.T) {
 		},
 	})
 }
-
-func TestSplittingHybridCJSAndESMIssue617(t *testing.T) {
-	splitting_suite.expectBundled(t, bundled{
-		files: map[string]string{
-			"/a.js": `
-				export let foo
-				exports.bar = 123
-			`,
-			"/b.js": `
-				export {foo} from './a'
-			`,
-		},
-		entryPaths: []string{"/a.js", "/b.js"},
-		options: config.Options{
-			Mode:          config.ModeBundle,
-			CodeSplitting: true,
-			OutputFormat:  config.FormatESModule,
-			AbsOutputDir:  "/out",
-		},
-	})
-}

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -1375,10 +1375,9 @@ func (c *linkerContext) scanImportsAndExports() {
 
 		// If the output format doesn't have an implicit CommonJS wrapper, any file
 		// that uses CommonJS features will need to be wrapped, even though the
-		// resulting wrapper won't be invoked by other files.
-		if repr.meta.cjsStyleExports &&
-			(c.options.OutputFormat == config.FormatIIFE ||
-				c.options.OutputFormat == config.FormatESModule) {
+		// resulting wrapper won't be invoked by other files. An exception is made
+		// for entry point files in CommonJS format (or when in pass-through mode).
+		if repr.meta.cjsStyleExports && (!file.isEntryPoint || c.options.OutputFormat == config.FormatIIFE || c.options.OutputFormat == config.FormatESModule) {
 			repr.meta.cjsWrap = true
 		}
 

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -2647,6 +2647,41 @@ var import_es6_ns_export_class = __toModule(require_es6_ns_export_class());
 var import_es6_ns_export_abstract_class = __toModule(require_es6_ns_export_abstract_class());
 
 ================================================================================
+TestTopLevelAwaitAllowedImportWithSplitting
+---------- /out/entry.js ----------
+// entry.js
+import("./a.js");
+import("./b.js");
+import("./c.js");
+import("./entry.js");
+await 0;
+
+---------- /out/a.js ----------
+import "./chunk-7VOEXAIV.js";
+import "./chunk-FLIOJ2XZ.js";
+
+---------- /out/b.js ----------
+import "./chunk-7VOEXAIV.js";
+import "./chunk-FLIOJ2XZ.js";
+
+---------- /out/chunk-7VOEXAIV.js ----------
+
+---------- /out/c.js ----------
+import "./chunk-FLIOJ2XZ.js";
+
+---------- /out/chunk-FLIOJ2XZ.js ----------
+// c.js
+await 0;
+
+================================================================================
+TestTopLevelAwaitESM
+---------- /out.js ----------
+// entry.js
+await foo;
+for await (foo of bar)
+  ;
+
+================================================================================
 TestTopLevelAwaitNoBundle
 ---------- /out.js ----------
 await foo;

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -977,17 +977,23 @@ console.log((0, import_foo.default)(import_foo.x, import_foo.y));
 TestImportMissingNeitherES6NorCommonJS
 ---------- /out/named.js ----------
 // foo.js
-console.log("no exports here");
+var require_foo = __commonJS(() => {
+  console.log("no exports here");
+});
 
 // named.js
-console.log((void 0)(void 0, void 0));
+var import_foo = __toModule(require_foo());
+console.log((0, import_foo.default)(void 0, void 0));
 
 ---------- /out/star.js ----------
 // foo.js
-console.log("no exports here");
+var require_foo = __commonJS(() => {
+  console.log("no exports here");
+});
 
 // star.js
-console.log((void 0)(void 0, void 0));
+var ns = __toModule(require_foo());
+console.log(ns.default(void 0, void 0));
 
 ---------- /out/star-capture.js ----------
 // foo.js

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -402,18 +402,8 @@ console.log(import__.x);
 ================================================================================
 TestDynamicImportWithExpressionCJS
 ---------- /out.js ----------
-Promise.resolve().then(() => __toModule(require("foo")));
-Promise.resolve().then(() => __toModule(require(foo())));
-
-================================================================================
-TestDynamicImportWithExpressionCJSAndES5
----------- /out.js ----------
-Promise.resolve().then(function() {
-  return __toModule(require("foo"));
-});
-Promise.resolve().then(function() {
-  return __toModule(require(foo()));
-});
+import("foo");
+import(foo());
 
 ================================================================================
 TestDynamicImportWithTemplateIIFE
@@ -1628,12 +1618,7 @@ TestMinifiedBundleEndingWithImportantSemicolon
 ================================================================================
 TestMinifiedDynamicImportWithExpressionCJS
 ---------- /out.js ----------
-Promise.resolve().then(()=>__toModule(require("foo")));Promise.resolve().then(()=>__toModule(require(foo())));
-
-================================================================================
-TestMinifiedDynamicImportWithExpressionCJSAndES5
----------- /out.js ----------
-Promise.resolve().then(function(){return __toModule(require("foo"))});Promise.resolve().then(function(){return __toModule(require(foo()))});
+import("foo");import(foo());
 
 ================================================================================
 TestMinifiedExportsAndModuleFormatCommonJS

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -455,8 +455,8 @@ console.log((0, import_foo.foo)(), (0, import_bar.bar)());
 TestEmptyExportClauseBundleAsCommonJSIssue910
 ---------- /out.js ----------
 // types.mjs
-var require_types = __commonJS((exports2) => {
-  __markAsModule(exports2);
+var require_types = __commonJS((exports) => {
+  __markAsModule(exports);
 });
 
 // entry.js
@@ -489,11 +489,8 @@ TestExportFSNodeInCommonJSModule
 import * as fs from "fs";
 import {readFileSync} from "fs";
 var require_entry = __commonJS((exports) => {
-  __markAsModule(exports);
-  __export(exports, {
-    fs: () => fs,
-    readFileSync: () => readFileSync
-  });
+  exports.fs = fs;
+  exports.readFileSync = readFileSync;
   exports.foo = 123;
 });
 export default require_entry();
@@ -1916,26 +1913,6 @@ var export_bar = import_foo.bar;
 export {
   export_bar as bar
 };
-
-================================================================================
-TestReExportDefaultCommonJS
----------- /out.js ----------
-// bar.js
-var require_bar = __commonJS((exports) => {
-  __markAsModule(exports);
-  __export(exports, {
-    default: () => foo
-  });
-  function foo() {
-    return exports;
-  }
-});
-
-// foo.js
-var import_bar = __toModule(require_bar());
-
-// entry.js
-(0, import_bar.default)();
 
 ================================================================================
 TestReExportDefaultExternalCommonJS

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -2465,13 +2465,6 @@ var require_es6_expr_import_dynamic = __commonJS((exports) => {
   console.log(exports);
 });
 
-// es6-export-star.js
-var require_es6_export_star = __commonJS((exports) => {
-  __markAsModule(exports);
-  __exportStar(exports, require_dummy());
-  console.log(void 0);
-});
-
 // es6-export-assign.ts
 var require_es6_export_assign = __commonJS((exports, module) => {
   console.log(exports);
@@ -2626,8 +2619,10 @@ console.log(void 0);
 var import_dummy2 = require_dummy();
 console.log(void 0);
 
-// entry.js
-var import_es6_export_star = require_es6_export_star();
+// es6-export-star.js
+var es6_export_star_exports = {};
+__exportStar(es6_export_star_exports, require_dummy());
+console.log(void 0);
 
 // es6-export-star-as.js
 var ns = require_dummy();

--- a/internal/bundler/snapshots/snapshots_importstar.txt
+++ b/internal/bundler/snapshots/snapshots_importstar.txt
@@ -841,22 +841,18 @@ TestReExportStarExternalIIFE
 ---------- /out.js ----------
 var mod = (() => {
   // entry.js
-  var require_entry = __commonJS((exports) => {
-    __markAsModule(exports);
-    __exportStar(exports, __toModule(require("foo")));
-  });
-  return require_entry();
+  var entry_exports = {};
+  __exportStar(entry_exports, __toModule(require("foo")));
+  return entry_exports;
 })();
 
 ================================================================================
 TestReExportStarIIFENoBundle
 ---------- /out.js ----------
 var mod = (() => {
-  var require_entry = __commonJS((exports) => {
-    __markAsModule(exports);
-    __exportStar(exports, __toModule(require("foo")));
-  });
-  return require_entry();
+  var entry_exports = {};
+  __exportStar(entry_exports, __toModule(require("foo")));
+  return entry_exports;
 })();
 
 ================================================================================

--- a/internal/bundler/snapshots/snapshots_importstar.txt
+++ b/internal/bundler/snapshots/snapshots_importstar.txt
@@ -1,8 +1,8 @@
 TestExportOtherAsNamespaceCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports2) => {
-  exports2.foo = 123;
+var require_foo = __commonJS((exports) => {
+  exports.foo = 123;
 });
 
 // entry.js
@@ -16,8 +16,8 @@ var ns = __toModule(require_foo());
 TestExportOtherCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports2) => {
-  exports2.foo = 123;
+var require_foo = __commonJS((exports) => {
+  exports.foo = 123;
 });
 
 // entry.js
@@ -31,8 +31,8 @@ var import_foo = __toModule(require_foo());
 TestExportOtherNestedCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports2) => {
-  exports2.foo = 123;
+var require_foo = __commonJS((exports) => {
+  exports.foo = 123;
 });
 
 // entry.js
@@ -251,8 +251,8 @@ console.log(internal_default, void 0);
 TestImportExportOtherAsNamespaceCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports2) => {
-  exports2.foo = 123;
+var require_foo = __commonJS((exports) => {
+  exports.foo = 123;
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_splitting.txt
+++ b/internal/bundler/snapshots/snapshots_splitting.txt
@@ -306,45 +306,6 @@ import("../node_modules/package/index.js");
 console.log("imported");
 
 ================================================================================
-TestSplittingHybridCJSAndESMIssue617
----------- /out/a.js ----------
-import {
-  require_a
-} from "./chunk-IXXZP4MD.js";
-export default require_a();
-
----------- /out/b.js ----------
-import {
-  __defProp,
-  __markAsModule,
-  require_a
-} from "./chunk-IXXZP4MD.js";
-
-// b.js
-var import_a = __toModule(require_a());
-var export_foo = import_a.foo;
-export {
-  export_foo as foo
-};
-
----------- /out/chunk-IXXZP4MD.js ----------
-// a.js
-var require_a = __commonJS((exports) => {
-  __markAsModule(exports);
-  __export(exports, {
-    foo: () => foo
-  });
-  var foo;
-  exports.bar = 123;
-});
-
-export {
-  __defProp,
-  require_a,
-  __markAsModule
-};
-
-================================================================================
 TestSplittingHybridESMAndCJSIssue617
 ---------- /out/a.js ----------
 import {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,8 +160,17 @@ const (
 	ModeBundle
 )
 
+type ModuleType uint8
+
+const (
+	ModuleUnknown ModuleType = iota
+	ModuleCommonJS
+	ModuleESM
+)
+
 type Options struct {
 	Mode              Mode
+	ModuleType        ModuleType
 	PreserveSymlinks  bool
 	RemoveWhitespace  bool
 	MinifyIdentifiers bool

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1593,7 +1593,22 @@ const (
 	// export names. Named imports to this module are only allowed if they are
 	// in the set of export names.
 	ExportsESM
+
+	// Some export names are known explicitly, but others fall back to a dynamic
+	// run-time object. This is necessary when using the "export * from" syntax
+	// with either a CommonJS module or an external module (i.e. a module whose
+	// export names are not known at compile-time).
+	//
+	// Calling "require()" on this module generates an exports object (stored in
+	// "exports") with getters for the export names. All named imports to this
+	// module are allowed. Direct named imports reference the corresponding export
+	// directly. Other imports go through property accesses on "exports".
+	ExportsESMWithDynamicFallback
 )
+
+func (kind ExportsKind) IsDynamic() bool {
+	return kind == ExportsCommonJS || kind == ExportsESMWithDynamicFallback
+}
 
 type AST struct {
 	ApproximateLineCount  int32

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -12930,12 +12930,19 @@ func (p *parser) prepareForVisitPass() {
 	p.hoistSymbols(p.moduleScope)
 
 	if p.options.mode != config.ModePassThrough {
-		p.exportsRef = p.declareCommonJSSymbol(js_ast.SymbolHoisted, "exports")
 		p.requireRef = p.declareCommonJSSymbol(js_ast.SymbolUnbound, "require")
+	} else {
+		p.requireRef = p.newSymbol(js_ast.SymbolUnbound, "require")
+	}
+
+	// CommonJS-style exports are only enabled if this isn't using ECMAScript-
+	// style exports. You can still use "require" in ESM, just not "module" or
+	// "exports". You can also still use "import" in CommonJS.
+	if p.options.mode != config.ModePassThrough && p.es6ExportKeyword.Len == 0 && p.topLevelAwaitKeyword.Len == 0 {
+		p.exportsRef = p.declareCommonJSSymbol(js_ast.SymbolHoisted, "exports")
 		p.moduleRef = p.declareCommonJSSymbol(js_ast.SymbolHoisted, "module")
 	} else {
 		p.exportsRef = p.newSymbol(js_ast.SymbolHoisted, "exports")
-		p.requireRef = p.newSymbol(js_ast.SymbolUnbound, "require")
 		p.moduleRef = p.newSymbol(js_ast.SymbolHoisted, "module")
 	}
 

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -57,7 +57,6 @@ type parser struct {
 	requireRef               js_ast.Ref
 	moduleRef                js_ast.Ref
 	importMetaRef            js_ast.Ref
-	promiseRef               js_ast.Ref
 	findSymbolHelper         func(loc logger.Loc, name string) js_ast.Ref
 	symbolForDefineHelper    func(int) js_ast.Ref
 	injectedDefineSymbols    []js_ast.Ref
@@ -1538,13 +1537,6 @@ func (p *parser) callRuntime(loc logger.Loc, name string, args []js_ast.Expr) js
 		Target: js_ast.Expr{Loc: loc, Data: &js_ast.EIdentifier{Ref: ref}},
 		Args:   args,
 	}}
-}
-
-func (p *parser) makePromiseRef() js_ast.Ref {
-	if p.promiseRef == js_ast.InvalidRef {
-		p.promiseRef = p.newSymbol(js_ast.SymbolUnbound, "Promise")
-	}
-	return p.promiseRef
 }
 
 // The name is temporarily stored in the ref until the scope traversal pass
@@ -11162,49 +11154,6 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 				}
 			}
 
-			// We need to convert this into a call to "require()" if ES6 syntax is
-			// not supported in the current output format. The full conversion:
-			//
-			//   Before:
-			//     import(foo)
-			//
-			//   After:
-			//     Promise.resolve().then(() => require(foo))
-			//
-			// This is normally done by the printer since we don't know during the
-			// parsing stage whether this module is external or not. However, it's
-			// guaranteed to be external if the argument isn't a string. We handle
-			// this case here instead of in the printer because both the printer
-			// and the linker currently need an import record to handle this case
-			// correctly, and you need a string literal to get an import record.
-			if !p.options.outputFormat.KeepES6ImportExportSyntax() {
-				var then js_ast.Expr
-				value := p.callRuntime(arg.Loc, "__toModule", []js_ast.Expr{{Loc: expr.Loc, Data: &js_ast.ECall{
-					Target: js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EIdentifier{Ref: p.requireRef}},
-					Args:   []js_ast.Expr{arg},
-				}}})
-				body := js_ast.FnBody{Loc: expr.Loc, Stmts: []js_ast.Stmt{{Loc: expr.Loc, Data: &js_ast.SReturn{Value: &value}}}}
-				if p.options.unsupportedJSFeatures.Has(compat.Arrow) {
-					then = js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EFunction{Fn: js_ast.Fn{Body: body}}}
-				} else {
-					then = js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EArrow{Body: body, PreferExpr: true}}
-				}
-				return js_ast.Expr{Loc: expr.Loc, Data: &js_ast.ECall{
-					Target: js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EDot{
-						Target: js_ast.Expr{Loc: expr.Loc, Data: &js_ast.ECall{
-							Target: js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EDot{
-								Target:  js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EIdentifier{Ref: p.makePromiseRef()}},
-								Name:    "resolve",
-								NameLoc: expr.Loc,
-							}},
-						}},
-						Name:    "then",
-						NameLoc: expr.Loc,
-					}},
-					Args: []js_ast.Expr{then},
-				}}
-			}
-
 			return js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EImport{
 				Expr:                    arg,
 				LeadingInteriorComments: e.LeadingInteriorComments,
@@ -12682,7 +12631,6 @@ func newParser(log logger.Log, source logger.Source, lexer js_lexer.Lexer, optio
 		allowIn:           true,
 		options:           *options,
 		runtimeImports:    make(map[string]js_ast.Ref),
-		promiseRef:        js_ast.InvalidRef,
 		afterArrowBodyLoc: logger.Loc{Start: -1},
 
 		// For lowering private methods

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -18,16 +18,10 @@ func (p *parser) markSyntaxFeature(feature compat.JSFeature, r logger.Range) (di
 	didGenerateError = true
 
 	if !p.options.unsupportedJSFeatures.Has(feature) {
-		if feature == compat.TopLevelAwait {
-			if p.options.mode == config.ModeBundle {
-				p.log.AddRangeError(&p.source, r, "Top-level await is currently not supported when bundling")
-				return
-			}
-			if p.options.mode == config.ModeConvertFormat && !p.options.outputFormat.KeepES6ImportExportSyntax() {
-				p.log.AddRangeError(&p.source, r, fmt.Sprintf(
-					"Top-level await is currently not supported with the %q output format", p.options.outputFormat.String()))
-				return
-			}
+		if feature == compat.TopLevelAwait && !p.options.outputFormat.KeepES6ImportExportSyntax() {
+			p.log.AddRangeError(&p.source, r, fmt.Sprintf(
+				"Top-level await is currently not supported with the %q output format", p.options.outputFormat.String()))
+			return
 		}
 
 		didGenerateError = false

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1216,7 +1216,7 @@ func (p *printer) printRequireOrImportExpr(importRecordIndex uint32, leadingInte
 	p.printSpaceBeforeIdentifier()
 
 	// Preserve "import()" expressions that don't point inside the bundle
-	if !record.SourceIndex.IsValid() && record.Kind == ast.ImportDynamic && p.options.OutputFormat.KeepES6ImportExportSyntax() {
+	if !record.SourceIndex.IsValid() && record.Kind == ast.ImportDynamic {
 		p.print("import(")
 		if len(leadingInteriorComments) > 0 {
 			p.printNewline()

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -94,12 +94,13 @@ type ResolveResult struct {
 	JSXFactory  []string // Default if empty: "React.createElement"
 	JSXFragment []string // Default if empty: "React.Fragment"
 
-	IsExternal    bool
 	DifferentCase *fs.DifferentCase
 
 	// If true, any ES6 imports to this file can be considered to have no side
 	// effects. This means they should be removed if unused.
 	IgnorePrimaryIfUnused *IgnoreIfUnusedData
+
+	IsExternal bool
 
 	// If true, the class field transform should use Object.defineProperty().
 	UseDefineForClassFieldsTS bool
@@ -108,6 +109,9 @@ type ResolveResult struct {
 	// behavior of the "importsNotUsedAsValues" field in "tsconfig.json" when the
 	// value is not "remove".
 	PreserveUnusedImportsTS bool
+
+	// This is the "type" field from "package.json"
+	ModuleType config.ModuleType
 }
 
 type AlternativeApproach uint8
@@ -414,6 +418,9 @@ func (r *resolver) finalizeResolve(result *ResolveResult) {
 									result.IgnorePrimaryIfUnused = info.packageJSON.ignoreIfUnusedData
 								}
 							}
+
+							// Also copy over the "type" field
+							result.ModuleType = info.packageJSON.moduleType
 							break
 						}
 					}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -100,13 +100,7 @@ func code(isES6 bool) string {
 		}
 
 		// Wraps a CommonJS closure and returns a require() function
-		export var __commonJS = (callback, module) => () => {
-			if (!module) {
-				module = {exports: {}}
-				callback(module.exports, module)
-			}
-			return module.exports
-		}
+		export var __commonJS = (cb, mod) => () => (mod || cb((mod = {exports: {}}).exports, mod), mod.exports)
 
 		// Used to implement ES6 exports to CommonJS
 		export var __export = (target, all) => {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -780,6 +780,63 @@
     }),
   )
 
+  // Test imports from modules without any imports
+  tests.push(
+    test(['in.js', '--outfile=node.js', '--bundle'], {
+      'in.js': `
+        import * as ns from 'pkg'
+        if (ns.default === void 0) throw 'fail'
+      `,
+      'node_modules/pkg/index.js': ``,
+    }, {}),
+    test(['in.js', '--outfile=node.js', '--bundle'], {
+      'in.js': `
+        import * as ns from 'pkg/index.cjs'
+        if (ns.default === void 0) throw 'fail'
+      `,
+      'node_modules/pkg/index.cjs': ``,
+    }),
+    test(['in.js', '--outfile=node.js', '--bundle'], {
+      'in.js': `
+        import * as ns from 'pkg/index.mjs'
+        if (ns.default !== void 0) throw 'fail'
+      `,
+      'node_modules/pkg/index.mjs': ``,
+    }, {
+      expectedStderr: ` > in.js:3:15: warning: Import "default" will always be undefined because there is no matching export
+    3 │         if (ns.default !== void 0) throw 'fail'
+      ╵                ~~~~~~~
+
+`,
+    }),
+    test(['in.js', '--outfile=node.js', '--bundle'], {
+      'in.js': `
+        import * as ns from 'pkg'
+        if (ns.default === void 0) throw 'fail'
+      `,
+      'node_modules/pkg/package.json': `{
+        "type": "commonjs"
+      }`,
+      'node_modules/pkg/index.js': ``,
+    }),
+    test(['in.js', '--outfile=node.js', '--bundle'], {
+      'in.js': `
+        import * as ns from 'pkg'
+        if (ns.default !== void 0) throw 'fail'
+      `,
+      'node_modules/pkg/package.json': `{
+        "type": "module"
+      }`,
+      'node_modules/pkg/index.js': ``,
+    }, {
+      expectedStderr: ` > in.js:3:15: warning: Import "default" will always be undefined because there is no matching export
+    3 │         if (ns.default !== void 0) throw 'fail'
+      ╵                ~~~~~~~
+
+`,
+    }),
+  )
+
   // Test imports not being able to access the namespace object
   tests.push(
     test(['in.js', '--outfile=node.js', '--bundle'], {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -1155,32 +1155,6 @@
     }),
   )
 
-  // Tests for "eval" scope issues
-  tests.push(
-    test(['in.js', '--bundle', '--outfile=node.js', '--minify-syntax', '--minify-identifiers'], {
-      'in.js': `
-        import a from './a'
-        import b, {Button} from './b'
-        import c from './c'
-        if (a[0] !== a[1]) throw 'fail'
-        if (b !== Button) throw 'fail'
-        if (!(new c instanceof c)) throw 'fail'
-      `,
-      'a.js': `
-        class Button {}
-        export default [Button, eval('Button')]
-      `,
-      'b.js': `
-        export class Button {}
-        export default eval('Button')
-      `,
-      'c.js': `
-        class Button {}
-        export default eval('Button')
-      `,
-    }),
-  )
-
   // Tests for "arguments" scope issues
   tests.push(
     test(['in.js', '--outfile=node.js', '--minify'], {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -397,33 +397,6 @@
       'in.js': `export default 123; const out = require('./in'); if (!out.__esModule || out.default !== 123) throw 'fail'`,
     }),
 
-    // Complex circular import case, must not crash
-    test(['--bundle', 'in.js', '--outfile=node.js'], {
-      'in.js': `
-        import {bar} from './re-export'
-        if (bar() !== 123) throw 'fail'
-      `,
-      're-export.js': `
-        export * from './foo'
-        export * from './bar'
-      `,
-      'foo.js': `
-        export function foo() {
-          return module.exports.foo ? 123 : 234 // "module" makes this a CommonJS file
-        }
-      `,
-      'bar.js': `
-        import {getFoo} from './get'
-        export let bar = getFoo(module) // "module" makes this a CommonJS file
-      `,
-      'get.js': `
-        import {foo} from './foo'
-        export function getFoo() {
-          return foo
-        }
-      `,
-    }),
-
     // Test bundled and non-bundled double export star
     test(['node.ts', '--bundle', '--format=cjs', '--outdir=.'], {
       'node.ts': `

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -452,6 +452,33 @@
         export let b = 'b'
       `,
     }),
+    test(['entry1.js', 'entry2.js', '--splitting', '--bundle', '--format=esm', '--outdir=out'], {
+      'entry1.js': `
+        import { abc, def, xyz } from './a'
+        export default [abc, def, xyz]
+      `,
+      'entry2.js': `
+        import * as x from './b'
+        export default x
+      `,
+      'a.js': `
+        export let abc = 'abc'
+        export * from './b'
+      `,
+      'b.js': `
+        export * from './c'
+        export const def = 'def'
+      `,
+      'c.js': `
+        exports.xyz = 'xyz'
+      `,
+      'node.js': `
+        import entry1 from './out/entry1.js'
+        import entry2 from './out/entry2.js'
+        if (entry1[0] !== 'abc' || entry1[1] !== 'def' || entry1[2] !== 'xyz') throw 'fail'
+        if (entry2.def !== 'def' || entry2.xyz !== 'xyz') throw 'fail'
+      `,
+    }),
 
     // Complex circular bundled and non-bundled import case (https://github.com/evanw/esbuild/issues/758)
     test(['node.ts', '--bundle', '--format=cjs', '--outdir=.'], {


### PR DESCRIPTION
This is a PR for version 0.10.0, which is a release that contains the following breaking changes:

* No longer support `module` or `exports` in an ESM file (fixes #769)

    This removes support for using CommonJS exports in a file with ESM exports. Previously this worked by converting the ESM file to CommonJS and then mixing the CommonJS and ESM exports into the same `exports` object. But it turns out that supporting this is additional complexity for the bundler, so it has been removed. It's also not something that works in real JavaScript environments since modules will never support both export syntaxes at once.

    Note that this doesn't remove support for using `require` in ESM files. Doing this still works (and can be made to work in a real ESM environment by assigning to `globalThis.require`). This also doesn't remove support for using `import` in CommonJS files. Doing this also still works.

* No longer change `import()` to `require()` (fixes #1029)

    Previously esbuild's transform for `import()` matched TypeScript's behavior, which is to transform it into `Promise.resolve().then(() => require())` when the current output format is something other than ESM. This was done when an import is external (i.e. not bundled), either due to the expression not being a string or due to the string matching an external import path.

    With this release, esbuild will no longer do this. Now `import()` expressions will be preserved in the output instead. These expressions can be handled in non-ESM code by arranging for the `import` identifier to be a function that imports ESM code. This is how node works, so it will now be possible to use `import()` with node when the output format is something other than ESM.

* Run-time `export * as` statements no longer convert the file to CommonJS

    Certain `export * as` statements require a bundler to evaluate them at run-time instead of at compile-time like the JavaScript specification. This is the case when re-exporting symbols from an external file and a file in CommonJS format.

    Previously esbuild would handle this by converting the module containing the `export * as` statement to CommonJS too, since CommonJS exports are evaluated at run-time while ESM exports are evaluated at bundle-time. However, this is undesirable because tree shaking only works for ESM, not for CommonJS, and the CommonJS wrapper causes additional code bloat. Another upcoming problem is that top-level await cannot work within a CommonJS module because CommonJS `require()` is synchronous.

    With this release, esbuild will now convert modules containing a run-time `export * as` statement to a special ESM-plus-dynamic-fallback mode. In this mode, named exports present at bundle time can still be imported directly by name, but any imports that don't match one of the explicit named imports present at bundle time will be converted to a property access on the fallback object instead of being a bundle error. These property accesses are then resolved at run-time and will be undefined if the export is missing.

* Initial support for bundling with top-level await (#253)

    Top-level await is a feature that lets you use an `await` expression at the top level (outside of an `async` function). Here is an example:

    ```js
    let promise = fetch('https://www.example.com/data')
    export let data = await promise.then(x => x.json())
    ```

    Top-level await only works in ECMAScript modules, and does not work in CommonJS modules. This means that you must use an `import` statement or an `import()` expression to import a module containing top-level await. You cannot use `require()` because it's synchronous while top-level await is asynchronous. There should be a descriptive error message when you try to do this.

    This initial release only has limited support for top-level await. It is only supported with the `esm` output format, but not with the `iife` or `cjs` output formats. In addition, the compilation is not correct in that two modules that both contain top-level await and that are siblings in the import graph will be evaluated in serial instead of in parallel. Full support for top-level await will come in a future release.

* Change whether certain files are interpreted as ESM or CommonJS (fixes #1043)

    The bundling algorithm currently doesn't contain any logic that requires flagging modules as CommonJS vs. ESM beforehand. Instead it handles a superset and then sort of decides later if the module should be treated as CommonJS vs. ESM based on whether the module uses the `module` or `exports` variables and/or the `exports` keyword.

    With this release, files that follow [node's rules for module types](https://nodejs.org/api/packages.html#packages_type) will be flagged as explicitly ESM. This includes files that end in `.mjs` and files within a package containing `"type": "module"` in the enclosing `package.json` file. The CommonJS `require`, `module`, and `exports` features will be unavailable in these files. This matters most for files without any exports, since then it's otherwise ambiguous what the module type is.

    In addition, files without exports should now accurately fall back to being considered CommonJS. They should now generate a `default` export of an empty object when imported using an `import` statement, since that's what happens in node when you import a CommonJS file into an ESM file in node. Previously the default export could be undefined because these export-less files were sort of treated as ESM but with missing import errors turned into warnings instead.

    This is an edge case that rarely comes up in practice, since you usually never import things from a module that has no exports.

The main user-facing feature in this release is initial support for top-level await (only with the `esm` format, and only serial not parallel). The remaining changes are related to the ongoing linker rewrite and help unblock future linker improvements. These changes are being spread out over multiple releases instead of holding them all back into one big release to make the rollout of the new linker go more smoothly. Landing these linker changes incrementally gives them time to "bake" ahead of them being relied on by the new linker, and also helps avoid the overhead of constantly rebasing a large long-lived branch.
