### PR TITLE
Fix invalid mangling of zero and negative zero

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -889,6 +889,15 @@ func valuesLookTheSame(left js_ast.E, right js_ast.E) bool {
 			}
 			return true
 		}
+
+	// Special-case to distinguish between negative an non-negative zero when mangling
+	// "a ? -0 : 0" => "a ? -0 : 0"
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness
+	case *js_ast.ENumber:
+		b, ok := right.(*js_ast.ENumber)
+		if ok && a.Value == 0 && b.Value == 0 && math.Signbit(a.Value) != math.Signbit(b.Value) {
+			return false
+		}
 	}
 
 	equal, ok := checkEqualityIfNoSideEffects(left, right)

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2557,6 +2557,13 @@ func TestMangleIf(t *testing.T) {
 	expectPrintedMangle(t, "let b; a = null === b || b === undefined ? c : b", "let b;\na = b ?? c;\n")
 	expectPrintedMangle(t, "let b; a = b !== undefined && b !== null ? b : c", "let b;\na = b ?? c;\n")
 
+	// Distinguish between negative an non-negative zero (i.e. Object.is)
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness
+	expectPrintedMangle(t, "a(b ? 0 : 0)", "a((b, 0));\n")
+	expectPrintedMangle(t, "a(b ? +0 : -0)", "a(b ? 0 : -0);\n")
+	expectPrintedMangle(t, "a(b ? +0 : 0)", "a((b, 0));\n")
+	expectPrintedMangle(t, "a(b ? -0 : 0)", "a(b ? -0 : 0);\n")
+
 	expectPrintedMangle(t, "a ? b : b", "a, b;\n")
 	expectPrintedMangle(t, "let a; a ? b : b", "let a;\nb;\n")
 


### PR DESCRIPTION
Fixes #1159

It seemed better to just add a special case within `valuesLookTheSame` rather than introduce an equality mode configuration into `checkEqualityIfNoSideEffects`.

Or it may be better to put this logic into `mangleIfExpr` directly, I wasn't sure.