### PR TITLE
Minify property accesses on object literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@
 
     This is a new flag that allows output files to overwrite input files. It's not enabled by default because doing so means overwriting your source code, which can lead to data loss if your code is not checked in. But supporting this makes certain workflows easier by avoiding the need for a temporary directory so doing this is now supported.
 
+* Minify property accesses on object literals ([#1166](https://github.com/evanw/esbuild/issues/1166))
+
+    The code `{a: {b: 1}}.a.b` will now be minified to `1`. This optimization is relatively complex and hard to do safely. Here are some tricky cases that are correctly handled:
+
+    ```js
+    var obj = {a: 1}
+    assert({a: 1, a: 2}.a === 2)
+    assert({a: 1, [String.fromCharCode(97)]: 2}.a === 2)
+    assert({__proto__: obj}.a === 1)
+    assert({__proto__: null}.a === undefined)
+    assert({__proto__: null}.__proto__ === undefined)
+    assert({a: function() { return this.b }, b: 1}.a() === 1)
+    assert(({a: 1}.a = 2) === 2)
+    assert(++{a: 1}.a === 2)
+    assert.throws(() => { new ({ a() {} }.a) })
+    ```
+
 ## 0.11.12
 
 * Fix a bug where `-0` and `0` were collapsed to the same value ([#1159](https://github.com/evanw/esbuild/issues/1159))

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2930,6 +2930,18 @@ func TestMangleObject(t *testing.T) {
 	expectPrintedMangle(t, "x = {a, ...'123', b}", "x = {a, ...\"123\", b};\n")
 	expectPrintedMangle(t, "x = {a, ...[1, 2, 3], b}", "x = {a, ...[1, 2, 3], b};\n")
 	expectPrintedMangle(t, "x = {a, ...(()=>{})(), b}", "x = {a, ...(() => {\n})(), b};\n")
+
+	// Check simple cases of object simplification (advanced cases are checked in end-to-end tests)
+	expectPrintedMangle(t, "x = {['y']: z}.y", "x = {y: z}.y;\n")
+	expectPrintedMangle(t, "x = {['y']: z}.y; var z", "x = z;\nvar z;\n")
+	expectPrintedMangle(t, "x = {foo: foo(), y: 1}.y", "x = {foo: foo(), y: 1}.y;\n")
+	expectPrintedMangle(t, "x = {foo: /* @__PURE__ */ foo(), y: 1}.y", "x = 1;\n")
+	expectPrintedMangle(t, "x = {__proto__: null}.y", "x = void 0;\n")
+	expectPrintedMangle(t, "x = {__proto__: null, y: 1}.y", "x = 1;\n")
+	expectPrintedMangle(t, "x = {__proto__: null}.__proto__", "x = void 0;\n")
+	expectPrintedMangle(t, "x = {['__proto__']: null}.y", "x = {[\"__proto__\"]: null}.y;\n")
+	expectPrintedMangle(t, "x = {['__proto__']: null, y: 1}.y", "x = {[\"__proto__\"]: null, y: 1}.y;\n")
+	expectPrintedMangle(t, "x = {['__proto__']: null}.__proto__", "x = {[\"__proto__\"]: null}.__proto__;\n")
 }
 
 func TestMangleArrow(t *testing.T) {


### PR DESCRIPTION
The code `{a: {b: 1}}.a.b` will now be minified to `1`. This optimization is relatively complex and hard to do safely. Here are some tricky cases that are correctly handled:

```js
var obj = {a: 1}
assert({a: 1, a: 2}.a === 2)
assert({a: 1, [String.fromCharCode(97)]: 2}.a === 2)
assert({__proto__: obj}.a === 1)
assert({__proto__: null}.a === undefined)
assert({__proto__: null}.__proto__ === undefined)
assert({a: function() { return this.b }, b: 1}.a() === 1)
assert(({a: 1}.a = 2) === 2)
assert(++{a: 1}.a === 2)
assert.throws(() => { new ({ a() {} }.a) })
```

Fixes #1166