### PR TITLE
Be maximally liberal in the interpretation of the `browser` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
     Property names in object literals do not have to be quoted if the property is a valid JavaScript identifier. This is defined as starting with a character in the `ID_Start` Unicode category and ending with zero or more characters in the `ID_Continue` Unicode category. However, esbuild had a bug where non-BMP characters (i.e. characters encoded using two UTF-16 code units instead of one) were always checked against `ID_Continue` instead of `ID_Start` because they included a code unit that wasn't at the start. This could result in invalid JavaScript being generated when using `--charset=utf8` because `ID_Continue` is a superset of `ID_Start` and contains some characters that are not valid at the start of an identifier. This bug has been fixed.
 
+* Be maximally liberal in the interpretation of the `browser` field ([#740](https://github.com/evanw/esbuild/issues/740))
+
+    The `browser` field in `package.json` is an informal convention followed by browser-specific bundlers that allows package authors to substitute certain node-specific import paths with alternative browser-specific import paths. It doesn't have a rigorous specification and the [canonical description](https://github.com/defunctzombie/package-browser-field-spec) of the feature doesn't include any tests. As a result, each bundler implements this feature differently. I have tried to create a [survey of how different bundlers interpret the `browser` field](https://github.com/evanw/package-json-browser-tests) and the results are very inconsistent.
+
+    This release attempts to change esbuild to support the union of the behavior of all other bundlers. That way if people have the `browser` field working with some other bundler and they switch to esbuild, the `browser` field shouldn't ever suddenly stop working. This seemed like the most principled approach to take in this situation.
+
+    The drawback of this approach is that it means the `browser` field may start working when switching to esbuild when it was previously not working. This could cause bugs, but I consider this to be a problem with the package (i.e. not using a more well-supported form of the `browser` field), not a problem with esbuild itself.
+
 ## 0.11.8
 
 * Fix hash calculation for code splitting and dynamic imports ([#1076](https://github.com/evanw/esbuild/issues/1076))

--- a/internal/bundler/snapshots/snapshots_packagejson.txt
+++ b/internal/bundler/snapshots/snapshots_packagejson.txt
@@ -132,7 +132,7 @@ console.log((0, import_demo_pkg.default)());
 ================================================================================
 TestPackageJsonBrowserMapRelativeDisabled
 ---------- /Users/user/project/out.js ----------
-// (disabled):Users/user/project/node_modules/demo-pkg/util-node.js
+// (disabled):Users/user/project/node_modules/demo-pkg/util-node
 var require_util_node = __commonJS(() => {
 });
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1604,21 +1604,6 @@ func (r resolverQuery) loadNodeModules(path string, kind ast.ImportKind, dirInfo
 				}
 			}
 
-			// Check the "browser" map for the first time (1 out of 2)
-			if importDirInfo := r.dirInfoCached(r.fs.Dir(absPath)); importDirInfo != nil && importDirInfo.enclosingBrowserScope != nil {
-				if packageJSON := importDirInfo.enclosingBrowserScope.packageJSON; packageJSON.browserMap != nil {
-					if relPath, ok := r.fs.Rel(r.fs.Dir(packageJSON.source.KeyPath.Text), absPath); ok {
-						if remapped, ok := r.checkBrowserMap(packageJSON, relPath); ok {
-							if remapped == nil {
-								return PathPair{Primary: logger.Path{Text: absPath, Namespace: "file", Flags: logger.PathDisabled}}, true, nil, DebugMeta{}
-							} else if remappedResult, ok, diffCase, notes := r.resolveWithoutRemapping(importDirInfo.enclosingBrowserScope, *remapped, kind); ok {
-								return remappedResult, true, diffCase, notes
-							}
-						}
-					}
-				}
-			}
-
 			if absolute, ok, diffCase := r.loadAsFileOrDirectory(absPath, kind); ok {
 				return absolute, true, diffCase, DebugMeta{}
 			}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -608,7 +608,7 @@ func (r resolverQuery) resolveWithoutSymlinks(sourceDir string, importPath strin
 			return &ResolveResult{PathPair: PathPair{Primary: logger.Path{Text: absPath, Namespace: "file"}}, IsExternal: true}, DebugMeta{}
 		}
 
-		// Check the non-package "browser" map for the first time (1 out of 2)
+		// Check the "browser" map for the first time (1 out of 2)
 		if importDirInfo := r.dirInfoCached(r.fs.Dir(absPath)); importDirInfo != nil && importDirInfo.enclosingBrowserScope != nil {
 			if packageJSON := importDirInfo.enclosingBrowserScope.packageJSON; packageJSON.browserMap != nil {
 				if relPath, ok := r.fs.Rel(r.fs.Dir(packageJSON.source.KeyPath.Text), absPath); ok {
@@ -697,7 +697,7 @@ func (r resolverQuery) resolveWithoutSymlinks(sourceDir string, importPath strin
 		}
 	}
 
-	// Check the non-package "browser" map for the second time (2 out of 2)
+	// Check the "browser" map for the second time (2 out of 2)
 	for _, path := range result.PathPair.iter() {
 		if resultDirInfo := r.dirInfoCached(r.fs.Dir(path.Text)); resultDirInfo != nil && resultDirInfo.enclosingBrowserScope != nil {
 			if packageJSON := resultDirInfo.enclosingBrowserScope.packageJSON; packageJSON.browserMap != nil {
@@ -840,13 +840,13 @@ func (r resolverQuery) parseTSConfig(file string, visited map[string]bool) (*TSC
 	result := ParseTSConfigJSON(r.log, source, &r.caches.JSONCache, func(extends string, extendsRange logger.Range) *TSConfigJSON {
 		if IsPackagePath(extends) {
 			// If this is a package path, try to resolve it to a "node_modules"
-			// starting from %q. This doesn't use the normal node module resolution algorit,dirInfo.absPathhm
+			// folder. This doesn't use the normal node module resolution algorithm
 			// both because it's different (e.g. we don't want to match a directory)
 			// and because it would deadlock since we're currently in the middle of
 			// populating the directory info cache.
 			current := fileDir
 			for {
-				// Skip "node_modules" starting from %,dirInfo.absPathqs
+				// Skip "node_modules" folders
 				if r.fs.Base(current) != "node_modules" {
 					join := r.fs.Join(current, "node_modules", extends)
 					filesToCheck := []string{r.fs.Join(join, "tsconfig.json"), join, join + ".json"}
@@ -1458,7 +1458,7 @@ func (r resolverQuery) loadNodeModules(path string, kind ast.ImportKind, dirInfo
 				r.debugLogs.addNote(fmt.Sprintf("Checking for a package in the directory %q", absPath))
 			}
 
-			// Check for an "exports" map in the package's package.json starting from ,dirInfo.absPath%q
+			// Check for an "exports" map in the package's package.json folder
 			if esmOK {
 				absPkgPath := r.fs.Join(dirInfo.absPath, "node_modules", esmPackageName)
 				if pkgDirInfo := r.dirInfoCached(absPkgPath); pkgDirInfo != nil {
@@ -1592,7 +1592,7 @@ func (r resolverQuery) loadNodeModules(path string, kind ast.ImportKind, dirInfo
 				}
 			}
 
-			// Check the non-package "browser" map for the first time (1 out of 2)
+			// Check the "browser" map for the first time (1 out of 2)
 			if importDirInfo := r.dirInfoCached(r.fs.Dir(absPath)); importDirInfo != nil && importDirInfo.enclosingBrowserScope != nil {
 				if packageJSON := importDirInfo.enclosingBrowserScope.packageJSON; packageJSON.browserMap != nil {
 					if relPath, ok := r.fs.Rel(r.fs.Dir(packageJSON.source.KeyPath.Text), absPath); ok {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -153,6 +153,16 @@
       'node_modules/pkg/file.js': `var works = true`,
     }),
     test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg/foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./foo/bar": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg/foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "foo/bar": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
       'entry.js': `require('pkg')`,
       'node_modules/pkg/index.js': `require('foo/bar')`,
       'node_modules/pkg/package.json': `{ "browser": { "./foo/bar": "./file" } }`,

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -182,6 +182,22 @@
     }),
     test(['entry.js', '--bundle', '--outfile=node.js'], {
       'entry.js': `require('pkg')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./index.js": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/index.js': `throw 'fail'`,
+      'node_modules/pkg/package.json': `{ "browser": { "./index": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./index": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
       'node_modules/pkg/main.js': `throw 'fail'`,
       'node_modules/pkg/package.json': `{ "main": "./main",\n  "browser": { "./main.js": "./file" } }`,
       'node_modules/pkg/file.js': `var works = true`,

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -118,6 +118,92 @@
     }),
   )
 
+  // Test the "browser" field in "package.json"
+  tests.push(
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('foo')`,
+      'package.json': `{ "browser": { "./foo": "./file" } }`,
+      'file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('foo')`,
+      'package.json': `{ "browser": { "foo": "./file" } }`,
+      'file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('./foo')`,
+      'package.json': `{ "browser": { "./foo": "./file" } }`,
+      'file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('./foo')`,
+      'package.json': `{ "browser": { "foo": "./file" } }`,
+      'file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg/foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./foo/bar": "./file" } }`,
+      'node_modules/pkg/foo/bar.js': `invalid syntax`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg/foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "foo/bar": "./file" } }`,
+      'node_modules/pkg/foo/bar.js': `invalid syntax`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/index.js': `require('foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./foo/bar": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/index.js': `require('foo/bar')`,
+      'node_modules/pkg/package.json': `{ "browser": { "foo/bar": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/index.js': `throw 'fail'`,
+      'node_modules/pkg/package.json': `{ "browser": { "./index.js": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/main.js': `throw 'fail'`,
+      'node_modules/pkg/package.json': `{ "main": "./main",\n  "browser": { "./main.js": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'node_modules/pkg/package.json': `{ "main": "./main",\n  "browser": { "./main.js": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'package.json': `{ "browser": { "pkg2": "pkg3" } }`,
+      'node_modules/pkg/index.js': `require('pkg2')`,
+      'node_modules/pkg/package.json': `{ "browser": { "pkg2": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'package.json': `{ "browser": { "pkg2": "pkg3" } }`,
+      'node_modules/pkg/index.js': `require('pkg2')`,
+      'node_modules/pkg2/index.js': `throw 'fail'`,
+      'node_modules/pkg3/index.js': `var works = true`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `require('pkg')`,
+      'package.json': `{ "browser": { "pkg2": "pkg3" } }`,
+      'node_modules/pkg/index.js': `require('pkg2')`,
+      'node_modules/pkg/package.json': `{ "browser": { "./pkg2": "./file" } }`,
+      'node_modules/pkg/file.js': `var works = true`,
+    }),
+  )
+
   // Tests for symlinks
   //
   // Note: These are disabled on Windows because they fail when run with GitHub

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -409,7 +409,7 @@ let buildTests = {
     const resultMap = await readFileAsync(output + '.map', 'utf8')
     const json = JSON.parse(resultMap)
     assert.strictEqual(json.version, 3)
-    assert.strictEqual(json.sources[0], path.basename(disabled))
+    assert.strictEqual(json.sources[0], 'disabled')
     assert.strictEqual(json.sources[1], path.basename(input))
     assert.strictEqual(json.sourcesContent[0], '')
     assert.strictEqual(json.sourcesContent[1], content)


### PR DESCRIPTION
The `browser` field in `package.json` is an informal convention followed by browser-specific bundlers that allows package authors to substitute certain node-specific import paths with alternative browser-specific import paths. It doesn't have a rigorous specification and the [canonical description](https://github.com/defunctzombie/package-browser-field-spec) of the feature doesn't include any tests. As a result, each bundler implements this feature differently. I have tried to create a [survey of how different bundlers interpret the `browser` field](https://github.com/evanw/package-json-browser-tests) and the results are very inconsistent.

This PR attempts to change esbuild to support the union of the behavior of all other bundlers. That way if people have the `browser` field working with some other bundler and they switch to esbuild, the `browser` field shouldn't ever suddenly stop working. This seemed like the most principled approach to take in this situation.

The drawback of this approach is that it means the `browser` field may start working when switching to esbuild when it was previously not working. This could cause bugs, but I consider this to be a problem with the package (i.e. not using a more well-supported form of the `browser` field), not a problem with esbuild itself.

Fixes #740
