### PR TITLE
Implement ergonomic brand checks for private fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+* Implement ergonomic brand checks for private fields
+
+    This introduces new JavaScript syntax:
+
+    ```js
+    class Foo {
+      #field
+      static isFoo(x) {
+        return #foo in x // This is an "ergonomic brand check"
+      }
+    }
+    assert(Foo.isFoo(new Foo))
+    ```
+
+    [The TC39 proposal for this feature](https://github.com/tc39/proposal-private-fields-in-in) is currently at stage 3 but has already been shipped in Chrome 91 and has also landed in Firefox. It seems reasonably inevitable given that it's already shipping and that it's a very simple feature, so it seems appropriate to add this feature to esbuild.
+
 ## 0.11.12
 
 * Fix a bug where `-0` and `0` were collapsed to the same value ([#1159](https://github.com/evanw/esbuild/issues/1159))

--- a/internal/bundler/bundler_lower_test.go
+++ b/internal/bundler/bundler_lower_test.go
@@ -1486,3 +1486,42 @@ func TestLowerPrivateClassStaticAccessorOrder(t *testing.T) {
 		},
 	})
 }
+
+func TestLowerPrivateClassBrandCheckUnsupported(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				class Foo {
+					#foo
+					#bar
+					baz() { #foo in this }
+				}
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:                  config.ModePassThrough,
+			AbsOutputFile:         "/out.js",
+			UnsupportedJSFeatures: compat.ClassPrivateBrandCheck,
+		},
+	})
+}
+
+func TestLowerPrivateClassBrandCheckSupported(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				class Foo {
+					#foo
+					#bar
+					baz() { #foo in this }
+				}
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModePassThrough,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -281,6 +281,33 @@ foo_get = function() {
 console.log(new Foo().bar === 123);
 
 ================================================================================
+TestLowerPrivateClassBrandCheckSupported
+---------- /out.js ----------
+class Foo {
+  #foo;
+  #bar;
+  baz() {
+    #foo in this;
+  }
+}
+
+================================================================================
+TestLowerPrivateClassBrandCheckUnsupported
+---------- /out.js ----------
+var _foo;
+class Foo {
+  constructor() {
+    _foo.set(this, void 0);
+    this.#bar = void 0;
+  }
+  #bar;
+  baz() {
+    __privateIn(_foo, this);
+  }
+}
+_foo = new WeakMap();
+
+================================================================================
 TestLowerPrivateClassExpr2020NoBundle
 ---------- /out.js ----------
 var _field, _method, method_fn, _a, _staticField, _staticMethod, staticMethod_fn;

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -45,6 +45,7 @@ const (
 	Class
 	ClassField
 	ClassPrivateAccessor
+	ClassPrivateBrandCheck
 	ClassPrivateField
 	ClassPrivateMethod
 	ClassPrivateStaticAccessor
@@ -149,6 +150,9 @@ var jsTable = map[JSFeature]map[Engine][]int{
 		Chrome: {84},
 		Edge:   {84},
 		Node:   {14, 6},
+	},
+	ClassPrivateBrandCheck: {
+		Chrome: {91},
 	},
 	ClassPrivateField: {
 		Chrome: {84},

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -10150,10 +10150,14 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 			private.Ref = result.ref
 
 			// Unlike regular identifiers, there are no unbound private identifiers
-			kind := p.symbols[result.ref.InnerIndex].Kind
-			if !kind.IsPrivate() {
+			symbol := &p.symbols[result.ref.InnerIndex]
+			if !symbol.Kind.IsPrivate() {
 				r := logger.Range{Loc: e.Left.Loc, Len: int32(len(name))}
 				p.log.AddRangeError(&p.source, r, fmt.Sprintf("Private name %q must be declared in an enclosing class", name))
+			} else if p.options.unsupportedJSFeatures.Has(compat.ClassPrivateBrandCheck) {
+				// This is an additional feature on top of private members, so make
+				// sure to lower this private member if it's used in a brand check
+				symbol.PrivateSymbolMustBeLowered = true
 			}
 
 			e.Right = p.visitExpr(e.Right)

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -2642,6 +2642,21 @@ func (p *parser) parsePrefix(level js_ast.L, errors *deferredErrors, flags exprF
 		p.lexer.Next()
 		return js_ast.Expr{Loc: loc, Data: &js_ast.EThis{}}
 
+	case js_lexer.TPrivateIdentifier:
+		if !p.allowPrivateIdentifiers {
+			p.lexer.Unexpected()
+		}
+
+		ref := p.storeNameInRef(p.lexer.Identifier)
+		p.lexer.Next()
+
+		// Check for "#foo in bar"
+		if p.lexer.Token != js_lexer.TIn {
+			p.lexer.Expected(js_lexer.TIn)
+		}
+
+		return js_ast.Expr{Loc: loc, Data: &js_ast.EPrivateIdentifier{Ref: ref}}
+
 	case js_lexer.TIdentifier:
 		name := p.lexer.Identifier
 		nameRange := p.lexer.Range()
@@ -10128,6 +10143,27 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 		}
 
 	case *js_ast.EBinary:
+		// Special-case EPrivateIdentifier to allow it here
+		if private, ok := e.Left.Data.(*js_ast.EPrivateIdentifier); ok && e.Op == js_ast.BinOpIn {
+			name := p.loadNameFromRef(private.Ref)
+			result := p.findSymbol(e.Left.Loc, name)
+			private.Ref = result.ref
+
+			// Unlike regular identifiers, there are no unbound private identifiers
+			kind := p.symbols[result.ref.InnerIndex].Kind
+			if !kind.IsPrivate() {
+				r := logger.Range{Loc: e.Left.Loc, Len: int32(len(name))}
+				p.log.AddRangeError(&p.source, r, fmt.Sprintf("Private name %q must be declared in an enclosing class", name))
+			}
+
+			e.Right = p.visitExpr(e.Right)
+
+			if p.privateSymbolNeedsToBeLowered(private) {
+				return p.lowerPrivateBrandCheck(e.Right, expr.Loc, private), exprOut{}
+			}
+			break
+		}
+
 		isCallTarget := e == p.callTarget
 		isStmtExpr := e == p.stmtExprValue
 		wasAnonymousNamedExpr := p.isAnonymousNamedExpr(e.Right)

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -971,6 +971,14 @@ func (p *parser) lowerObjectSpread(loc logger.Loc, e *js_ast.EObject) js_ast.Exp
 	return result
 }
 
+func (p *parser) lowerPrivateBrandCheck(target js_ast.Expr, loc logger.Loc, private *js_ast.EPrivateIdentifier) js_ast.Expr {
+	// "#field in this" => "__privateIn(#field, this)"
+	return p.callRuntime(loc, "__privateIn", []js_ast.Expr{
+		{Loc: loc, Data: &js_ast.EIdentifier{Ref: private.Ref}},
+		target,
+	})
+}
+
 func (p *parser) lowerPrivateGet(target js_ast.Expr, loc logger.Loc, private *js_ast.EPrivateIdentifier) js_ast.Expr {
 	switch p.symbols[private.Ref.InnerIndex].Kind {
 	case js_ast.SymbolPrivateMethod, js_ast.SymbolPrivateStaticMethod:

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -3864,10 +3864,12 @@ func TestPreserveOptionalChainParentheses(t *testing.T) {
 
 func TestPrivateIdentifiers(t *testing.T) {
 	expectParseError(t, "#foo", "<stdin>: error: Unexpected \"#foo\"\n")
+	expectParseError(t, "#foo in this", "<stdin>: error: Unexpected \"#foo\"\n")
 	expectParseError(t, "this.#foo", "<stdin>: error: Expected identifier but found \"#foo\"\n")
 	expectParseError(t, "this?.#foo", "<stdin>: error: Expected identifier but found \"#foo\"\n")
 	expectParseError(t, "({ #foo: 1 })", "<stdin>: error: Expected identifier but found \"#foo\"\n")
 	expectParseError(t, "class Foo { x = { #foo: 1 } }", "<stdin>: error: Expected identifier but found \"#foo\"\n")
+	expectParseError(t, "class Foo { x = #foo }", "<stdin>: error: Expected \"in\" but found \"}\"\n")
 	expectParseError(t, "class Foo { #foo; foo() { delete this.#foo } }",
 		"<stdin>: error: Deleting the private name \"#foo\" is forbidden\n")
 	expectParseError(t, "class Foo { #foo; foo() { delete this?.#foo } }",
@@ -3877,6 +3879,7 @@ func TestPrivateIdentifiers(t *testing.T) {
 
 	expectPrinted(t, "class Foo { #foo }", "class Foo {\n  #foo;\n}\n")
 	expectPrinted(t, "class Foo { #foo = 1 }", "class Foo {\n  #foo = 1;\n}\n")
+	expectPrinted(t, "class Foo { #foo = #foo in this }", "class Foo {\n  #foo = #foo in this;\n}\n")
 	expectPrinted(t, "class Foo { #foo() {} }", "class Foo {\n  #foo() {\n  }\n}\n")
 	expectPrinted(t, "class Foo { get #foo() {} }", "class Foo {\n  get #foo() {\n  }\n}\n")
 	expectPrinted(t, "class Foo { set #foo(x) {} }", "class Foo {\n  set #foo(x) {\n  }\n}\n")
@@ -3930,6 +3933,8 @@ func TestPrivateIdentifiers(t *testing.T) {
 	expectParseError(t, "class Foo { #foo } class Bar { foo = this.#foo }",
 		"<stdin>: error: Private name \"#foo\" must be declared in an enclosing class\n")
 	expectParseError(t, "class Foo { #foo } class Bar { foo = this?.#foo }",
+		"<stdin>: error: Private name \"#foo\" must be declared in an enclosing class\n")
+	expectParseError(t, "class Foo { #foo } class Bar { foo = #foo in this }",
 		"<stdin>: error: Private name \"#foo\" must be declared in an enclosing class\n")
 
 	// Getter and setter warnings

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -2095,7 +2095,7 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags int) {
 		}
 
 		// Special-case "#foo in bar"
-		if private, ok := e.Left.Data.(*js_ast.EPrivateIdentifier); ok {
+		if private, ok := e.Left.Data.(*js_ast.EPrivateIdentifier); ok && e.Op == js_ast.BinOpIn {
 			p.printSymbol(private.Ref)
 		} else {
 			p.printExpr(e.Left, leftLevel, flags&forbidIn)

--- a/internal/js_printer/js_printer_test.go
+++ b/internal/js_printer/js_printer_test.go
@@ -596,6 +596,11 @@ func TestClass(t *testing.T) {
 	expectPrinted(t, "class Foo { static set foo(x) {} }", "class Foo {\n  static set foo(x) {\n  }\n}\n")
 }
 
+func TestPrivateIdentifiers(t *testing.T) {
+	expectPrinted(t, "class Foo { #foo; foo() { return #foo in this } }", "class Foo {\n  #foo;\n  foo() {\n    return #foo in this;\n  }\n}\n")
+	expectPrintedMinify(t, "class Foo { #foo; foo() { return #foo in this } }", "class Foo{#foo;foo(){return#foo in this}}")
+}
+
 func TestImport(t *testing.T) {
 	expectPrinted(t, "import('path');", "import(\"path\");\n") // The semicolon must not be a separate statement
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -218,6 +218,10 @@ func code(isES6 bool) string {
 		var __accessCheck = (obj, member, msg) => {
 			if (!member.has(obj)) throw TypeError('Cannot ' + msg)
 		}
+		export var __privateIn = (member, obj) => {
+			if (Object(obj) !== obj) throw TypeError('Cannot use the "in" operator on this value')
+			return member.has(obj)
+		}
 		export var __privateGet = (obj, member, getter) => {
 			__accessCheck(obj, member, 'read from private field')
 			return getter ? getter.call(obj) : member.get(obj)

--- a/scripts/compat-table.js
+++ b/scripts/compat-table.js
@@ -71,6 +71,9 @@ const features = {
   'private class methods: private accessor properties': { target: 'ClassPrivateAccessor' },
   'private class methods: private static methods': { target: 'ClassPrivateStaticMethod' },
   'private class methods: private static accessor properties': { target: 'ClassPrivateStaticAccessor' },
+
+  // Private "in"
+  'Ergonomic brand checks for private fields': { target: 'ClassPrivateBrandCheck' },
 }
 
 const versions = {}


### PR DESCRIPTION
This introduces new JavaScript syntax:

```js
class Foo {
  #field
  static isFoo(x) {
    return #foo in x // This is an "ergonomic brand check"
  }
}
assert(Foo.isFoo(new Foo))
```

[The TC39 proposal for this feature](https://github.com/tc39/proposal-private-fields-in-in) is currently at stage 3 but has already been shipped in Chrome 91 and has also landed in Firefox. It seems reasonably inevitable given that it's already shipping and that it's a very simple feature, so it seems appropriate to add this feature to esbuild.

The most recent update (and the reason for this PR) is that tests for this feature have finally landed: https://github.com/tc39/test262/pull/2963.
