### PR TITLE
Add onBuild to esbuild.serve

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -523,14 +523,20 @@ func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptio
 		})
 	}
 	serveOptions.OnBuild = func(args api.BuildResult) {
+		response := map[string]interface{}{
+			"errors":   encodeMessages(args.Errors),
+			"warnings": encodeMessages(args.Warnings),
+		}
+		if !options.Write {
+			response["outputFiles"] = encodeOutputFiles(args.OutputFiles)
+		}
+		if options.Metafile {
+			response["metafile"] = args.Metafile
+		}
 		service.sendRequest(map[string]interface{}{
 			"command": "serve-build",
 			"serveID": serveID,
-			"args": map[string]interface{}{
-				"errors":   encodeMessages(args.Errors),
-				"warnings": encodeMessages(args.Warnings),
-				"metafile": args.Metafile,
-			},
+			"args":    response,
 		})
 	}
 	result, err := api.Serve(serveOptions, options)

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -522,6 +522,17 @@ func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptio
 			},
 		})
 	}
+	serveOptions.OnBuild = func(args api.BuildResult) {
+		service.sendRequest(map[string]interface{}{
+			"command": "serve-build",
+			"serveID": serveID,
+			"args": map[string]interface{}{
+				"errors":   encodeMessages(args.Errors),
+				"warnings": encodeMessages(args.Warnings),
+				"metafile": args.Metafile,
+			},
+		})
+	}
 	result, err := api.Serve(serveOptions, options)
 	if err != nil {
 		return outgoingPacket{bytes: encodeErrorPacket(id, err)}

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -88,7 +88,7 @@ export interface OnRequestRequest {
 export interface OnServeBuild {
   command: 'serve-build';
   serveID: number;
-  args: types.BuildResult;
+  args: BuildResponse;
 }
 
 export interface OnWaitRequest {

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -85,6 +85,12 @@ export interface OnRequestRequest {
   args: types.ServeOnRequestArgs;
 }
 
+export interface OnServeBuild {
+  command: 'serve-build';
+  serveID: number;
+  args: types.BuildResult;
+}
+
 export interface OnWaitRequest {
   command: 'serve-wait';
   serveID: number;

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -134,6 +134,7 @@ export interface ServeOptions {
   host?: string;
   servedir?: string;
   onRequest?: (args: ServeOnRequestArgs) => void;
+  onBuild?: (args: BuildResult) => void;
 }
 
 export interface ServeOnRequestArgs {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -376,6 +376,7 @@ type ServeOptions struct {
 	Host      string
 	Servedir  string
 	OnRequest func(ServeOnRequestArgs)
+	OnBuild   func(BuildResult)
 }
 
 type ServeOnRequestArgs struct {

--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -29,6 +29,7 @@ type apiHandler struct {
 	servedir         string
 	options          *config.Options
 	onRequest        func(ServeOnRequestArgs)
+	onBuild          func(BuildResult)
 	rebuild          func() BuildResult
 	currentBuild     *runningBuild
 	fs               fs.FS
@@ -53,6 +54,9 @@ func (h *apiHandler) build() BuildResult {
 				result := h.rebuild()
 				h.rebuild = result.Rebuild
 				build.result = result
+				if h.onBuild != nil {
+					h.onBuild(result)
+				}
 				build.waitGroup.Done()
 
 				// Build results stay valid for a little bit afterward since a page
@@ -526,6 +530,7 @@ func serveImpl(serveOptions ServeOptions, buildOptions BuildOptions) (ServeResul
 	var handler *apiHandler
 	handler = &apiHandler{
 		onRequest:        serveOptions.OnRequest,
+		onBuild:          serveOptions.OnBuild,
 		outdirPathPrefix: outdirPathPrefix,
 		servedir:         serveOptions.Servedir,
 		rebuild: func() BuildResult {


### PR DESCRIPTION
An attempt to resolve https://github.com/evanw/esbuild/issues/1072

I use `metafile` during build to replace `index.js` to `index-[hash].js` in my html template, the code goes like this:
```
require('esbuild').build(buildOptions).catch((err) => {
  console.error(err);
  process.exit(1);
}).then((res) => {
  buildHtmlSync(res.metafile); // template replace based on metafile
});
```
But `metafile` is missing from `esbuild.serve` (CMIIW)

This PR will add optional `onBuild` callback into `esbuild.serve` first argument:
```
esbuild.serve({
  servedir: './out',
  onBuild: (res) => {
    buildHtmlSync(res.metafile);
  },
}, buildOptions).then((result) => {
...
```

Note: I am new to this, please give me pointers if I miss something 🙇🏼 