### PR TITLE
fix non-bmp characters in identifier validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Fix escaping of non-BMP characters in property names ([#977](https://github.com/evanw/esbuild/issues/977))
+
+    Property names in object literals do not have to be quoted if the property is a valid JavaScript identifier. This is defined as starting with a character in the `ID_Start` Unicode category and ending with zero or more characters in the `ID_Continue` Unicode category. However, esbuild had a bug where non-BMP characters (i.e. characters encoded using two UTF-16 code units instead of one) were always checked against `ID_Continue` instead of `ID_Start` because they included a code unit that wasn't at the start. This could result in invalid JavaScript being generated when using `--charset=utf8` because `ID_Continue` is a superset of `ID_Start` and contains some characters that are not valid at the start of an identifier. This bug has been fixed.
+
 ## 0.11.8
 
 * Fix hash calculation for code splitting and dynamic imports ([#1076](https://github.com/evanw/esbuild/issues/1076))

--- a/internal/js_lexer/js_lexer.go
+++ b/internal/js_lexer/js_lexer.go
@@ -565,6 +565,7 @@ func IsIdentifierUTF16(text []uint16) bool {
 		return false
 	}
 	for i := 0; i < n; i++ {
+		isStart := i == 0
 		r1 := rune(text[i])
 		if r1 >= 0xD800 && r1 <= 0xDBFF && i+1 < n {
 			if r2 := rune(text[i+1]); r2 >= 0xDC00 && r2 <= 0xDFFF {
@@ -572,7 +573,7 @@ func IsIdentifierUTF16(text []uint16) bool {
 				i++
 			}
 		}
-		if i == 0 {
+		if isStart {
 			if !IsIdentifierStart(r1) {
 				return false
 			}

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -3386,6 +3386,12 @@ let transformTests = {
     assert.strictEqual(code, `var x = "y";\nvar stdin_default = {x};\nexport {\n  stdin_default as default,\n  x\n};\n`)
   },
 
+  async jsonInvalidIdentifierStart({ esbuild }) {
+    // This character is a valid "ID_Continue" but not a valid "ID_Start" so it must be quoted
+    const { code } = await esbuild.transform(`{ "\\uD835\\uDFCE": "y" }`, { loader: 'json' })
+    assert.strictEqual(code, `module.exports = {"\\u{1D7CE}": "y"};\n`)
+  },
+
   async text({ esbuild }) {
     const { code } = await esbuild.transform(`This is some text`, { loader: 'text' })
     assert.strictEqual(code, `module.exports = "This is some text";\n`)


### PR DESCRIPTION
Property names in object literals do not have to be quoted if the property is a valid JavaScript identifier. This is defined as starting with a character in the `ID_Start` Unicode category and ending with zero or more characters in the `ID_Continue` Unicode category. However, esbuild had a bug where non-BMP characters (i.e. characters encoded using two UTF-16 code units instead of one) were always checked against `ID_Continue` instead of `ID_Start` because they included a code unit that wasn't at the start. This could result in invalid JavaScript being generated when using `--charset=utf8` because `ID_Continue` is a superset of `ID_Start` and contains some characters that are not valid at the start of an identifier. This bug has been fixed.

Fixes #977