### PR TITLE
Use xxHash instead of SHA1 for speed

### DIFF
--- a/internal/bundler/snapshots/snapshots_css.txt
+++ b/internal/bundler/snapshots/snapshots_css.txt
@@ -18,7 +18,7 @@ TestCSSAndJavaScriptCodeSplittingIssue1064
 ---------- /out/a.js ----------
 import {
   shared_default
-} from "./chunk-JWQFE3AN.js";
+} from "./chunk-JHSNRTG6.js";
 
 // a.js
 console.log(shared_default() + 1);
@@ -26,12 +26,12 @@ console.log(shared_default() + 1);
 ---------- /out/b.js ----------
 import {
   shared_default
-} from "./chunk-JWQFE3AN.js";
+} from "./chunk-JHSNRTG6.js";
 
 // b.js
 console.log(shared_default() + 2);
 
----------- /out/chunk-JWQFE3AN.js ----------
+---------- /out/chunk-JHSNRTG6.js ----------
 // shared.js
 function shared_default() {
   return 3;
@@ -53,7 +53,7 @@ body {
   color: blue;
 }
 
----------- /out/chunk-Y6KZESIP.css ----------
+---------- /out/chunk-C7T4PGKL.css ----------
 /* shared.css */
 body {
   background: black;
@@ -183,17 +183,17 @@ path {
 
 ================================================================================
 TestFileImportURLInCSS
----------- /out/example-RPS4CMHF.data ----------
+---------- /out/example-GDKWWYFY.data ----------
 This is some data.
 ---------- /out/entry.css ----------
 /* one.css */
 a {
-  background: url(./example-RPS4CMHF.data);
+  background: url(./example-GDKWWYFY.data);
 }
 
 /* two.css */
 b {
-  background: url(./example-RPS4CMHF.data);
+  background: url(./example-GDKWWYFY.data);
 }
 
 /* entry.css */

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1320,14 +1320,14 @@ console.log(a, b);
 
 ================================================================================
 TestLoaderFileWithQueryParameter
----------- /out/file-JAWLBT6L.txt ----------
+---------- /out/file-UEHVHXRQ.txt ----------
 This is some text
 ---------- /out/entry.js ----------
 // file.txt?foo
-var file_default = "./file-JAWLBT6L.txt?foo";
+var file_default = "./file-UEHVHXRQ.txt?foo";
 
 // file.txt?bar
-var file_default2 = "./file-JAWLBT6L.txt?bar";
+var file_default2 = "./file-UEHVHXRQ.txt?bar";
 
 // entry.js
 console.log(file_default, file_default2);
@@ -2650,26 +2650,26 @@ var import_es6_ns_export_abstract_class = __toModule(require_es6_ns_export_abstr
 TestTopLevelAwaitAllowedImportWithSplitting
 ---------- /out/entry.js ----------
 // entry.js
-import("./a-4AEJWCHS.js");
-import("./b-6EB7BLIM.js");
-import("./c-VSFX3WL4.js");
+import("./a-ZK7H2YZU.js");
+import("./b-MPIVDXIR.js");
+import("./c-F7O26T5D.js");
 require_entry();
 await 0;
 
----------- /out/a-4AEJWCHS.js ----------
-import "./chunk-K5FAGUED.js";
-import "./chunk-7Y4CCLAO.js";
+---------- /out/a-ZK7H2YZU.js ----------
+import "./chunk-BYXBJQAS.js";
+import "./chunk-34XDKUTO.js";
 
----------- /out/b-6EB7BLIM.js ----------
-import "./chunk-K5FAGUED.js";
-import "./chunk-7Y4CCLAO.js";
+---------- /out/b-MPIVDXIR.js ----------
+import "./chunk-BYXBJQAS.js";
+import "./chunk-34XDKUTO.js";
 
----------- /out/chunk-K5FAGUED.js ----------
+---------- /out/chunk-BYXBJQAS.js ----------
 
----------- /out/c-VSFX3WL4.js ----------
-import "./chunk-7Y4CCLAO.js";
+---------- /out/c-F7O26T5D.js ----------
+import "./chunk-34XDKUTO.js";
 
----------- /out/chunk-7Y4CCLAO.js ----------
+---------- /out/chunk-34XDKUTO.js ----------
 // c.js
 await 0;
 

--- a/internal/bundler/snapshots/snapshots_loader.txt
+++ b/internal/bundler/snapshots/snapshots_loader.txt
@@ -46,12 +46,12 @@ console.log(x_url, y_default);
 
 ================================================================================
 TestLoaderFile
----------- /out/test-T3K5TRK4.svg ----------
+---------- /out/test-IPILGNO5.svg ----------
 <svg></svg>
 ---------- /out/entry.js ----------
 // test.svg
 var require_test = __commonJS((exports, module) => {
-  module.exports = "./test-T3K5TRK4.svg";
+  module.exports = "./test-IPILGNO5.svg";
 });
 
 // entry.js
@@ -59,18 +59,18 @@ console.log(require_test());
 
 ================================================================================
 TestLoaderFileCommonJSAndES6
----------- /y-SXFQX7JJ.txt ----------
+---------- /y-YE5AYNFB.txt ----------
 y
----------- /x-CH3K3DWF.txt ----------
+---------- /x-LSAMBFUD.txt ----------
 x
 ---------- /out.js ----------
 // x.txt
 var require_x = __commonJS((exports, module) => {
-  module.exports = "./x-CH3K3DWF.txt";
+  module.exports = "./x-LSAMBFUD.txt";
 });
 
 // y.txt
-var y_default = "./y-SXFQX7JJ.txt";
+var y_default = "./y-YE5AYNFB.txt";
 
 // entry.js
 var x_url = require_x();
@@ -78,17 +78,17 @@ console.log(x_url, y_default);
 
 ================================================================================
 TestLoaderFileMultipleNoCollision
----------- /dist/test-VFFI7ZOM.txt ----------
+---------- /dist/test-J7OMUXO3.txt ----------
 test
 ---------- /dist/out.js ----------
 // a/test.txt
 var require_test = __commonJS((exports, module) => {
-  module.exports = "./test-VFFI7ZOM.txt";
+  module.exports = "./test-J7OMUXO3.txt";
 });
 
 // b/test.txt
 var require_test2 = __commonJS((exports, module) => {
-  module.exports = "./test-VFFI7ZOM.txt";
+  module.exports = "./test-J7OMUXO3.txt";
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_splitting.txt
+++ b/internal/bundler/snapshots/snapshots_splitting.txt
@@ -9,7 +9,7 @@ TestSplittingAssignToLocal
 import {
   foo,
   setFoo
-} from "./chunk-GTAJUI3Z.js";
+} from "./chunk-TPCZRFNC.js";
 
 // a.js
 setFoo(123);
@@ -18,12 +18,12 @@ console.log(foo);
 ---------- /out/b.js ----------
 import {
   foo
-} from "./chunk-GTAJUI3Z.js";
+} from "./chunk-TPCZRFNC.js";
 
 // b.js
 console.log(foo);
 
----------- /out/chunk-GTAJUI3Z.js ----------
+---------- /out/chunk-TPCZRFNC.js ----------
 // shared.js
 var foo;
 function setFoo(value) {
@@ -41,7 +41,7 @@ TestSplittingCircularReferenceIssue251
 import {
   p,
   q
-} from "./chunk-TNYF4Q76.js";
+} from "./chunk-G2XWJIBP.js";
 export {
   p,
   q
@@ -51,13 +51,13 @@ export {
 import {
   p,
   q
-} from "./chunk-TNYF4Q76.js";
+} from "./chunk-G2XWJIBP.js";
 export {
   p,
   q
 };
 
----------- /out/chunk-TNYF4Q76.js ----------
+---------- /out/chunk-G2XWJIBP.js ----------
 // a.js
 var p = 5;
 
@@ -74,15 +74,15 @@ TestSplittingCrossChunkAssignmentDependencies
 ---------- /out/a.js ----------
 import {
   setValue
-} from "./chunk-TGFRGD76.js";
+} from "./chunk-HVACKF5T.js";
 
 // a.js
 setValue(123);
 
 ---------- /out/b.js ----------
-import "./chunk-TGFRGD76.js";
+import "./chunk-HVACKF5T.js";
 
----------- /out/chunk-TGFRGD76.js ----------
+---------- /out/chunk-HVACKF5T.js ----------
 // shared.js
 var observer;
 var value;
@@ -105,7 +105,7 @@ TestSplittingCrossChunkAssignmentDependenciesRecursive
 ---------- /out/a.js ----------
 import {
   setX
-} from "./chunk-75SXVHUV.js";
+} from "./chunk-IDNNK5VP.js";
 
 // a.js
 setX();
@@ -113,8 +113,8 @@ setX();
 ---------- /out/b.js ----------
 import {
   setZ
-} from "./chunk-6EC7U6VG.js";
-import "./chunk-75SXVHUV.js";
+} from "./chunk-XQAYB53B.js";
+import "./chunk-IDNNK5VP.js";
 
 // b.js
 setZ();
@@ -123,20 +123,20 @@ setZ();
 import {
   setY2,
   setZ2
-} from "./chunk-6EC7U6VG.js";
+} from "./chunk-XQAYB53B.js";
 import {
   setX2
-} from "./chunk-75SXVHUV.js";
+} from "./chunk-IDNNK5VP.js";
 
 // c.js
 setX2();
 setY2();
 setZ2();
 
