### PR TITLE
support TS 4.3 `override` syntax

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -1829,7 +1829,7 @@ func (p *parser) parseProperty(kind js_ast.PropertyKind, opts propertyOpts, erro
 						return p.parseProperty(kind, opts, nil)
 					}
 
-				case "private", "protected", "public", "readonly", "abstract", "declare":
+				case "private", "protected", "public", "readonly", "abstract", "declare", "override":
 					// Skip over TypeScript keywords
 					if opts.isClass && p.options.ts.Parse && raw == name {
 						return p.parseProperty(kind, opts, nil)

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -350,6 +350,10 @@ func TestTSClass(t *testing.T) {
 	expectPrintedTS(t, "class Foo { declare foo: number }", "class Foo {\n}\n")
 	expectPrintedTS(t, "class Foo { declare public foo: number }", "class Foo {\n}\n")
 	expectPrintedTS(t, "class Foo { public declare foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { override foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { override public foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { public override foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { declare override public foo: number }", "class Foo {\n}\n")
 
 	expectPrintedTS(t, "class Foo { public static foo: number }", "class Foo {\n}\n")
 	expectPrintedTS(t, "class Foo { private static foo: number }", "class Foo {\n}\n")
@@ -358,6 +362,11 @@ func TestTSClass(t *testing.T) {
 	expectPrintedTS(t, "class Foo { declare public static foo: number }", "class Foo {\n}\n")
 	expectPrintedTS(t, "class Foo { public declare static foo: number }", "class Foo {\n}\n")
 	expectPrintedTS(t, "class Foo { public static declare foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { override static foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { override public static foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { public override static foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { public static override foo: number }", "class Foo {\n}\n")
+	expectPrintedTS(t, "class Foo { declare override public static foo: number }", "class Foo {\n}\n")
 
 	expectPrintedTS(t, "class Foo { [key: string]: any\nfoo = 0 }", "class Foo {\n  constructor() {\n    this.foo = 0;\n  }\n}\n")
 	expectPrintedTS(t, "class Foo { [key: string]: any; foo = 0 }", "class Foo {\n  constructor() {\n    this.foo = 0;\n  }\n}\n")


### PR DESCRIPTION
Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-3-beta/#override-and-the-noimplicitoverride-flag