### PR TITLE
track and retain intermediate re-exporting files

### DIFF
--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -233,6 +233,87 @@ TestPackageJsonSideEffectsArrayRemove
 console.log("unused import");
 
 ================================================================================
+TestPackageJsonSideEffectsFalseAllFork
+---------- /out.js ----------
+// Users/user/project/node_modules/c/index.js
+var foo;
+var init_c = __esm(() => {
+  foo = "foo";
+});
+
+// Users/user/project/node_modules/b/index.js
+var init_b = __esm(() => {
+  init_c();
+});
+
+// Users/user/project/node_modules/a/index.js
+var a_exports = {};
+__export(a_exports, {
+  foo: () => foo
+});
+var init_a = __esm(() => {
+  init_b();
+});
+
+// Users/user/project/src/entry.js
+Promise.resolve().then(() => (init_a(), a_exports)).then((x) => assert(x.foo === "foo"));
+
+================================================================================
+TestPackageJsonSideEffectsFalseIntermediateFilesChainAll
+---------- /out.js ----------
+// Users/user/project/node_modules/d/index.js
+var foo = 123;
+
+// Users/user/project/node_modules/b/index.js
+throw "keep this";
+
+// Users/user/project/src/entry.js
+console.log(foo);
+
+================================================================================
+TestPackageJsonSideEffectsFalseIntermediateFilesChainOne
+---------- /out.js ----------
+// Users/user/project/node_modules/d/index.js
+var foo = 123;
+
+// Users/user/project/node_modules/b/index.js
+throw "keep this";
+
+// Users/user/project/src/entry.js
+console.log(foo);
+
+================================================================================
+TestPackageJsonSideEffectsFalseIntermediateFilesDiamond
+---------- /out.js ----------
+// Users/user/project/node_modules/d/index.js
+var foo = 123;
+
+// Users/user/project/node_modules/b1/index.js
+throw "keep this 1";
+
+// Users/user/project/node_modules/b2/index.js
+throw "keep this 2";
+
+// Users/user/project/src/entry.js
+console.log(foo);
+
+================================================================================
+TestPackageJsonSideEffectsFalseIntermediateFilesUnused
+---------- /out.js ----------
+
+================================================================================
+TestPackageJsonSideEffectsFalseIntermediateFilesUsed
+---------- /out.js ----------
+// Users/user/project/node_modules/demo-pkg/foo.js
+var foo = 123;
+
+// Users/user/project/node_modules/demo-pkg/index.js
+throw "keep this";
+
+// Users/user/project/src/entry.js
+console.log(foo);
+
+================================================================================
 TestPackageJsonSideEffectsFalseKeepBareImportAndRequireCommonJS
 ---------- /out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
@@ -321,6 +402,37 @@ console.log("unused import");
 
 // Users/user/project/src/entry.js
 console.log("used import");
+
+================================================================================
+TestPackageJsonSideEffectsFalseOneFork
+---------- /out.js ----------
+// Users/user/project/node_modules/c/index.js
+var foo;
+var init_c = __esm(() => {
+  foo = "foo";
+});
+
+// Users/user/project/node_modules/d/index.js
+var init_d = __esm(() => {
+});
+
+// Users/user/project/node_modules/b/index.js
+var init_b = __esm(() => {
+  init_c();
+  init_d();
+});
+
+// Users/user/project/node_modules/a/index.js
+var a_exports = {};
+__export(a_exports, {
+  foo: () => foo
+});
+var init_a = __esm(() => {
+  init_b();
+});
+
+// Users/user/project/src/entry.js
+Promise.resolve().then(() => (init_a(), a_exports)).then((x) => assert(x.foo === "foo"));
 
 ================================================================================
 TestPackageJsonSideEffectsFalseRemoveBareImportCommonJS


### PR DESCRIPTION
This fixes a subtle bug with esbuild's support for [Webpack's `"sideEffects": false` annotation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) in `package.json` when combined with re-export statements. A re-export is when you import something from one file and then export it again. You can re-export something with `export * from` or `export {foo} from` or `import {foo} from` followed by `export {foo}`.

The bug was that files which only contain re-exports and that are marked as being side-effect free were not being included in the bundle if you import one of the re-exported symbols. This is because esbuild's implementation of re-export linking caused the original importing file to "short circuit" the re-export and just import straight from the file containing the final symbol, skipping the file containing the re-export entirely.

This was normally not observable since the intermediate file consisted entirely of re-exports, which have no side effects. However, a recent change to allow ESM files to be lazily-initialized relies on all intermediate files being included in the bundle to trigger the initialization of the lazy evaluation wrappers. So the behavior of skipping over re-export files is now causing the imported symbols to not be initialized if the re-exported file is marked as lazily-evaluated.

The fix is to track all re-exports in the import chain from the original file to the file containing the final symbol and then retain all of those statements if the import ends up being used.

Fixes #1088.