----------- /out/chunk-6EC7U6VG.js ----------
+---------- /out/chunk-XQAYB53B.js ----------
 import {
   setX
-} from "./chunk-75SXVHUV.js";
+} from "./chunk-IDNNK5VP.js";
 
 // y.js
 var _y;
@@ -164,7 +164,7 @@ export {
   setZ2
 };
 
----------- /out/chunk-75SXVHUV.js ----------
+---------- /out/chunk-IDNNK5VP.js ----------
 // x.js
 var _x;
 function setX(v) {
@@ -182,21 +182,21 @@ export {
 ================================================================================
 TestSplittingDuplicateChunkCollision
 ---------- /out/a.js ----------
-import"./chunk-4T5H7UUE.js";
+import"./chunk-EG4ZQE7C.js";
 
 ---------- /out/b.js ----------
-import"./chunk-4T5H7UUE.js";
+import"./chunk-EG4ZQE7C.js";
 
----------- /out/chunk-4T5H7UUE.js ----------
+---------- /out/chunk-EG4ZQE7C.js ----------
 console.log(123);
 
 ---------- /out/c.js ----------
-import"./chunk-XC3EKDXN.js";
+import"./chunk-YEYDWHHT.js";
 
 ---------- /out/d.js ----------
-import"./chunk-XC3EKDXN.js";
+import"./chunk-YEYDWHHT.js";
 
----------- /out/chunk-XC3EKDXN.js ----------
+---------- /out/chunk-YEYDWHHT.js ----------
 console.log(123);
 
 ================================================================================
@@ -205,19 +205,19 @@ TestSplittingDynamicAndNotDynamicCommonJSIntoES6
 import {
   __toModule,
   require_foo
-} from "./chunk-THTO4X5I.js";
+} from "./chunk-NAN7I22W.js";
 
 // entry.js
 var import_foo = __toModule(require_foo());
-import("./foo-O5HS6I4Y.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
+import("./foo-GCHTONSU.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
 
----------- /out/foo-O5HS6I4Y.js ----------
+---------- /out/foo-GCHTONSU.js ----------
 import {
   require_foo
-} from "./chunk-THTO4X5I.js";
+} from "./chunk-NAN7I22W.js";
 export default require_foo();
 
----------- /out/chunk-THTO4X5I.js ----------
+---------- /out/chunk-NAN7I22W.js ----------
 // foo.js
 var require_foo = __commonJS((exports) => {
   exports.bar = 123;
@@ -233,20 +233,20 @@ TestSplittingDynamicAndNotDynamicES6IntoES6
 ---------- /out/entry.js ----------
 import {
   bar
-} from "./chunk-H5N7CGKD.js";
+} from "./chunk-A3NXEA7F.js";
 
 // entry.js
-import("./foo-JI3FODLQ.js").then(({bar: b}) => console.log(bar, b));
+import("./foo-ZFJDZWZM.js").then(({bar: b}) => console.log(bar, b));
 
----------- /out/foo-JI3FODLQ.js ----------
+---------- /out/foo-ZFJDZWZM.js ----------
 import {
   bar
-} from "./chunk-H5N7CGKD.js";
+} from "./chunk-A3NXEA7F.js";
 export {
   bar
 };
 
----------- /out/chunk-H5N7CGKD.js ----------
+---------- /out/chunk-A3NXEA7F.js ----------
 // foo.js
 var bar = 123;
 
@@ -258,9 +258,9 @@ export {
 TestSplittingDynamicCommonJSIntoES6
 ---------- /out/entry.js ----------
 // entry.js
-import("./foo-JL7J2HWZ.js").then(({default: {bar}}) => console.log(bar));
+import("./foo-2YYMPLZI.js").then(({default: {bar}}) => console.log(bar));
 
----------- /out/foo-JL7J2HWZ.js ----------
+---------- /out/foo-2YYMPLZI.js ----------
 // foo.js
 var require_foo = __commonJS((exports) => {
   exports.bar = 123;
@@ -271,9 +271,9 @@ export default require_foo();
 TestSplittingDynamicES6IntoES6
 ---------- /out/entry.js ----------
 // entry.js
-import("./foo-X5YA5FZI.js").then(({bar}) => console.log(bar));
+import("./foo-F64I22OH.js").then(({bar}) => console.log(bar));
 
----------- /out/foo-X5YA5FZI.js ----------
+---------- /out/foo-F64I22OH.js ----------
 // foo.js
 var bar = 123;
 export {
@@ -297,13 +297,13 @@ export {
 TestSplittingDynamicImportOutsideSourceTreeIssue264
 ---------- /out/entry1.js ----------
 // Users/user/project/src/entry1.js
-import("./package-VNMD6VBC.js");
+import("./package-UW4GHB5S.js");
 
 ---------- /out/entry2.js ----------
 // Users/user/project/src/entry2.js
-import("./package-VNMD6VBC.js");
+import("./package-UW4GHB5S.js");
 
----------- /out/package-VNMD6VBC.js ----------
+---------- /out/package-UW4GHB5S.js ----------
 // Users/user/project/node_modules/package/index.js
 console.log("imported");
 
@@ -313,7 +313,7 @@ TestSplittingHybridESMAndCJSIssue617
 import {
   foo,
   init_a
-} from "./chunk-W4X67SGW.js";
+} from "./chunk-UHVVO4ZE.js";
 init_a();
 export {
   foo
@@ -323,7 +323,7 @@ export {
 import {
   a_exports,
   init_a
-} from "./chunk-W4X67SGW.js";
+} from "./chunk-UHVVO4ZE.js";
 
 // b.js
 var bar = (init_a(), a_exports);
@@ -331,7 +331,7 @@ export {
   bar
 };
 
----------- /out/chunk-W4X67SGW.js ----------
+---------- /out/chunk-UHVVO4ZE.js ----------
 // a.js
 var a_exports = {};
 __export(a_exports, {
@@ -352,7 +352,7 @@ TestSplittingMinifyIdentifiersCrashIssue437
 ---------- /out/a.js ----------
 import {
   a as o
-} from "./chunk-IS477MWU.js";
+} from "./chunk-R2S2ETVH.js";
 
 // a.js
 console.log(o);
@@ -360,15 +360,15 @@ console.log(o);
 ---------- /out/b.js ----------
 import {
   a as o
-} from "./chunk-IS477MWU.js";
+} from "./chunk-R2S2ETVH.js";
 
 // b.js
 console.log(o);
 
 ---------- /out/c.js ----------
-import "./chunk-IS477MWU.js";
+import "./chunk-R2S2ETVH.js";
 
----------- /out/chunk-IS477MWU.js ----------
+---------- /out/chunk-R2S2ETVH.js ----------
 // shared.js
 function n(o) {
 }
@@ -382,7 +382,7 @@ TestSplittingMissingLazyExport
 ---------- /out/a.js ----------
 import {
   foo
-} from "./chunk-R2FSE7OU.js";
+} from "./chunk-36BLICPM.js";
 
 // a.js
 console.log(foo());
@@ -390,12 +390,12 @@ console.log(foo());
 ---------- /out/b.js ----------
 import {
   bar
-} from "./chunk-R2FSE7OU.js";
+} from "./chunk-36BLICPM.js";
 
 // b.js
 console.log(bar());
 
----------- /out/chunk-R2FSE7OU.js ----------
+---------- /out/chunk-36BLICPM.js ----------
 // empty.js
 var empty_exports = {};
 
@@ -417,7 +417,7 @@ TestSplittingNestedDirectories
 ---------- /Users/user/project/out/pageA/page.js ----------
 import {
   shared_default
-} from "../chunk-5UB6FEQF.js";
+} from "../chunk-7WMS7BBG.js";
 
 // Users/user/project/src/pages/pageA/page.js
 console.log(shared_default);
@@ -425,12 +425,12 @@ console.log(shared_default);
 ---------- /Users/user/project/out/pageB/page.js ----------
 import {
   shared_default
-} from "../chunk-5UB6FEQF.js";
+} from "../chunk-7WMS7BBG.js";
 
 // Users/user/project/src/pages/pageB/page.js
 console.log(-shared_default);
 
----------- /Users/user/project/out/chunk-5UB6FEQF.js ----------
+---------- /Users/user/project/out/chunk-7WMS7BBG.js ----------
 // Users/user/project/src/pages/shared.js
 var shared_default = 123;
 
@@ -442,9 +442,9 @@ export {
 TestSplittingPublicPathEntryName
 ---------- /out/a.js ----------
 // a.js
-import("/www/b-B4DKQN35.js");
+import("/www/b-UNIUFLXI.js");
 
----------- /out/b-B4DKQN35.js ----------
+---------- /out/b-UNIUFLXI.js ----------
 // b.js
 console.log("b");
 
@@ -453,7 +453,7 @@ TestSplittingReExportIssue273
 ---------- /out/a.js ----------
 import {
   a
-} from "./chunk-MIMHPL7U.js";
+} from "./chunk-OBLLZOHJ.js";
 export {
   a
 };
@@ -461,12 +461,12 @@ export {
 ---------- /out/b.js ----------
 import {
   a
-} from "./chunk-MIMHPL7U.js";
+} from "./chunk-OBLLZOHJ.js";
 export {
   a
 };
 
----------- /out/chunk-MIMHPL7U.js ----------
+---------- /out/chunk-OBLLZOHJ.js ----------
 // a.js
 var a = 1;
 
@@ -479,7 +479,7 @@ TestSplittingSharedCommonJSIntoES6
 ---------- /out/a.js ----------
 import {
   require_shared
-} from "./chunk-6QFZUCAJ.js";
+} from "./chunk-JWGRGYBR.js";
 
 // a.js
 var {foo} = require_shared();
@@ -488,13 +488,13 @@ console.log(foo);
 ---------- /out/b.js ----------
 import {
   require_shared
-} from "./chunk-6QFZUCAJ.js";
+} from "./chunk-JWGRGYBR.js";
 
 // b.js
 var {foo} = require_shared();
 console.log(foo);
 
----------- /out/chunk-6QFZUCAJ.js ----------
+---------- /out/chunk-JWGRGYBR.js ----------
 // shared.js
 var require_shared = __commonJS((exports) => {
   exports.foo = 123;
@@ -509,7 +509,7 @@ TestSplittingSharedES6IntoES6
 ---------- /out/a.js ----------
 import {
   foo
-} from "./chunk-PLTAVKRZ.js";
+} from "./chunk-YKAJFEJE.js";
 
 // a.js
 console.log(foo);
@@ -517,12 +517,12 @@ console.log(foo);
 ---------- /out/b.js ----------
 import {
   foo
-} from "./chunk-PLTAVKRZ.js";
+} from "./chunk-YKAJFEJE.js";
 
 // b.js
 console.log(foo);
 
----------- /out/chunk-PLTAVKRZ.js ----------
+---------- /out/chunk-YKAJFEJE.js ----------
 // shared.js
 var foo = 123;
 
@@ -535,7 +535,7 @@ TestSplittingSideEffectsWithoutDependencies
 ---------- /out/a.js ----------
 import {
   a
-} from "./chunk-S7YX2BOR.js";
+} from "./chunk-TWOYFNBQ.js";
 
 // a.js
 console.log(a);
