### PR TITLE
Add tests for the new Deno package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       with:
         node-version: 14
 
+    - name: Setup Deno 1.x
+      uses: denolib/setup-deno@v2
+      with:
+        deno-version: v1.x
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -36,6 +41,12 @@ jobs:
 
     - name: go vet
       run: go vet ./cmd/... ./internal/... ./pkg/...
+
+    - name: Deno Tests
+      # Deno tests currently don't run on Windows because of "esbuild" vs.
+      # "esbuild.exe" in the test harness. This should be fixed...
+      if: matrix.os != 'windows-latest'
+      run: make test-deno
 
     - name: Test for path/filepath
       if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test-common: test-go vet-go no-filepath verify-source-map end-to-end-tests js-ap
 
 # These tests are for release (the extra tests are not included in "test" because they are pretty slow)
 test-all:
-	make -j6 test-common ts-type-tests test-wasm-node test-wasm-browser lib-typecheck
+	make -j6 test-common test-deno ts-type-tests test-wasm-node test-wasm-browser lib-typecheck
 
 # This includes tests of some 3rd-party libraries, which can be very slow
 test-prepublish: check-go-version test-all test-preact-splitting test-sucrase bench-rome-esbuild bench-readmin-esbuild test-esprima test-rollup
@@ -44,6 +44,9 @@ test-wasm-node: esbuild
 
 test-wasm-browser: platform-wasm | scripts/browser/node_modules
 	cd scripts/browser && node browser-tests.js
+
+test-deno: esbuild platform-deno
+	ESBUILD_BINARY_PATH="$(shell pwd)/esbuild" deno run --allow-run --allow-env --allow-net --allow-read --allow-write scripts/deno-tests.js
 
 register-test: cmd/esbuild/version.go | scripts/node_modules
 	cd npm/esbuild && npm version "$(ESBUILD_VERSION)" --allow-same-version

--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -80,7 +80,12 @@ function getCachePath(name: string): { finalPath: string, finalDir: string } {
       break
 
     case 'windows':
-      baseDir = Deno.env.get('FOLDERID_LocalAppData')
+      baseDir = Deno.env.get('LOCALAPPDATA')
+      if (!baseDir) {
+        baseDir = Deno.env.get('USERPROFILE')
+        if (baseDir) baseDir += '/AppData/Local'
+      }
+      if (baseDir) baseDir += '/Cache'
       break
 
     case 'linux':
@@ -123,6 +128,9 @@ function extractFileFromTarGzip(buffer: Uint8Array, file: string): Uint8Array {
 }
 
 async function install(): Promise<string> {
+  const overridePath = Deno.env.get('ESBUILD_BINARY_PATH')
+  if (overridePath) return overridePath
+
   const platformKey = Deno.build.target
   const knownWindowsPackages: Record<string, string> = {
     'x86_64-pc-windows-msvc': 'esbuild-windows-64',

--- a/scripts/deno-tests.js
+++ b/scripts/deno-tests.js
@@ -1,0 +1,79 @@
+// To run this, you must first build the Deno package with "make platform-deno"
+import * as esbuild from '../deno/mod.js'
+import * as path from 'https://deno.land/std@0.93.0/path/mod.ts'
+import * as asserts from 'https://deno.land/std@0.93.0/testing/asserts.ts'
+
+const rootTestDir = path.join(path.dirname(path.fromFileUrl(import.meta.url)), '.deno-tests')
+
+let tests = {
+  async basicBuild({ testDir }) {
+    const input = path.join(testDir, 'in.ts')
+    const dep = path.join(testDir, 'dep.ts')
+    const output = path.join(testDir, 'out.ts')
+    await Deno.writeTextFile(input, 'import dep from "./dep.ts"; export default dep === 123')
+    await Deno.writeTextFile(dep, 'export default 123')
+    await esbuild.build({
+      entryPoints: [input],
+      bundle: true,
+      outfile: output,
+      format: 'esm',
+    })
+    const result = await import(path.toFileUrl(output))
+    asserts.assertStrictEquals(result.default, true)
+  },
+
+  async basicTransform() {
+    const ts = 'let x: number = 1+2'
+    const result = await esbuild.transform(ts, { loader: 'ts' })
+    asserts.assertStrictEquals(result.code, 'let x = 1 + 2;\n')
+  },
+
+  async largeTransform() {
+    // This should be large enough to use the file system passing optimization
+    let x = '0'
+    for (let i = 0; i < 1000; i++)x += '+' + i
+    x += ','
+    let y = 'return['
+    for (let i = 0; i < 1000; i++)y += x
+    y += ']'
+    const result = await esbuild.transform(y, { minify: true })
+    asserts.assertStrictEquals(result.code, y.slice(0, -2) + '];\n')
+  },
+}
+
+async function main() {
+  try {
+    Deno.removeSync(rootTestDir, { recursive: true })
+  } catch {
+  }
+  Deno.mkdirSync(rootTestDir, { recursive: true })
+
+  // Run all tests concurrently
+  const runTest = async ([name, fn]) => {
+    let testDir = path.join(rootTestDir, name)
+    try {
+      await Deno.mkdir(testDir, { recursive: true })
+      await fn({ testDir })
+      await Deno.remove(testDir, { recursive: true }).catch(() => null)
+      return true
+    } catch (e) {
+      console.error(`❌ ${name}: ${e && e.stack || e}`)
+      return false
+    }
+  }
+  const allTestsPassed = (await Promise.all(Object.entries(tests).map(runTest))).every(success => success)
+  esbuild.stop()
+
+  if (!allTestsPassed) {
+    console.error(`❌ deno tests failed`)
+    Deno.exit(1)
+  } else {
+    console.log(`✅ deno tests passed`)
+    try {
+      Deno.removeSync(rootTestDir, { recursive: true })
+    } catch {
+    }
+  }
+}
+
+await main()


### PR DESCRIPTION
This adds some simple tests for the new Deno package. The package just installs the binary esbuild executable from npm and reuses most of the same code from the npm package, so in theory heavily testing Deno package itself is mostly redundant.

Issue: #936 
