### PR TITLE
Break apart tree shaking and code splitting

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -52,6 +52,10 @@ type file struct {
 	// to this file
 	distanceFromEntryPoint uint32
 
+	// This is true if this file has been marked as live by the tree shaking
+	// algorithm.
+	isLive bool
+
 	// This holds all entry points that can reach this file. It will be used to
 	// assign the parts in this file to a chunk.
 	entryBits helpers.BitSet

--- a/internal/bundler/debug.go
+++ b/internal/bundler/debug.go
@@ -40,7 +40,7 @@ func (c *linkerContext) generateExtraDataForFileJS(sourceIndex uint32) string {
 		var isFirst bool
 		code := ""
 
-		sb.WriteString(fmt.Sprintf(`{"isLive":%v`, partMeta.isLive()))
+		sb.WriteString(fmt.Sprintf(`{"isLive":%v`, partMeta.isLive))
 		sb.WriteString(fmt.Sprintf(`,"canBeRemovedIfUnused":%v`, part.CanBeRemovedIfUnused))
 
 		if partIndex == int(repr.meta.nsExportPartIndex) {

--- a/internal/helpers/bitset.go
+++ b/internal/helpers/bitset.go
@@ -22,15 +22,6 @@ func (bs BitSet) Equals(other BitSet) bool {
 	return bytes.Equal(bs.entries, other.entries)
 }
 
-func (bs *BitSet) IsAllZeros() bool {
-	for _, v := range bs.entries {
-		if v != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func (bs BitSet) String() string {
 	return string(bs.entries)
 }

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -3456,6 +3456,33 @@
       `,
     }),
 
+    // Code splitting where only one entry point uses the runtime
+    // https://github.com/evanw/esbuild/issues/1123
+    test(['a.js', 'b.js', '--outdir=out', '--splitting', '--format=esm', '--bundle'], {
+      'a.js': `
+        import * as foo from './shared'
+        export default foo
+      `,
+      'b.js': `
+        import {bar} from './shared'
+        export default bar
+      `,
+      'shared.js': `
+        export function foo() {
+          return 'foo'
+        }
+        export function bar() {
+          return 'bar'
+        }
+      `,
+      'node.js': `
+        import a from './out/a.js'
+        import b from './out/b.js'
+        if (a.foo() !== 'foo') throw 'fail'
+        if (b() !== 'bar') throw 'fail'
+      `,
+    }),
+
     // Code splitting with a dynamic import that imports a CSS file
     // https://github.com/evanw/esbuild/issues/1125
     test(['parent.js', '--outdir=out', '--splitting', '--format=esm', '--bundle'], {


### PR DESCRIPTION
The original code splitting algorithm allowed for files to be split apart and for different parts of the same file to end up in different chunks based on which entry points needed which parts. This was done at the same time as tree shaking by essentially performing tree shaking multiple times, once per entry point, and tracking which entry points each file part is live in. Each file part that is live in at least one entry point was then assigned to a code splitting chunk with all of the other code that is live in the same set of entry points. This ensures that entry points only import code that they will use (i.e. no code will be downloaded by an entry point that is guaranteed to not be used).

This file-splitting feature has been removed because it doesn't work well with the recently-added top-level await JavaScript syntax, which has complex evaluation order rules that operate at file boundaries. File parts now have a single boolean flag for whether they are live or not instead of a set of flags that track which entry points that part is reachable from (reachability is still tracked at the file level).

However, this change appears to have introduced some subtly incorrect behavior with code splitting because there is now an implicit dependency in the import graph between adjacent parts within the same file even if the two parts are unrelated and don't reference each other. This is due to the fact each entry point that references one part pulls in the file (but not the whole file, only the parts that are live in at least one entry point). So liveness must be fully computed first before code splitting is computed.

This PR splits apart tree shaking and code splitting into two separate passes, which fixes certain cases where two generated code splitting chunks ended up each importing symbols from the other and causing a cycle. There should hopefully no longer be cycles in generated code splitting chunks.

Fixes #1123
