### PR TITLE
Avoid using the same helper function names as TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+* Avoid name collisions with TypeScript helper functions ([#1102](https://github.com/evanw/esbuild/issues/1102))
+
+    Helper functions are sometimes used when transforming newer JavaScript syntax for older browsers. For example, `let {x, ...y} = {z}` is transformed into `let _a = {z}, {x} = _a, y = __rest(_a, ["x"])` which uses the `__rest` helper function. Many of esbuild's transforms were modeled after the transforms in the TypeScript compiler, so many of the helper functions use the same names as TypeScript's helper functions.
+
+    However, the TypeScript compiler doesn't avoid name collisions with existing identifiers in the transformed code. This means that post-processing esbuild's output with the TypeScript compiler (e.g. for lowering ES6 to ES5) will cause issues since TypeScript will fail to call its own helper functions: [microsoft/TypeScript#43296](https://github.com/microsoft/TypeScript/issues/43296). There is also a problem where TypeScript's `tslib` library overwrites globals with these names, which can overwrite esbuild's helper functions if code bundled with esbuild is run in the global scope.
+
+    To avoid these problems, esbuild will now use different names for its helper functions.
+
 ## 0.11.3
 
 * Auto-define `process.env.NODE_ENV` when platform is set to `browser`

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -82,7 +82,7 @@ type ImportRecord struct {
 	ContainsDefaultAlias bool
 
 	// If true, this "export * from 'path'" statement is evaluated at run-time by
-	// calling the "__exportStar()" helper function
+	// calling the "__reExport()" helper function
 	CallsRunTimeExportStarFn bool
 
 	// Tell the printer to wrap this call to "require()" in "__toModule(...)"

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -727,7 +727,7 @@ TestExportWildcardFSNodeCommonJS
 ---------- /out.js ----------
 // entry.js
 __markAsModule(exports);
-__exportStar(exports, __toModule(require("fs")));
+__reExport(exports, __toModule(require("fs")));
 
 ================================================================================
 TestExportWildcardFSNodeES6
@@ -798,7 +798,7 @@ var init_d = __esm(() => {
 var e_exports = {};
 import * as x_star from "x";
 var init_e = __esm(() => {
-  __exportStar(e_exports, x_star);
+  __reExport(e_exports, x_star);
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_importstar.txt
+++ b/internal/bundler/snapshots/snapshots_importstar.txt
@@ -818,7 +818,7 @@ var mod = (() => {
 TestReExportStarCommonJSNoBundle
 ---------- /out.js ----------
 __markAsModule(exports);
-__exportStar(exports, __toModule(require("foo")));
+__reExport(exports, __toModule(require("foo")));
 
 ================================================================================
 TestReExportStarES6NoBundle
@@ -830,7 +830,7 @@ TestReExportStarExternalCommonJS
 ---------- /out.js ----------
 // entry.js
 __markAsModule(exports);
-__exportStar(exports, __toModule(require("foo")));
+__reExport(exports, __toModule(require("foo")));
 
 ================================================================================
 TestReExportStarExternalES6
@@ -844,7 +844,7 @@ TestReExportStarExternalIIFE
 var mod = (() => {
   // entry.js
   var entry_exports = {};
-  __exportStar(entry_exports, __toModule(require("foo")));
+  __reExport(entry_exports, __toModule(require("foo")));
   return entry_exports;
 })();
 
@@ -853,7 +853,7 @@ TestReExportStarIIFENoBundle
 ---------- /out.js ----------
 var mod = (() => {
   var entry_exports = {};
-  __exportStar(entry_exports, __toModule(require("foo")));
+  __reExport(entry_exports, __toModule(require("foo")));
   return entry_exports;
 })();
 

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -916,83 +916,83 @@ Foo.s_foo = 123;
 TestTSLowerObjectRest2017NoBundle
 ---------- /out.js ----------
 var _o, _p, _r, _s, _t, _u, _v;
-const local_const = __rest({}, []);
-let local_let = __rest({}, []);
-var local_var = __rest({}, []);
+const local_const = __objRest({}, []);
+let local_let = __objRest({}, []);
+var local_var = __objRest({}, []);
 let arrow_fn = (_a) => {
-  var x2 = __rest(_a, []);
+  var x2 = __objRest(_a, []);
 };
 let fn_expr = function(_b = default_value) {
-  var x2 = __rest(_b, []);
+  var x2 = __objRest(_b, []);
 };
 let class_expr = class {
   method(x2, ..._c) {
-    var [y, _d] = _c, z = __rest(_d, []);
+    var [y, _d] = _c, z = __objRest(_d, []);
   }
 };
 function fn_stmt(_e, _f) {
-  var {a = b()} = _e, x2 = __rest(_e, ["a"]);
-  var {c = d()} = _f, y = __rest(_f, ["c"]);
+  var {a = b()} = _e, x2 = __objRest(_e, ["a"]);
+  var {c = d()} = _f, y = __objRest(_f, ["c"]);
 }
 class class_stmt {
   method(_g) {
-    var x2 = __rest(_g, []);
+    var x2 = __objRest(_g, []);
   }
 }
 var ns;
 (function(ns2) {
-  ns2.x = __rest({}, []);
+  ns2.x = __objRest({}, []);
 })(ns || (ns = {}));
 try {
 } catch (_h) {
-  let catch_clause = __rest(_h, []);
+  let catch_clause = __objRest(_h, []);
 }
 for (const _i in {abc}) {
-  const for_in_const = __rest(_i, []);
+  const for_in_const = __objRest(_i, []);
 }
 for (let _j in {abc}) {
-  let for_in_let = __rest(_j, []);
+  let for_in_let = __objRest(_j, []);
 }
 for (var _k in {abc}) {
-  var for_in_var = __rest(_k, []);
+  var for_in_var = __objRest(_k, []);
   ;
 }
 for (const _l of [{}]) {
-  const for_of_const = __rest(_l, []);
+  const for_of_const = __objRest(_l, []);
   ;
 }
 for (let _m of [{}]) {
-  let for_of_let = __rest(_m, []);
+  let for_of_let = __objRest(_m, []);
   x();
 }
 for (var _n of [{}]) {
-  var for_of_var = __rest(_n, []);
+  var for_of_var = __objRest(_n, []);
   x();
 }
-for (const for_const = __rest({}, []); x; x = null) {
+for (const for_const = __objRest({}, []); x; x = null) {
 }
-for (let for_let = __rest({}, []); x; x = null) {
+for (let for_let = __objRest({}, []); x; x = null) {
 }
-for (var for_var = __rest({}, []); x; x = null) {
+for (var for_var = __objRest({}, []); x; x = null) {
 }
 for (_o in {abc}) {
-  x = __rest(_o, []);
+  x = __objRest(_o, []);
 }
 for (_p of [{}]) {
-  x = __rest(_p, []);
+  x = __objRest(_p, []);
 }
-for (x = __rest({}, []); x; x = null) {
+for (x = __objRest({}, []); x; x = null) {
 }
-assign = __rest({}, []);
+assign = __objRest({}, []);
 ({obj_method(_q) {
-  var x2 = __rest(_q, []);
+  var x2 = __objRest(_q, []);
 }});
-x = __rest(x, []);
-for (x = __rest(x, []); 0; )
+x = __objRest(x, []);
+for (x = __objRest(x, []); 0; )
   ;
-console.log((x = __rest(_r = x, []), _r));
-console.log((_t = _s = {x}, {x} = _t, xx = __rest(_t, ["x"]), _s));
-console.log(({x: _v} = _u = {x}, xx = __rest(_v, []), _u));
+console.log((x = __objRest(_r = x, []), _r));
+console.log((_t = _s = {x}, {x} = _t, xx = __objRest(_t, ["x"]), _s));
+console.log(({x: _v} = _u = {x}, xx = __objRest(_v, []), _u));
 
 ================================================================================
 TestTSLowerObjectRest2018NoBundle

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -222,28 +222,28 @@ export {ns2 as sn};
 TestLowerObjectSpreadNoBundle
 ---------- /out.js ----------
 let tests = [
-  __assign(__assign({}, a), b),
-  __assign({a, b}, c),
-  __assign(__assign({}, a), {b, c}),
-  __assign(__assign({a}, b), {c}),
-  __assign(__assign(__assign(__assign(__assign(__assign({a, b}, c), d), {e, f}), g), h), {i, j})
+  __objSpread(__objSpread({}, a), b),
+  __objSpread({a, b}, c),
+  __objSpread(__objSpread({}, a), {b, c}),
+  __objSpread(__objSpread({a}, b), {c}),
+  __objSpread(__objSpread(__objSpread(__objSpread(__objSpread(__objSpread({a, b}, c), d), {e, f}), g), h), {i, j})
 ];
 let jsx = [
-  /* @__PURE__ */ React.createElement("div", __assign(__assign({}, a), b)),
-  /* @__PURE__ */ React.createElement("div", __assign({
+  /* @__PURE__ */ React.createElement("div", __objSpread(__objSpread({}, a), b)),
+  /* @__PURE__ */ React.createElement("div", __objSpread({
     a: true,
     b: true
   }, c)),
-  /* @__PURE__ */ React.createElement("div", __assign(__assign({}, a), {
+  /* @__PURE__ */ React.createElement("div", __objSpread(__objSpread({}, a), {
     b: true,
     c: true
   })),
-  /* @__PURE__ */ React.createElement("div", __assign(__assign({
+  /* @__PURE__ */ React.createElement("div", __objSpread(__objSpread({
     a: true
   }, b), {
     c: true
   })),
-  /* @__PURE__ */ React.createElement("div", __assign(__assign(__assign(__assign(__assign(__assign({
+  /* @__PURE__ */ React.createElement("div", __objSpread(__objSpread(__objSpread(__objSpread(__objSpread(__objSpread({
     a: true,
     b: true
   }, c), d), {

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -333,10 +333,10 @@ __decorateClass([
 __decorateClass([
   x,
   y,
-  __param(0, x0),
-  __param(0, y0),
-  __param(1, x1),
-  __param(1, y1)
+  __decorateParam(0, x0),
+  __decorateParam(0, y0),
+  __decorateParam(1, x1),
+  __decorateParam(1, y1)
 ], Foo.prototype, "method", 1);
 __decorateClass([
   x,
@@ -349,18 +349,18 @@ __decorateClass([
 __decorateClass([
   x,
   y,
-  __param(0, x0),
-  __param(0, y0),
-  __param(1, x1),
-  __param(1, y1)
+  __decorateParam(0, x0),
+  __decorateParam(0, y0),
+  __decorateParam(1, x1),
+  __decorateParam(1, y1)
 ], Foo, "sMethod", 1);
 Foo = __decorateClass([
   x.y(),
   new y.x(),
-  __param(0, x0),
-  __param(0, y0),
-  __param(1, x1),
-  __param(1, y1)
+  __decorateParam(0, x0),
+  __decorateParam(0, y0),
+  __decorateParam(1, x1),
+  __decorateParam(1, y1)
 ], Foo);
 var all_default = Foo;
 
@@ -391,10 +391,10 @@ __decorateClass([
 __decorateClass([
   x,
   y,
-  __param(0, x0),
-  __param(0, y0),
-  __param(1, x1),
-  __param(1, y1)
+  __decorateParam(0, x0),
+  __decorateParam(0, y0),
+  __decorateParam(1, x1),
+  __decorateParam(1, y1)
 ], Foo2.prototype, _c, 1);
 __decorateClass([
   x,
@@ -407,10 +407,10 @@ __decorateClass([
 __decorateClass([
   x,
   y,
-  __param(0, x0),
-  __param(0, y0),
-  __param(1, x1),
-  __param(1, y1)
+  __decorateParam(0, x0),
+  __decorateParam(0, y0),
+  __decorateParam(1, x1),
+  __decorateParam(1, y1)
 ], Foo2, _h, 1);
 Foo2 = __decorateClass([
   x?.[_ + "y"](),
@@ -537,8 +537,8 @@ var k_default = class {
   }
 };
 __decorateClass([
-  __param(0, x2(() => 0)),
-  __param(0, y(() => 1))
+  __decorateParam(0, x2(() => 0)),
+  __decorateParam(0, y(() => 1))
 ], k_default.prototype, "foo", 1);
 var k_default2 = k_default;
 

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -322,15 +322,15 @@ var Foo = class {
   }
 };
 Foo.sDef = new Foo();
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo.prototype, "mUndef", 2);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo.prototype, "mDef", 2);
-__decorate([
+__decorateClass([
   x,
   y,
   __param(0, x0),
@@ -338,15 +338,15 @@ __decorate([
   __param(1, x1),
   __param(1, y1)
 ], Foo.prototype, "method", 1);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo, "sUndef", 2);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo, "sDef", 2);
-__decorate([
+__decorateClass([
   x,
   y,
   __param(0, x0),
@@ -354,7 +354,7 @@ __decorate([
   __param(1, x1),
   __param(1, y1)
 ], Foo, "sMethod", 1);
-Foo = __decorate([
+Foo = __decorateClass([
   x.y(),
   new y.x(),
   __param(0, x0),
@@ -380,15 +380,15 @@ var Foo2 = class {
 };
 Foo2[_e] = 3;
 Foo2[_g] = new Foo2();
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo2.prototype, _a, 2);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo2.prototype, _b, 2);
-__decorate([
+__decorateClass([
   x,
   y,
   __param(0, x0),
@@ -396,15 +396,15 @@ __decorate([
   __param(1, x1),
   __param(1, y1)
 ], Foo2.prototype, _c, 1);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo2, _f, 2);
-__decorate([
+__decorateClass([
   x,
   y
 ], Foo2, _g, 2);
-__decorate([
+__decorateClass([
   x,
   y,
   __param(0, x0),
@@ -412,7 +412,7 @@ __decorate([
   __param(1, x1),
   __param(1, y1)
 ], Foo2, _h, 1);
-Foo2 = __decorate([
+Foo2 = __decorateClass([
   x?.[_ + "y"](),
   new y?.[_ + "x"]()
 ], Foo2);
@@ -425,7 +425,7 @@ var a_class = class {
   }
 };
 a_class.z = new a_class();
-a_class = __decorate([
+a_class = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], a_class);
@@ -438,7 +438,7 @@ var b_class = class {
   }
 };
 b_class.z = new b_class();
-b_class = __decorate([
+b_class = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], b_class);
@@ -451,7 +451,7 @@ var c = class {
   }
 };
 c.z = new c();
-c = __decorate([
+c = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], c);
@@ -463,7 +463,7 @@ var d = class {
   }
 };
 d.z = new d();
-d = __decorate([
+d = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], d);
@@ -471,7 +471,7 @@ d = __decorate([
 // e.ts
 var e_default = class {
 };
-e_default = __decorate([
+e_default = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], e_default);
@@ -484,7 +484,7 @@ var f = class {
   }
 };
 f.z = new f();
-f = __decorate([
+f = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], f);
@@ -493,7 +493,7 @@ var f_default = f;
 // g.ts
 var g_default = class {
 };
-g_default = __decorate([
+g_default = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], g_default);
@@ -506,7 +506,7 @@ var h = class {
   }
 };
 h.z = new h();
-h = __decorate([
+h = __decorateClass([
   x(() => 0),
   y(() => 1)
 ], h);
@@ -515,7 +515,7 @@ var h_default = h;
 // i.ts
 var i_class = class {
 };
-__decorate([
+__decorateClass([
   x(() => 0),
   y(() => 1)
 ], i_class.prototype, "foo", 2);
@@ -526,7 +526,7 @@ var j = class {
   foo() {
   }
 };
-__decorate([
+__decorateClass([
   x(() => 0),
   y(() => 1)
 ], j.prototype, "foo", 1);
@@ -536,7 +536,7 @@ var k_default = class {
   foo(x2) {
   }
 };
-__decorate([
+__decorateClass([
   __param(0, x2(() => 0)),
   __param(0, y(() => 1))
 ], k_default.prototype, "foo", 1);
@@ -551,7 +551,7 @@ function fn(x2) {
     [_a2 = arguments[0]]() {
     }
   }
-  __decorate([
+  __decorateClass([
     dec(arguments[0])
   ], Foo3.prototype, _a2, 1);
   return Foo3;

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -1407,13 +1407,13 @@ func (p *parser) lowerObjectRestHelper(
 			p.recordUsage(ref)
 		}
 
-		// Call "__rest" to clone the initializer without the keys for previous
+		// Call "__objRest" to clone the initializer without the keys for previous
 		// properties, then assign the result to the binding for the rest pattern
 		keysToExclude := make([]js_ast.Expr, len(capturedKeys))
 		for i, capturedKey := range capturedKeys {
 			keysToExclude[i] = capturedKey()
 		}
-		assign(binding, p.callRuntime(binding.Loc, "__rest", []js_ast.Expr{init,
+		assign(binding, p.callRuntime(binding.Loc, "__objRest", []js_ast.Expr{init,
 			{Loc: binding.Loc, Data: &js_ast.EArray{Items: keysToExclude, IsSingleLine: isSingleLine}}}))
 	}
 
@@ -1573,7 +1573,7 @@ func (p *parser) lowerObjectRestHelper(
 	//
 	//   // Output:
 	//   var _a;
-	//   console.log((x = __rest(_a = x, []), _a));
+	//   console.log((x = __objRest(_a = x, []), _a));
 	//
 	// This isn't necessary if the return value is unused:
 	//
@@ -1581,7 +1581,7 @@ func (p *parser) lowerObjectRestHelper(
 	//   ({...x} = x);
 	//
 	//   // Output:
-	//   x = __rest(x, []);
+	//   x = __objRest(x, []);
 	//
 	if mode == objRestMustReturnInitExpr {
 		initFunc, initWrapFunc := p.captureValueWithPossibleSideEffects(rootInit.Loc, 2, rootInit, valueCouldBeMutated)
@@ -1595,7 +1595,7 @@ func (p *parser) lowerObjectRestHelper(
 	return wrapFunc, true
 }
 
-// Save a copy of the key for the call to "__rest" later on. Certain
+// Save a copy of the key for the call to "__objRest" later on. Certain
 // expressions can be converted to keys more efficiently than others.
 func (p *parser) captureKeyForObjectRest(originalKey js_ast.Expr) (finalKey js_ast.Expr, capturedKey func() js_ast.Expr) {
 	loc := originalKey.Loc

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -1789,13 +1789,13 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 				}
 				for i, arg := range fn.Fn.Args {
 					for _, decorator := range arg.TSDecorators {
-						// Generate a call to "__param()" for this parameter decorator
+						// Generate a call to "__decorateParam()" for this parameter decorator
 						var decorators *[]js_ast.Expr = &prop.TSDecorators
 						if isConstructor {
 							decorators = &class.TSDecorators
 						}
 						*decorators = append(*decorators,
-							p.callRuntime(decorator.Loc, "__param", []js_ast.Expr{
+							p.callRuntime(decorator.Loc, "__decorateParam", []js_ast.Expr{
 								{Loc: decorator.Loc, Data: &js_ast.ENumber{Value: float64(i)}},
 								decorator,
 							}),

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -1859,7 +1859,7 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 
 		// Handle decorators
 		if p.options.ts.Parse {
-			// Generate a single call to "__decorate()" for this property
+			// Generate a single call to "__decorateClass()" for this property
 			if len(prop.TSDecorators) > 0 {
 				loc := prop.Key.Loc
 
@@ -1876,7 +1876,7 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 					panic("Internal error")
 				}
 
-				// This code tells "__decorate()" if the descriptor should be undefined
+				// This code tells "__decorateClass()" if the descriptor should be undefined
 				descriptorKind := float64(1)
 				if !prop.IsMethod {
 					descriptorKind = 2
@@ -1890,7 +1890,7 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 					target = js_ast.Expr{Loc: loc, Data: &js_ast.EDot{Target: nameFunc(), Name: "prototype", NameLoc: loc}}
 				}
 
-				decorator := p.callRuntime(loc, "__decorate", []js_ast.Expr{
+				decorator := p.callRuntime(loc, "__decorateClass", []js_ast.Expr{
 					{Loc: loc, Data: &js_ast.EArray{Items: prop.TSDecorators}},
 					target,
 					descriptorKey,
@@ -2345,7 +2345,7 @@ func (p *parser) lowerClass(stmt js_ast.Stmt, expr js_ast.Expr, shadowRef js_ast
 	if len(class.TSDecorators) > 0 {
 		stmts = append(stmts, js_ast.AssignStmt(
 			js_ast.Expr{Loc: nameForClassDecorators.Loc, Data: &js_ast.EIdentifier{Ref: nameForClassDecorators.Ref}},
-			p.callRuntime(classLoc, "__decorate", []js_ast.Expr{
+			p.callRuntime(classLoc, "__decorateClass", []js_ast.Expr{
 				{Loc: classLoc, Data: &js_ast.EArray{Items: class.TSDecorators}},
 				{Loc: nameForClassDecorators.Loc, Data: &js_ast.EIdentifier{Ref: nameForClassDecorators.Ref}},
 			}),

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -185,7 +185,7 @@ func TestLowerClassInstance(t *testing.T) {
 `)
 	expectPrintedTarget(t, 2015, "class Foo extends Bar { bar() {} foo; constructor({ ...args }) { super() } }", `class Foo extends Bar {
   constructor(_a) {
-    var args = __rest(_a, []);
+    var args = __objRest(_a, []);
     super();
     __publicField(this, "foo");
   }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -62,7 +62,7 @@ func code(isES6 bool) string {
 	//   __spreadArrays
 	//   __values
 	//
-	// Note: The "__rest" function has a for-of loop which requires ES6, but
+	// Note: The "__objRest" function has a for-of loop which requires ES6, but
 	// transforming destructuring to ES5 isn't even supported so it's ok.
 	text := `
 		var __create = Object.create
@@ -114,7 +114,7 @@ func code(isES6 bool) string {
 
 		// For object rest patterns
 		export var __restKey = key => typeof key === 'symbol' ? key : key + ''
-		export var __rest = (source, exclude) => {
+		export var __objRest = (source, exclude) => {
 			var target = {}
 			for (var prop in source)
 				if (__hasOwnProp.call(source, prop) && exclude.indexOf(prop) < 0)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,6 +20,48 @@ func CanUseES6(unsupportedFeatures compat.JSFeature) bool {
 }
 
 func code(isES6 bool) string {
+	// Note: These helper functions used to be named similar things to the helper
+	// functions from the TypeScript compiler. However, people sometimes use these
+	// two projects in combination and TypeScript's implementation of these helpers
+	// causes name collisions. Some examples:
+	//
+	// * The "tslib" library will overwrite esbuild's helper functions if the bundled
+	//   code is run in the global scope: https://github.com/evanw/esbuild/issues/1102
+	//
+	// * Running the TypeScript compiler on esbuild's output to convert ES6 to ES5
+	//   will also overwrite esbuild's helper functions because TypeScript doesn't
+	//   change the names of its helper functions to avoid name collisions:
+	//   https://github.com/microsoft/TypeScript/issues/43296
+	//
+	// These can both be considered bugs in TypeScript. However, they are unlikely
+	// to be fixed and it's simplest to just avoid using the same names to avoid
+	// these bugs. Forbidden names (from "tslib"):
+	//
+	//   __assign
+	//   __asyncDelegator
+	//   __asyncGenerator
+	//   __asyncValues
+	//   __await
+	//   __awaiter
+	//   __classPrivateFieldGet
+	//   __classPrivateFieldSet
+	//   __createBinding
+	//   __decorate
+	//   __exportStar
+	//   __extends
+	//   __generator
+	//   __importDefault
+	//   __importStar
+	//   __makeTemplateObject
+	//   __metadata
+	//   __param
+	//   __read
+	//   __rest
+	//   __spread
+	//   __spreadArray
+	//   __spreadArrays
+	//   __values
+	//
 	// Note: The "__rest" function has a for-of loop which requires ES6, but
 	// transforming destructuring to ES5 isn't even supported so it's ok.
 	text := `

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -252,9 +252,7 @@ func code(isES6 bool) string {
 						reject(e)
 					}
 				}
-				var step = result => {
-					return result.done ? resolve(result.value) : Promise.resolve(result.value).then(fulfilled, rejected)
-				}
+				var step = x => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected)
 				step((generator = generator.apply(__this, __arguments)).next())
 			})
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -199,7 +199,7 @@ func code(isES6 bool) string {
 		// - kind === undefined: class
 		// - kind === 1: method, parameter
 		// - kind === 2: field
-		export var __decorate = (decorators, target, key, kind) => {
+		export var __decorateClass = (decorators, target, key, kind) => {
 			var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target
 			for (var i = decorators.length - 1, decorator; i >= 0; i--)
 				if (decorator = decorators[i])
@@ -301,12 +301,12 @@ var ES5Source = logger.Source{
 // The TypeScript decorator transform behaves similar to the official
 // TypeScript compiler.
 //
-// One difference is that the "__decorate" function doesn't contain a reference
+// One difference is that the "__decorateClass" function doesn't contain a reference
 // to the non-existent "Reflect.decorate" function. This function was never
 // standardized and checking for it is wasted code (as well as a potentially
 // dangerous cause of unintentional behavior changes in the future).
 //
-// Another difference is that the "__decorate" function doesn't take in an
+// Another difference is that the "__decorateClass" function doesn't take in an
 // optional property descriptor like it does in the official TypeScript
 // compiler's support code. This appears to be a dead code path in the official
 // support code that is only there for legacy reasons.
@@ -318,7 +318,7 @@ var ES5Source = logger.Source{
 //   // TypeScript                      // JavaScript
 //   @dec                               let C = class {
 //   class C {                          };
-//   }                                  C = __decorate([
+//   }                                  C = __decorateClass([
 //                                        dec
 //                                      ], C);
 //
@@ -328,7 +328,7 @@ var ES5Source = logger.Source{
 //   class C {                          class C {
 //     @dec                               foo() {}
 //     foo() {}                         }
-//   }                                  __decorate([
+//   }                                  __decorateClass([
 //                                        dec
 //                                      ], C.prototype, 'foo', 1);
 //
@@ -338,7 +338,7 @@ var ES5Source = logger.Source{
 //   class C {                          class C {
 //     foo(@dec bar) {}                   foo(bar) {}
 //   }                                  }
-//                                      __decorate([
+//                                      __decorateClass([
 //                                        __param(0, dec)
 //                                      ], C.prototype, 'foo', 1);
 //
@@ -350,6 +350,6 @@ var ES5Source = logger.Source{
 //     foo = 123                            this.foo = 123
 //   }                                    }
 //                                      }
-//                                      __decorate([
+//                                      __decorateClass([
 //                                        dec
 //                                      ], C.prototype, 'foo', 2);

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -80,7 +80,7 @@ func code(isES6 bool) string {
 			? __defProp(obj, key, {enumerable: true, configurable: true, writable: true, value})
 			: obj[key] = value
 
-		export var __assign = (a, b) => {
+		export var __objSpread = (a, b) => {
 			for (var prop in b ||= {})
 				if (__hasOwnProp.call(b, prop))
 					__defNormalProp(a, prop, b[prop])

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -152,7 +152,7 @@ func code(isES6 bool) string {
 			for (var name in all)
 				__defProp(target, name, { get: all[name], enumerable: true })
 		}
-		export var __exportStar = (target, module, desc) => {
+		export var __reExport = (target, module, desc) => {
 			if (module && typeof module === 'object' || typeof module === 'function')
 	`
 
@@ -179,7 +179,7 @@ func code(isES6 bool) string {
 
 		// Converts the module from CommonJS to ES6 if necessary
 		export var __toModule = module => {
-			return __exportStar(__markAsModule(
+			return __reExport(__markAsModule(
 				__defProp(
 					module != null ? __create(__getProtoOf(module)) : {},
 					'default',

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -208,7 +208,7 @@ func code(isES6 bool) string {
 				__defProp(target, key, result)
 			return result
 		}
-		export var __param = (index, decorator) => (target, key) => decorator(target, key, index)
+		export var __decorateParam = (index, decorator) => (target, key) => decorator(target, key, index)
 
 		// For class members
 		export var __publicField = (obj, key, value) => {
@@ -339,7 +339,7 @@ var ES5Source = logger.Source{
 //     foo(@dec bar) {}                   foo(bar) {}
 //   }                                  }
 //                                      __decorateClass([
-//                                        __param(0, dec)
+//                                        __decorateParam(0, dec)
 //                                      ], C.prototype, 'foo', 1);
 //
 // ============================= Field decorator ==============================


### PR DESCRIPTION
Helper functions are sometimes used when transforming newer JavaScript syntax for older browsers. For example, `let {x, ...y} = {z}` is transformed into `let _a = {z}, {x} = _a, y = __rest(_a, ["x"])` which uses the `__rest` helper function. Many of esbuild's transforms were modeled after the transforms in the TypeScript compiler, so many of the helper functions use the same names as TypeScript's helper functions.

However, the TypeScript compiler doesn't avoid name collisions with existing identifiers in the transformed code. This means that post-processing esbuild's output with the TypeScript compiler (e.g. for lowering ES6 to ES5) will cause issues since TypeScript will fail to call its own helper functions: https://github.com/microsoft/TypeScript/issues/43296. There is also a problem where TypeScript's `tslib` library overwrites globals with these names, which can overwrite esbuild's helper functions if code bundled with esbuild is run in the global scope.

To avoid these problems, esbuild will now use different names for its helper functions.

Fixes #1102