@@ -543,12 +543,12 @@ console.log(a);
 ---------- /out/b.js ----------
 import {
   b
-} from "./chunk-S7YX2BOR.js";
+} from "./chunk-TWOYFNBQ.js";
 
 // b.js
 console.log(b);
 
----------- /out/chunk-S7YX2BOR.js ----------
+---------- /out/chunk-TWOYFNBQ.js ----------
 // shared.js
 var a = 1;
 var b = 2;

--- a/internal/xxhash/LICENSE.txt
+++ b/internal/xxhash/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2016 Caleb Spare
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/xxhash/README.md
+++ b/internal/xxhash/README.md
@@ -1,0 +1,1 @@
+This Go implementation of xxHash is from https://github.com/cespare/xxhash.

--- a/internal/xxhash/xxhash.go
+++ b/internal/xxhash/xxhash.go
@@ -1,0 +1,235 @@
+// Package xxhash implements the 64-bit variant of xxHash (XXH64) as described
+// at http://cyan4973.github.io/xxHash/.
+package xxhash
+
+import (
+	"encoding/binary"
+	"errors"
+	"math/bits"
+)
+
+const (
+	prime1 uint64 = 11400714785074694791
+	prime2 uint64 = 14029467366897019727
+	prime3 uint64 = 1609587929392839161
+	prime4 uint64 = 9650029242287828579
+	prime5 uint64 = 2870177450012600261
+)
+
+// NOTE(caleb): I'm using both consts and vars of the primes. Using consts where
+// possible in the Go code is worth a small (but measurable) performance boost
+// by avoiding some MOVQs. Vars are needed for the asm and also are useful for
+// convenience in the Go code in a few places where we need to intentionally
+// avoid constant arithmetic (e.g., v1 := prime1 + prime2 fails because the
+// result overflows a uint64).
+var (
+	prime1v = prime1
+	prime2v = prime2
+	prime3v = prime3
+	prime4v = prime4
+	prime5v = prime5
+)
+
+// Digest implements hash.Hash64.
+type Digest struct {
+	v1    uint64
+	v2    uint64
+	v3    uint64
+	v4    uint64
+	total uint64
+	mem   [32]byte
+	n     int // how much of mem is used
+}
+
+// New creates a new Digest that computes the 64-bit xxHash algorithm.
+func New() *Digest {
+	var d Digest
+	d.Reset()
+	return &d
+}
+
+// Reset clears the Digest's state so that it can be reused.
+func (d *Digest) Reset() {
+	d.v1 = prime1v + prime2
+	d.v2 = prime2
+	d.v3 = 0
+	d.v4 = -prime1v
+	d.total = 0
+	d.n = 0
+}
+
+// Size always returns 8 bytes.
+func (d *Digest) Size() int { return 8 }
+
+// BlockSize always returns 32 bytes.
+func (d *Digest) BlockSize() int { return 32 }
+
+// Write adds more data to d. It always returns len(b), nil.
+func (d *Digest) Write(b []byte) (n int, err error) {
+	n = len(b)
+	d.total += uint64(n)
+
+	if d.n+n < 32 {
+		// This new data doesn't even fill the current block.
+		copy(d.mem[d.n:], b)
+		d.n += n
+		return
+	}
+
+	if d.n > 0 {
+		// Finish off the partial block.
+		copy(d.mem[d.n:], b)
+		d.v1 = round(d.v1, u64(d.mem[0:8]))
+		d.v2 = round(d.v2, u64(d.mem[8:16]))
+		d.v3 = round(d.v3, u64(d.mem[16:24]))
+		d.v4 = round(d.v4, u64(d.mem[24:32]))
+		b = b[32-d.n:]
+		d.n = 0
+	}
+
+	if len(b) >= 32 {
+		// One or more full blocks left.
+		nw := writeBlocks(d, b)
+		b = b[nw:]
+	}
+
+	// Store any remaining partial block.
+	copy(d.mem[:], b)
+	d.n = len(b)
+
+	return
+}
+
+// Sum appends the current hash to b and returns the resulting slice.
+func (d *Digest) Sum(b []byte) []byte {
+	s := d.Sum64()
+	return append(
+		b,
+		byte(s>>56),
+		byte(s>>48),
+		byte(s>>40),
+		byte(s>>32),
+		byte(s>>24),
+		byte(s>>16),
+		byte(s>>8),
+		byte(s),
+	)
+}
+
+// Sum64 returns the current hash.
+func (d *Digest) Sum64() uint64 {
+	var h uint64
+
+	if d.total >= 32 {
+		v1, v2, v3, v4 := d.v1, d.v2, d.v3, d.v4
+		h = rol1(v1) + rol7(v2) + rol12(v3) + rol18(v4)
+		h = mergeRound(h, v1)
+		h = mergeRound(h, v2)
+		h = mergeRound(h, v3)
+		h = mergeRound(h, v4)
+	} else {
+		h = d.v3 + prime5
+	}
+
+	h += d.total
+
+	i, end := 0, d.n
+	for ; i+8 <= end; i += 8 {
+		k1 := round(0, u64(d.mem[i:i+8]))
+		h ^= k1
+		h = rol27(h)*prime1 + prime4
+	}
+	if i+4 <= end {
+		h ^= uint64(u32(d.mem[i:i+4])) * prime1
+		h = rol23(h)*prime2 + prime3
+		i += 4
+	}
+	for i < end {
+		h ^= uint64(d.mem[i]) * prime5
+		h = rol11(h) * prime1
+		i++
+	}
+
+	h ^= h >> 33
+	h *= prime2
+	h ^= h >> 29
+	h *= prime3
+	h ^= h >> 32
+
+	return h
+}
+
+const (
+	magic         = "xxh\x06"
+	marshaledSize = len(magic) + 8*5 + 32
+)
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (d *Digest) MarshalBinary() ([]byte, error) {
+	b := make([]byte, 0, marshaledSize)
+	b = append(b, magic...)
+	b = appendUint64(b, d.v1)
+	b = appendUint64(b, d.v2)
+	b = appendUint64(b, d.v3)
+	b = appendUint64(b, d.v4)
+	b = appendUint64(b, d.total)
+	b = append(b, d.mem[:d.n]...)
+	b = b[:len(b)+len(d.mem)-d.n]
+	return b, nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (d *Digest) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic) || string(b[:len(magic)]) != magic {
+		return errors.New("xxhash: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize {
+		return errors.New("xxhash: invalid hash state size")
+	}
+	b = b[len(magic):]
+	b, d.v1 = consumeUint64(b)
+	b, d.v2 = consumeUint64(b)
+	b, d.v3 = consumeUint64(b)
+	b, d.v4 = consumeUint64(b)
+	b, d.total = consumeUint64(b)
+	copy(d.mem[:], b)
+	d.n = int(d.total % uint64(len(d.mem)))
+	return nil
+}
+
+func appendUint64(b []byte, x uint64) []byte {
+	var a [8]byte
+	binary.LittleEndian.PutUint64(a[:], x)
+	return append(b, a[:]...)
+}
+
+func consumeUint64(b []byte) ([]byte, uint64) {
+	x := u64(b)
+	return b[8:], x
+}
+
+func u64(b []byte) uint64 { return binary.LittleEndian.Uint64(b) }
+func u32(b []byte) uint32 { return binary.LittleEndian.Uint32(b) }
+
+func round(acc, input uint64) uint64 {
+	acc += input * prime2
+	acc = rol31(acc)
+	acc *= prime1
+	return acc
+}
+
+func mergeRound(acc, val uint64) uint64 {
+	val = round(0, val)
+	acc ^= val
+	acc = acc*prime1 + prime4
+	return acc
+}
+
+func rol1(x uint64) uint64  { return bits.RotateLeft64(x, 1) }
+func rol7(x uint64) uint64  { return bits.RotateLeft64(x, 7) }
+func rol11(x uint64) uint64 { return bits.RotateLeft64(x, 11) }
+func rol12(x uint64) uint64 { return bits.RotateLeft64(x, 12) }
+func rol18(x uint64) uint64 { return bits.RotateLeft64(x, 18) }
+func rol23(x uint64) uint64 { return bits.RotateLeft64(x, 23) }
+func rol27(x uint64) uint64 { return bits.RotateLeft64(x, 27) }
+func rol31(x uint64) uint64 { return bits.RotateLeft64(x, 31) }

