### PR TITLE
various fixes for private members

### DIFF
--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -2347,9 +2347,8 @@ var objFoo = {
     console.log(this);
   }
 };
-var Foo = class {
+var _Foo = class {
   x = this;
-  static y = this.z;
   foo(x = this) {
     console.log(this);
   }
@@ -2357,6 +2356,8 @@ var Foo = class {
     console.log(this);
   }
 };
+var Foo = _Foo;
+__publicField(Foo, "y", _Foo.z);
 new Foo(foo(objFoo));
 if (nested) {
   let bar = function(x = this) {
@@ -2543,9 +2544,8 @@ var objFoo = {
     console.log(this);
   }
 };
-var Foo = class {
+var _Foo = class {
   x = this;
-  static y = this.z;
   foo(x = this) {
     console.log(this);
   }
@@ -2553,6 +2553,8 @@ var Foo = class {
     console.log(this);
   }
 };
+var Foo = _Foo;
+__publicField(Foo, "y", _Foo.z);
 new Foo(foo(objFoo));
 if (nested) {
   let bar = function(x = this) {

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -271,8 +271,8 @@ var _foo, foo_get;
 class Foo {
   constructor() {
     _foo.add(this);
+    __publicField(this, "bar", __privateGet(this, _foo, foo_get));
   }
-  bar = __privateGet(this, _foo, foo_get);
 }
 _foo = new WeakSet();
 foo_get = function() {
@@ -300,10 +300,14 @@ export let Foo = (_a = class {
 ================================================================================
 TestLowerPrivateClassFieldOrder
 ---------- /out.js ----------
+var _foo;
 class Foo {
-  #foo = 123;
-  bar = __privateGet(this, #foo);
+  constructor() {
+    _foo.set(this, 123);
+    __publicField(this, "bar", __privateGet(this, _foo));
+  }
 }
+_foo = new WeakMap();
 console.log(new Foo().bar === 123);
 
 ================================================================================
@@ -313,8 +317,8 @@ var _foo, foo_fn;
 class Foo {
   constructor() {
     _foo.add(this);
+    __publicField(this, "bar", __privateMethod(this, _foo, foo_fn).call(this));
   }
-  bar = __privateMethod(this, _foo, foo_fn).call(this);
 }
 _foo = new WeakSet();
 foo_fn = function() {
@@ -327,7 +331,6 @@ TestLowerPrivateClassStaticAccessorOrder
 ---------- /out.js ----------
 var _foo, foo_get, _foo2, foo_get2;
 const _Foo = class {
-  static bar = __privateGet(_Foo, _foo, foo_get);
 };
 let Foo = _Foo;
 _foo = new WeakSet();
@@ -335,29 +338,36 @@ foo_get = function() {
   return 123;
 };
 _foo.add(Foo);
+__publicField(Foo, "bar", __privateGet(_Foo, _foo, foo_get));
 console.log(Foo.bar === 123);
-class FooThis {
-  static bar = __privateGet(this, _foo2, foo_get2);
-}
+const _FooThis = class {
+};
+let FooThis = _FooThis;
 _foo2 = new WeakSet();
 foo_get2 = function() {
   return 123;
 };
 _foo2.add(FooThis);
+__publicField(FooThis, "bar", __privateGet(_FooThis, _foo2, foo_get2));
 console.log(FooThis.bar === 123);
 
 ================================================================================
 TestLowerPrivateClassStaticFieldOrder
 ---------- /out.js ----------
-class Foo {
-  static #foo = 123;
-  static bar = __privateGet(Foo, #foo);
-}
+var _foo, _foo2;
+const _Foo = class {
+};
+let Foo = _Foo;
+_foo = new WeakMap();
+_foo.set(Foo, 123);
+__publicField(Foo, "bar", __privateGet(_Foo, _foo));
 console.log(Foo.bar === 123);
-class FooThis {
-  static #foo = 123;
-  static bar = __privateGet(this, #foo);
-}
+const _FooThis = class {
+};
+let FooThis = _FooThis;
+_foo2 = new WeakMap();
+_foo2.set(FooThis, 123);
+__publicField(FooThis, "bar", __privateGet(_FooThis, _foo2));
 console.log(FooThis.bar === 123);
 
 ================================================================================
@@ -365,7 +375,6 @@ TestLowerPrivateClassStaticMethodOrder
 ---------- /out.js ----------
 var _foo, foo_fn, _foo2, foo_fn2;
 const _Foo = class {
-  static bar = __privateMethod(_Foo, _foo, foo_fn).call(_Foo);
 };
 let Foo = _Foo;
 _foo = new WeakSet();
@@ -373,15 +382,17 @@ foo_fn = function() {
   return 123;
 };
 _foo.add(Foo);
+__publicField(Foo, "bar", __privateMethod(_Foo, _foo, foo_fn).call(_Foo));
 console.log(Foo.bar === 123);
-class FooThis {
-  static bar = __privateMethod(this, _foo2, foo_fn2).call(this);
-}
+const _FooThis = class {
+};
+let FooThis = _FooThis;
 _foo2 = new WeakSet();
 foo_fn2 = function() {
   return 123;
 };
 _foo2.add(FooThis);
+__publicField(FooThis, "bar", __privateMethod(_FooThis, _foo2, foo_fn2).call(_FooThis));
 console.log(FooThis.bar === 123);
 
 ================================================================================
@@ -1003,16 +1014,20 @@ console.log(loose_default2, strict_default2);
 ================================================================================
 TestTSLowerClassPrivateFieldNextNoBundle
 ---------- /out.js ----------
+var _foo, _bar, _s_foo, _s_bar;
 class Foo {
   constructor() {
-    this.#foo = 123;
+    _foo.set(this, 123);
+    _bar.set(this, void 0);
     this.foo = 123;
   }
-  #foo;
-  #bar;
-  static #s_foo = 123;
-  static #s_bar;
 }
+_foo = new WeakMap();
+_bar = new WeakMap();
+_s_foo = new WeakMap();
+_s_bar = new WeakMap();
+_s_foo.set(Foo, 123);
+_s_bar.set(Foo, void 0);
 Foo.s_foo = 123;
 
 ================================================================================

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -381,7 +381,7 @@ func TestTSPrivateIdentifiers(t *testing.T) {
 	// constructor, but it has to leave the private field declaration in place so
 	// the private field is still declared.
 	expectPrintedTS(t, "class Foo { #foo }", "class Foo {\n  #foo;\n}\n")
-	expectPrintedTS(t, "class Foo { #foo = 1 }", "class Foo {\n  constructor() {\n    this.#foo = 1;\n  }\n  #foo;\n}\n")
+	expectPrintedTS(t, "class Foo { #foo = 1 }", "class Foo {\n  #foo = 1;\n}\n")
 	expectPrintedTS(t, "class Foo { #foo() {} }", "class Foo {\n  #foo() {\n  }\n}\n")
 	expectPrintedTS(t, "class Foo { get #foo() {} }", "class Foo {\n  get #foo() {\n  }\n}\n")
 	expectPrintedTS(t, "class Foo { set #foo(x) {} }", "class Foo {\n  set #foo(x) {\n  }\n}\n")


### PR DESCRIPTION
This PR fixes multiple issues with esbuild's handling of the `#private` syntax. Previously there could be scenarios where references to `this.#private` could be moved outside of the class body, which would cause them to become invalid (since the `#private` name is only available within the class body). One such case is when TypeScript's `useDefineForClassFields` setting has the value `false` (which is the default value), which causes class field initializers to be replaced with assignment expressions to avoid using "define" semantics:

```js
class Foo {
  static #foo = 123
  static bar = Foo.#foo
}
```

Previously this was turned into the following code, which is incorrect because `Foo.#foo` was moved outside of the class body:

```js
class Foo {
  static #foo = 123;
}
Foo.bar = Foo.#foo;
```

This is now handled by converting the private field syntax into normal JavaScript that emulates it with a `WeakMap` instead.

This conversion is fairly conservative to make sure certain edge cases are covered, so this release may unfortunately convert more private fields than previous releases, even when the target is `esnext`. It should be possible to improve this transformation in future releases so that this happens less often while still preserving correctness.

Fixes #1131