### PR TITLE
Add cross-origin isolation headers

### DIFF
--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -117,6 +117,8 @@ func (h *apiHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	// Handle get requests
 	if req.Method == "GET" && strings.HasPrefix(req.URL.Path, "/") {
 		res.Header().Set("Access-Control-Allow-Origin", "*")
+		res.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
+		res.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 		queryPath := path.Clean(req.URL.Path)[1:]
 		result := h.build()
 


### PR DESCRIPTION
This PR adds COOP and COEP headers when serving locally in development using `--servedir`, as they are needed if working with the re-enabled `SharedArrayBuffer`s in your code:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes
https://developer.chrome.com/blog/enabling-shared-array-buffer/
https://web.dev/coop-coep/