--- a/internal/xxhash/xxhash_other.go
+++ b/internal/xxhash/xxhash_other.go
@@ -1,0 +1,74 @@
+package xxhash
+
+// Sum64 computes the 64-bit xxHash digest of b.
+func Sum64(b []byte) uint64 {
+	// A simpler version would be
+	//   d := New()
+	//   d.Write(b)
+	//   return d.Sum64()
+	// but this is faster, particularly for small inputs.
+
+	n := len(b)
+	var h uint64
+
+	if n >= 32 {
+		v1 := prime1v + prime2
+		v2 := prime2
+		v3 := uint64(0)
+		v4 := -prime1v
+		for len(b) >= 32 {
+			v1 = round(v1, u64(b[0:8:len(b)]))
+			v2 = round(v2, u64(b[8:16:len(b)]))
+			v3 = round(v3, u64(b[16:24:len(b)]))
+			v4 = round(v4, u64(b[24:32:len(b)]))
+			b = b[32:len(b):len(b)]
+		}
+		h = rol1(v1) + rol7(v2) + rol12(v3) + rol18(v4)
+		h = mergeRound(h, v1)
+		h = mergeRound(h, v2)
+		h = mergeRound(h, v3)
+		h = mergeRound(h, v4)
+	} else {
+		h = prime5
+	}
+
+	h += uint64(n)
+
+	i, end := 0, len(b)
+	for ; i+8 <= end; i += 8 {
+		k1 := round(0, u64(b[i:i+8:len(b)]))
+		h ^= k1
+		h = rol27(h)*prime1 + prime4
+	}
+	if i+4 <= end {
+		h ^= uint64(u32(b[i:i+4:len(b)])) * prime1
+		h = rol23(h)*prime2 + prime3
+		i += 4
+	}
+	for ; i < end; i++ {
+		h ^= uint64(b[i]) * prime5
+		h = rol11(h) * prime1
+	}
+
+	h ^= h >> 33
+	h *= prime2
+	h ^= h >> 29
+	h *= prime3
+	h ^= h >> 32
+
+	return h
+}
+
+func writeBlocks(d *Digest, b []byte) int {
+	v1, v2, v3, v4 := d.v1, d.v2, d.v3, d.v4
+	n := len(b)
+	for len(b) >= 32 {
+		v1 = round(v1, u64(b[0:8:len(b)]))
+		v2 = round(v2, u64(b[8:16:len(b)]))
+		v3 = round(v3, u64(b[16:24:len(b)]))
+		v4 = round(v4, u64(b[24:32:len(b)]))
+		b = b[32:len(b):len(b)]
+	}
+	d.v1, d.v2, d.v3, d.v4 = v1, v2, v3, v4
+	return n - len(b)
+}

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -524,7 +524,7 @@ let buildTests = {
     })
     assert.strictEqual(value.outputFiles, void 0)
     const result = require(output)
