### PR TITLE
Add tsconfig rootDir support

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1328,6 +1328,9 @@ func (s *scanner) addEntryPoints(entryPoints []EntryPoint) []graph.EntryPoint {
 			// If the output path is missing, automatically generate one from the input path
 			if outputPath == "" {
 				outputPath = entryPoints[i].InputPath
+				if resolveResult.RootDir != "" {
+					outputPath, _ = s.fs.Rel(resolveResult.RootDir, outputPath)
+				}
 				windowsVolumeLabel := ""
 
 				// The ":" character is invalid in file paths on Windows except when

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -112,6 +112,10 @@ type ResolveResult struct {
 	// value is not "remove".
 	PreserveUnusedImportsTS bool
 
+	// A relative dir which will be stripped in the output. Matches
+	// https://www.typescriptlang.org/tsconfig#rootDir
+	RootDir string
+
 	// This is the "type" field from "package.json"
 	ModuleType config.ModuleType
 }
@@ -509,6 +513,7 @@ func (r resolverQuery) finalizeResolve(result *ResolveResult) {
 					result.JSXFragment = dirInfo.tsConfigJSON.JSXFragmentFactory
 					result.UseDefineForClassFieldsTS = dirInfo.tsConfigJSON.UseDefineForClassFields
 					result.PreserveUnusedImportsTS = dirInfo.tsConfigJSON.PreserveImportsNotUsedAsValues
+					result.RootDir = dirInfo.tsConfigJSON.RootDir
 
 					if r.debugLogs != nil {
 						r.debugLogs.addNote(fmt.Sprintf("This import is under the effect of %q",

--- a/internal/resolver/tsconfig_json.go
+++ b/internal/resolver/tsconfig_json.go
@@ -35,6 +35,7 @@ type TSConfigJSON struct {
 
 	JSXFactory                     []string
 	JSXFragmentFactory             []string
+	RootDir                        string
 	UseDefineForClassFields        config.MaybeBool
 	PreserveImportsNotUsedAsValues bool
 }
@@ -62,7 +63,6 @@ func ParseTSConfigJSON(
 	}
 
 	var result TSConfigJSON
-	result.AbsPath = source.KeyPath.Text
 
 	// Parse "extends"
 	if extends != nil {
@@ -74,6 +74,9 @@ func ParseTSConfigJSON(
 			}
 		}
 	}
+
+	// preserve the absolute path of the non extends tsconfig
+	result.AbsPath = source.KeyPath.Text
 
 	// Parse "compilerOptions"
 	if compilerOptionsJSON, _, ok := getProperty(json, "compilerOptions"); ok {
@@ -95,6 +98,13 @@ func ParseTSConfigJSON(
 		if valueJSON, _, ok := getProperty(compilerOptionsJSON, "jsxFragmentFactory"); ok {
 			if value, ok := getString(valueJSON); ok {
 				result.JSXFragmentFactory = parseMemberExpressionForJSX(log, source, valueJSON.Loc, value)
+			}
+		}
+
+		// Parse "rootDir"
+		if valueJSON, _, ok := getProperty(compilerOptionsJSON, "rootDir"); ok {
+			if value, ok := getString(valueJSON); ok {
+				result.RootDir = value
 			}
 		}
 


### PR DESCRIPTION
This adds rudimentary support for tsconfig's `rootDir` to `esbuild`. It serves more as an MVP to showcase an idea, rather than a fleshed-out solution.

Let's say you have:

```
a/tsconfig.json

{
  "compilerOptions": {
      "rootDir": "src/"
  }
}

a/src/a.ts
```

Typescript will output:

```
build/a.js
```

whereas, `esbuild` will output:

```
build/src/a.js
```

This PR will make esbuild's output similar to `tsc` in this case. 

This makes progress towards #1156 