### PR TITLE
add more special cases to ts namespace transform

### DIFF
--- a/internal/bundler/bundler_ts_test.go
+++ b/internal/bundler/bundler_ts_test.go
@@ -665,13 +665,13 @@ func TestTSExportDefaultTypeIssue316(t *testing.T) {
 				import tone_def, { bar as tone } from './remove/type-only-namespace-exported'
 
 				export default [
-					dc,
-					dl,
-					im,
-					_in,
-					tn,
-					vn,
-					vnm,
+					dc_def, dc,
+					dl_def, dl,
+					im_def, im,
+					in_def, _in,
+					tn_def, tn,
+					vn_def, vn,
+					vnm_def, vnm,
 
 					i,
 					ie,

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -95,6 +95,7 @@ var _foo = class {
 };
 var foo2 = _foo;
 foo2.x = new _foo();
+var interface_merged_default = foo2;
 var bar3 = 123;
 
 // keep/interface-nested.ts
@@ -114,6 +115,7 @@ var foo3;
 (function(foo5) {
   foo5.num = 0;
 })(foo3 || (foo3 = {}));
+var value_namespace_default = foo3;
 var bar6 = 123;
 
 // keep/value-namespace-merged.ts
@@ -121,6 +123,7 @@ var foo4;
 (function(foo5) {
   foo5.num = 0;
 })(foo4 || (foo4 = {}));
+var value_namespace_merged_default = foo4;
 var bar7 = 123;
 
 // remove/interface.ts
@@ -143,12 +146,19 @@ var bar13 = 123;
 
 // entry.ts
 var entry_default = [
+  declare_class_default,
   bar,
+  declare_let_default,
   bar2,
+  interface_merged_default,
   bar3,
+  interface_nested_default,
   bar4,
+  type_nested_default,
   bar5,
+  value_namespace_default,
   bar6,
+  value_namespace_merged_default,
   bar7,
   bar8,
   bar9,

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -882,6 +882,30 @@ var f;
   log(f);
 })(f || (f = {}));
 `)
+
+	expectPrintedTS(t, `
+		namespace a { export declare var a }
+		namespace b { export declare let b }
+		namespace c { export declare enum c {} }
+		namespace d { export declare class d {} }
+		namespace e { export declare namespace e {} }
+		namespace f { export declare function f() {} }
+	`, `var a;
+(function(_a) {
+})(a || (a = {}));
+var b;
+(function(_b) {
+})(b || (b = {}));
+var c;
+(function(c) {
+})(c || (c = {}));
+var d;
+(function(d) {
+})(d || (d = {}));
+var f;
+(function(f) {
+})(f || (f = {}));
+`)
 }
 
 func TestTSNamespaceDestructuring(t *testing.T) {


### PR DESCRIPTION
With this PR, esbuild's TypeScript-to-JavaScript transform will no longer omit the namespace in this case:

```ts
namespace Something {
  export declare function Print(a: string): void
}
Something.Print = function(a) {}
```

This was previously omitted because TypeScript omits empty namespaces, and the namespace was considered empty because the `export declare function` statement isn't "real":

```ts
namespace Something {
  export declare function Print(a: string): void
  setTimeout(() => Print('test'))
}
Something.Print = function(a) {}
```

The TypeScript compiler compiles the above code into the following:

```js
var Something;
(function (Something) {
  setTimeout(() => Print('test'));
})(Something || (Something = {}));
Something.Print = function (a) { };
```

Notice how `Something.Print` is never called, and what appears to be a reference to the `Print` symbol on the namespace `Something` is actually a reference to the global variable `Print`. I can only assume this is a bug in TypeScript, but it's important to replicate this behavior inside esbuild for TypeScript compatibility.

The TypeScript-to-JavaScript transform in esbuild has been updated to match the TypeScript compiler's output in both of these cases.

Fixes #1158 
