### PR TITLE
Add warning when writing to private method

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -10552,7 +10552,10 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 				r := logger.Range{Loc: e.Index.Loc, Len: int32(len(name))}
 				p.log.AddRangeError(&p.source, r, fmt.Sprintf("Private name %q must be declared in an enclosing class", name))
 			} else if !p.options.suppressWarningsAboutWeirdCode {
-				if in.assignTarget != js_ast.AssignTargetNone && (kind == js_ast.SymbolPrivateGet || kind == js_ast.SymbolPrivateStaticGet) {
+				if in.assignTarget != js_ast.AssignTargetNone && (kind == js_ast.SymbolPrivateMethod || kind == js_ast.SymbolPrivateStaticMethod) {
+					r := logger.Range{Loc: e.Index.Loc, Len: int32(len(name))}
+					p.log.AddRangeWarning(&p.source, r, fmt.Sprintf("Writing to readonly method %q will throw", name))
+				} else if in.assignTarget != js_ast.AssignTargetNone && (kind == js_ast.SymbolPrivateGet || kind == js_ast.SymbolPrivateStaticGet) {
 					r := logger.Range{Loc: e.Index.Loc, Len: int32(len(name))}
 					p.log.AddRangeWarning(&p.source, r, fmt.Sprintf("Writing to getter-only property %q will throw", name))
 				} else if in.assignTarget != js_ast.AssignTargetReplace && (kind == js_ast.SymbolPrivateSet || kind == js_ast.SymbolPrivateStaticSet) {

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -3900,6 +3900,12 @@ func TestPrivateIdentifiers(t *testing.T) {
 	expectParseError(t, "class Foo { set #x(x) { this.#x += 1 } }",
 		"<stdin>: warning: Reading from setter-only property \"#x\" will throw\n")
 
+	// Writing to method warnings
+	expectParseError(t, "class Foo { #x() { this.#x = 1 } }",
+		"<stdin>: warning: Writing to readonly method \"#x\" will throw\n")
+	expectParseError(t, "class Foo { #x() { this.#x += 1 } }",
+		"<stdin>: warning: Writing to readonly method \"#x\" will throw\n")
+
 	expectPrinted(t, `class Foo {
 	#if
 	#im() { return this.#im(this.#if) }

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -2053,12 +2053,20 @@
         new Foo().bar()
       `,
     }, {
-      expectedStderr: ` > in.js:23:30: warning: Reading from setter-only property "#setter" will throw
+      expectedStderr: ` > in.js:22:29: warning: Writing to readonly method "#method" will throw
+    22 │             expect(() => obj.#method = 1, 'Cannot write to private f...
+       ╵                              ~~~~~~~
+
+ > in.js:23:30: warning: Reading from setter-only property "#setter" will throw
     23 │             expect(() => this.#setter, 'member.get is not a function')
        ╵                               ~~~~~~~
 
  > in.js:24:30: warning: Writing to getter-only property "#getter" will throw
     24 │             expect(() => this.#getter = 1, 'member.set is not a func...
+       ╵                               ~~~~~~~
+
+ > in.js:25:30: warning: Writing to readonly method "#method" will throw
+    25 │             expect(() => this.#method = 1, 'member.set is not a func...
        ╵                               ~~~~~~~
 
 `,


### PR DESCRIPTION
Regrettably, private methods aren't writable. The downleveling seems correct, but I noticed that there wasn't a warning like the getter-only/setter-only private accessors.