-    assert.strictEqual(result.value, './data-L3XDQOAT.bin')
+    assert.strictEqual(result.value, './data-BYATPJRB.bin')
     assert.strictEqual(result.__esModule, true)
   },
 
@@ -551,17 +551,17 @@ let buildTests = {
     assert.deepStrictEqual(value.outputFiles.length, 3)
     assert.deepStrictEqual(value.outputFiles[0].path, path.join(outdir, 'a', 'in1.js'))
     assert.deepStrictEqual(value.outputFiles[1].path, path.join(outdir, 'b', 'in2.js'))
-    assert.deepStrictEqual(value.outputFiles[2].path, path.join(outdir, 'chunk-YDJKVLBN.js'))
+    assert.deepStrictEqual(value.outputFiles[2].path, path.join(outdir, 'chunk-JFWYZSOB.js'))
     assert.deepStrictEqual(value.outputFiles[0].text, `import {
   foo
-} from "https://www.example.com/assets/chunk-YDJKVLBN.js";
+} from "https://www.example.com/assets/chunk-JFWYZSOB.js";
 export {
   foo as input1
 };
 `)
     assert.deepStrictEqual(value.outputFiles[1].text, `import {
   foo
-} from "https://www.example.com/assets/chunk-YDJKVLBN.js";
+} from "https://www.example.com/assets/chunk-JFWYZSOB.js";
 export {
   foo as input2
 };
@@ -593,7 +593,7 @@ export {
     })
     assert.strictEqual(value.outputFiles, void 0)
     const result = require(output)
-    assert.strictEqual(result.value, 'https://www.example.com/assets/data-L3XDQOAT.bin')
+    assert.strictEqual(result.value, 'https://www.example.com/assets/data-BYATPJRB.bin')
     assert.strictEqual(result.__esModule, true)
   },
 
@@ -613,7 +613,7 @@ export {
     assert.strictEqual(value.outputFiles, void 0)
     assert.strictEqual(await readFileAsync(output, 'utf8'), `/* scripts/.js-api-tests/fileLoaderCSS/in.css */
 body {
-  background: url(https://www.example.com/assets/data-L3XDQOAT.bin);
+  background: url(https://www.example.com/assets/data-BYATPJRB.bin);
 }
 `)
   },
@@ -634,7 +634,7 @@ body {
     })
     assert.strictEqual(value.outputFiles, void 0)
     const result = require(path.join(outdir, path.basename(input)))
-    assert.strictEqual(result.value, './assets/name=data/hash=L3XDQOAT.bin')
+    assert.strictEqual(result.value, './assets/name=data/hash=BYATPJRB.bin')
     assert.strictEqual(result.__esModule, true)
     const stuff = fs.readFileSync(path.join(outdir, result.value), 'utf8')
     assert.strictEqual(stuff, 'stuff')
@@ -657,9 +657,9 @@ body {
     })
     assert.strictEqual(value.outputFiles, void 0)
     const result = require(path.join(outdir, path.basename(input)))
-    assert.strictEqual(result.value, 'https://www.example.com/assets/name=data/hash=L3XDQOAT.bin')
+    assert.strictEqual(result.value, 'https://www.example.com/assets/name=data/hash=BYATPJRB.bin')
     assert.strictEqual(result.__esModule, true)
-    const stuff = fs.readFileSync(path.join(outdir, 'assets', 'name=data', 'hash=L3XDQOAT.bin'), 'utf8')
+    const stuff = fs.readFileSync(path.join(outdir, 'assets', 'name=data', 'hash=BYATPJRB.bin'), 'utf8')
     assert.strictEqual(stuff, 'stuff')
   },
 
@@ -798,7 +798,7 @@ body {
     const inEntry1 = makeInPath(entry1);
     const inEntry2 = makeInPath(entry2);
     const inImported = makeInPath(imported);
-    const chunk = 'chunk-IC5SAOF3.js';
+    const chunk = 'chunk-LJJNJUOL.js';
     const outEntry1 = makeOutPath(path.basename(entry1));
     const outEntry2 = makeOutPath(path.basename(entry2));
     const outChunk = makeOutPath(chunk);
@@ -862,7 +862,7 @@ body {
     const inEntry1 = makeInPath(entry1);
     const inEntry2 = makeInPath(entry2);
     const inImported = makeInPath(imported);
-    const chunk = 'chunk-D224I4QE.js';
+    const chunk = 'chunk-GIKHG2FZ.js';
     const outEntry1 = makeOutPath(path.basename(entry1));
     const outEntry2 = makeOutPath(path.basename(entry2));
     const outChunk = makeOutPath(chunk);
@@ -928,10 +928,10 @@ body {
     const inImport1 = makeInPath(import1);
     const inImport2 = makeInPath(import2);
     const inShared = makeInPath(shared);
-    const chunk = 'chunk-5CIBHJEX.js';
+    const chunk = 'chunk-M3UIZNA6.js';
     const outEntry = makeOutPath(path.relative(testDir, entry));
-    const outImport1 = makeOutPath('import1-S4GWUXIT.js');
-    const outImport2 = makeOutPath('import2-4GH3MAF7.js');
+    const outImport1 = makeOutPath('import1-RW4RT54M.js');
+    const outImport2 = makeOutPath('import2-QZ6YEQ7N.js');
     const outChunk = makeOutPath(chunk);
 
     assert.deepStrictEqual(json.inputs[inEntry], {
@@ -1280,7 +1280,7 @@ body {
     assert.strictEqual(value.outputFiles.length, 3)
 
     // These should all use forward slashes, even on Windows
-    const chunk = 'chunk-K7G5LPZA.js'
+    const chunk = 'chunk-EUXSFQEB.js'
     assert.strictEqual(Buffer.from(value.outputFiles[0].contents).toString(), `import {
   common_default
 } from "./${chunk}";
@@ -1337,7 +1337,7 @@ export {
     assert.strictEqual(value.outputFiles.length, 3)
 
     // These should all use forward slashes, even on Windows
-    const chunk = 'chunk-DTXWZ5FH.js'
+    const chunk = 'chunk-O2E3MTYM.js'
     assert.strictEqual(Buffer.from(value.outputFiles[0].contents).toString(), `import {
   common_default
 } from "../${chunk}";
@@ -1395,7 +1395,7 @@ export {
     assert.strictEqual(value.outputFiles.length, 3)
 
     // These should all use forward slashes, even on Windows
-    const chunk = 'chunks/name=chunk/hash=GKMMFTN3.js'
+    const chunk = 'chunks/name=chunk/hash=CHYWWIG3.js'
     assert.strictEqual(value.outputFiles[0].text, `import {
   common_default
 } from "../${chunk}";
@@ -1454,7 +1454,7 @@ export {
     assert.strictEqual(value.outputFiles.length, 3)
 
     // These should all use forward slashes, even on Windows
-    const chunk = 'chunks/name=chunk/hash=AJOY4XLB.js'
+    const chunk = 'chunks/name=chunk/hash=Q52CWN2F.js'
     assert.strictEqual(value.outputFiles[0].text, `import {
   common_default
 } from "../../${chunk}";
@@ -1477,8 +1477,8 @@ export {
 };
 `)
 
-    const outputA = 'entry/name=demo/hash=BCTKNBQJ.js'
-    const outputB = 'entry/name=demo/hash=O7DZ2ISM.js'
+    const outputA = 'entry/name=demo/hash=QKCLTVYB.js'
+    const outputB = 'entry/name=demo/hash=7E3HRWSH.js'
     assert.strictEqual(value.outputFiles[0].path, path.join(outdir, outputA))
     assert.strictEqual(value.outputFiles[1].path, path.join(outdir, outputB))
     assert.strictEqual(value.outputFiles[2].path, path.join(outdir, chunk))
@@ -2204,8 +2204,8 @@ console.log("success");
       write: false,
     })
     assert.strictEqual(outputFiles.length, 2)
-    assert.strictEqual(outputFiles[0].path, path.join(testDir, 'entry', 'out', '3UYSBRYQ-1.cjs.js'))
-    assert.strictEqual(outputFiles[1].path, path.join(testDir, 'entry', 'out', 'MWZ2XKVN-2.mjs.js'))
+    assert.strictEqual(outputFiles[0].path, path.join(testDir, 'entry', 'out', 'YMPAGTFY-1.cjs.js'))
+    assert.strictEqual(outputFiles[1].path, path.join(testDir, 'entry', 'out', 'MELA46K5-2.mjs.js'))
   },
 
   async customEntryPointOutputPathsAbs({ esbuild, testDir }) {
@@ -2225,8 +2225,8 @@ console.log("success");
       write: false,
     })
     assert.strictEqual(outputFiles.length, 2)
-    assert.strictEqual(outputFiles[0].path, path.join(testDir, 'entry', 'out', 'ZA2BCNIS-1.js'))
-    assert.strictEqual(outputFiles[1].path, path.join(testDir, 'entry', 'out', '6POZTF35-2.js'))
+    assert.strictEqual(outputFiles[0].path, path.join(testDir, 'entry', 'out', 'E5ZZI63T-1.js'))
+    assert.strictEqual(outputFiles[1].path, path.join(testDir, 'entry', 'out', 'FZK5DQMJ-2.js'))
   },
 }
 


### PR DESCRIPTION
Context: https://github.com/evanw/esbuild/issues/1099#issuecomment-812759512. Using [xxHash](https://github.com/Cyan4973/xxHash) instead of SHA1 is roughly a 6x speedup (hashing time goes from 25ms to 6ms on the main benchmark).

Note that I have also recently changed the hash to be computed in parallel so as to not slow down builds that don't need hashes. So this PR will no longer impact the main benchmark. But switching to xxHash is still relevant for scenarios where the hash is needed (mainly when code splitting is enabled) so this is still a useful change.
