### PR TITLE
Improve StringToUTF16 performance by ~2-3x

### DIFF
--- a/internal/js_lexer/js_lexer.go
+++ b/internal/js_lexer/js_lexer.go
@@ -2660,7 +2660,7 @@ func ContainsNonBMPCodePointUTF16(text []uint16) bool {
 }
 
 func StringToUTF16(text string) []uint16 {
-	decoded := []uint16{}
+	decoded := make([]uint16, 0, len(text))
 	for _, c := range text {
 		if c <= 0xFFFF {
 			decoded = append(decoded, uint16(c))


### PR DESCRIPTION
Benchmark code:
```go
func BenchmarkStringToUTF16(b *testing.B) {
	text := "Hello This is A String"

	for n := 0; n < b.N; n++ {
		js_lexer.StringToUTF16(text)
	}
	
}

func BenchmarkEmojiStringToUTF16(b *testing.B) {
	text := "Hello This is A UTF16 🍿🙀 🙋🇨🇦 and 👍🏿 and 👨‍👨‍👧‍👧 are also “astral” plane emojis, only they’re made out of 2+ surrogate pairs:"

	for n := 0; n < b.N; n++ {
		js_lexer.StringToUTF16(text)
	}
}
```

Before (ASCII):
```
Running tool: /Users/jarredsumner/.asdf/shims/go test -benchmem -run=^$ -bench ^(BenchmarkStringToUTF16)$ github.com/evanw/esbuild/internal/js_lexer

goos: darwin
goarch: amd64
pkg: github.com/evanw/esbuild/internal/js_lexer
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkStringToUTF16-16    	 8602806	       142.8 ns/op	     120 B/op	       4 allocs/op
PASS
ok  	github.com/evanw/esbuild/internal/js_lexer	1.457s
```

After: (ASCII):
```
Running tool: /Users/jarredsumner/.asdf/shims/go test -benchmem -run=^$ -bench ^(BenchmarkStringToUTF16)$ github.com/evanw/esbuild/internal/js_lexer

goos: darwin
goarch: amd64
pkg: github.com/evanw/esbuild/internal/js_lexer
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkStringToUTF16-16    	24977662	        42.68 ns/op	      48 B/op	       1 allocs/op
PASS
ok  	github.com/evanw/esbuild/internal/js_lexer	1.295s
```

Before (UTF16):
```
Running tool: /Users/jarredsumner/.asdf/shims/go test -benchmem -run=^$ -bench ^(BenchmarkEmojiStringToUTF16)$ github.com/evanw/esbuild/internal/js_lexer

goos: darwin
goarch: amd64
pkg: github.com/evanw/esbuild/internal/js_lexer
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEmojiStringToUTF16-16    	 2286937	       530.4 ns/op	    1016 B/op	       7 allocs/op
PASS
ok  	github.com/evanw/esbuild/internal/js_lexer	1.963s
```

After (UTF16):
```
Running tool: /Users/jarredsumner/.asdf/shims/go test -benchmem -run=^$ -bench ^(BenchmarkEmojiStringToUTF16)$ github.com/evanw/esbuild/internal/js_lexer

goos: darwin
goarch: amd64
pkg: github.com/evanw/esbuild/internal/js_lexer
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEmojiStringToUTF16-16    	 3843602	       289.4 ns/op	     352 B/op	       1 allocs/op
PASS
ok  	github.com/evanw/esbuild/internal/js_lexer	1.639s

```