### PR TITLE
Implement arbitrary module namespace identifier names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+* Implement arbitrary module namespace identifiers
+
+    This introduces new JavaScript syntax:
+
+    ```js
+    import {'🍕' as food} from 'file'
+    export {food as '🧀'}
+    ```
+
+    [The proposal for this feature](https://github.com/bmeck/proposal-arbitrary-module-namespace-identifiers) appears to not be going through the regular TC39 process. It is being done as a subtle [direct pull request](https://github.com/tc39/ecma262/pull/2154) instead. It seems appropriate for esbuild to support this feature since it has been implemented in V8 and has now shipped in Chrome 90 and node 16.
+
+    According to the proposal, this feature is intended to improve interop with non-JavaScript languages which use exports that aren't valid JavaScript identifiers such as `Foo::~Foo`. In particular, WebAssembly allows any valid UTF-8 string as to be used as an export alias.
+
+    This feature was actually already partially possible in previous versions of JavaScript via the computed property syntax:
+
+    ```js
+    import * as ns from './file.json'
+    console.log(ns['🍕'])
+    ```
+
+    However, doing this is very un-ergonomic and exporting something as an arbitrary name is impossible outside of `export * from`. So this proposal is designed to fully fill out the possibility matrix and make arbitrary alias names a proper first-class feature.
+
 ## 0.11.13
 
 * Implement ergonomic brand checks for private fields

--- a/internal/bundler/bundler_loader_test.go
+++ b/internal/bundler/bundler_loader_test.go
@@ -3,6 +3,7 @@ package bundler
 import (
 	"testing"
 
+	"github.com/evanw/esbuild/internal/compat"
 	"github.com/evanw/esbuild/internal/config"
 )
 
@@ -339,6 +340,21 @@ func TestLoaderJSONNoBundle(t *testing.T) {
 }
 
 func TestLoaderJSONNoBundleES6(t *testing.T) {
+	loader_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/test.json": `{"test": 123, "invalid-identifier": true}`,
+		},
+		entryPaths: []string{"/test.json"},
+		options: config.Options{
+			Mode:                  config.ModeConvertFormat,
+			OutputFormat:          config.FormatESModule,
+			UnsupportedJSFeatures: compat.ArbitraryModuleNamespaceNames,
+			AbsOutputFile:         "/out.js",
+		},
+	})
+}
+
+func TestLoaderJSONNoBundleES6ArbitraryModuleNamespaceNames(t *testing.T) {
 	loader_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/test.json": `{"test": 123, "invalid-identifier": true}`,

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -1532,7 +1532,9 @@ func (c *linkerContext) generateCodeForLazyExport(sourceIndex uint32) {
 		clone := *object
 		clone.Properties = append(make([]js_ast.Property, 0, len(clone.Properties)), clone.Properties...)
 		for i, property := range clone.Properties {
-			if str, ok := property.Key.Data.(*js_ast.EString); ok && (!file.IsEntryPoint() || js_lexer.IsIdentifierUTF16(str.Value)) {
+			if str, ok := property.Key.Data.(*js_ast.EString); ok &&
+				(!file.IsEntryPoint() || js_lexer.IsIdentifierUTF16(str.Value) ||
+					!c.options.UnsupportedJSFeatures.Has(compat.ArbitraryModuleNamespaceNames)) {
 				name := js_lexer.UTF16ToString(str.Value)
 				exportRef := generateExport(name, name, *property.Value).ref
 				prevExports = append(prevExports, exportRef)

--- a/internal/bundler/snapshots/snapshots_loader.txt
+++ b/internal/bundler/snapshots/snapshots_loader.txt
@@ -154,6 +154,18 @@ export {
 };
 
 ================================================================================
+TestLoaderJSONNoBundleES6ArbitraryModuleNamespaceNames
+---------- /out.js ----------
+var test = 123;
+var invalid_identifier = true;
+var test_default = {test, "invalid-identifier": invalid_identifier};
+export {
+  test_default as default,
+  invalid_identifier as "invalid-identifier",
+  test
+};
+
+================================================================================
 TestLoaderJSONNoBundleIIFE
 ---------- /out.js ----------
 (() => {

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -37,7 +37,8 @@ func (e Engine) String() string {
 type JSFeature uint64
 
 const (
-	ArraySpread JSFeature = 1 << iota
+	ArbitraryModuleNamespaceNames JSFeature = 1 << iota
+	ArraySpread
 	Arrow
 	AsyncAwait
 	AsyncGenerator
@@ -84,6 +85,10 @@ func (features JSFeature) Has(feature JSFeature) bool {
 }
 
 var jsTable = map[JSFeature]map[Engine][]int{
+	ArbitraryModuleNamespaceNames: {
+		Chrome: {90},
+		Node:   {16},
+	},
 	ArraySpread: {
 		Chrome:  {46},
 		Edge:    {13},

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -92,6 +92,11 @@ func (p *parser) markSyntaxFeature(feature compat.JSFeature, r logger.Range) (di
 			fmt.Sprintf("Top-level await is not available in %s", where))
 		return
 
+	case compat.ArbitraryModuleNamespaceNames:
+		p.log.AddRangeError(&p.source, r,
+			fmt.Sprintf("Using a string as a module namespace identifier name is not supported in %s", where))
+		return
+
 	case compat.BigInt:
 		// Transforming these will never be supported
 		p.log.AddRangeError(&p.source, r,

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -1469,7 +1469,7 @@ func TestTSTypeOnlyImport(t *testing.T) {
 	expectPrintedTS(t, "import type * as foo from 'bar'; x", "x;\n")
 	expectPrintedTS(t, "import type * as foo from 'bar'\nx", "x;\n")
 	expectPrintedTS(t, "import type {foo, bar as baz} from 'bar'; x", "x;\n")
-	expectPrintedTS(t, "import type {foo, bar as baz} from 'bar'\nx", "x;\n")
+	expectPrintedTS(t, "import type {'foo' as bar} from 'bar'\nx", "x;\n")
 
 	expectPrintedTS(t, "import type = bar; type", "const type = bar;\ntype;\n")
 	expectPrintedTS(t, "import type = foo.bar; type", "const type = foo.bar;\ntype;\n")
@@ -1484,7 +1484,7 @@ func TestTSTypeOnlyImport(t *testing.T) {
 	expectParseErrorTS(t, "import type", "<stdin>: error: Expected \"from\" but found end of file\n")
 	expectParseErrorTS(t, "import type * foo", "<stdin>: error: Expected \"as\" but found \"foo\"\n")
 	expectParseErrorTS(t, "import type * as 'bar'", "<stdin>: error: Expected identifier but found \"'bar'\"\n")
-	expectParseErrorTS(t, "import type { 'bar'", "<stdin>: error: Expected identifier but found \"'bar'\"\n")
+	expectParseErrorTS(t, "import type { 'bar' }", "<stdin>: error: Expected \"as\" but found \"}\"\n")
 
 	expectParseErrorTS(t, "import type foo, * as foo from 'bar'", "<stdin>: error: Expected \"from\" but found \",\"\n")
 	expectParseErrorTS(t, "import type foo, {foo} from 'bar'", "<stdin>: error: Expected \"from\" but found \",\"\n")

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -702,6 +702,15 @@ func (p *printer) printSymbol(ref js_ast.Ref) {
 	p.printIdentifier(name)
 }
 
+func (p *printer) printClauseAlias(alias string) {
+	if js_lexer.IsIdentifier(alias) {
+		p.printSpaceBeforeIdentifier()
+		p.printIdentifier(alias)
+	} else {
+		p.printQuotedUTF8(alias, false /* allowBacktick */)
+	}
+}
+
 func CanQuoteIdentifier(name string, unsupportedJSFeatures compat.JSFeature, asciiOnly bool) bool {
 	return js_lexer.IsIdentifier(name) && (!asciiOnly ||
 		!unsupportedJSFeatures.Has(compat.UnicodeEscapes) ||
@@ -2603,8 +2612,7 @@ func (p *printer) printStmt(stmt js_ast.Stmt) {
 		if s.Alias != nil {
 			p.print("as")
 			p.printSpace()
-			p.printSpaceBeforeIdentifier()
-			p.printIdentifier(s.Alias.OriginalName)
+			p.printClauseAlias(s.Alias.OriginalName)
 			p.printSpace()
 			p.printSpaceBeforeIdentifier()
 		}
@@ -2639,8 +2647,9 @@ func (p *printer) printStmt(stmt js_ast.Stmt) {
 			name := p.renamer.NameForSymbol(item.Name.Ref)
 			p.printIdentifier(name)
 			if name != item.Alias {
-				p.print(" as ")
-				p.printIdentifier(item.Alias)
+				p.print(" as")
+				p.printSpace()
+				p.printClauseAlias(item.Alias)
 			}
 		}
 
@@ -2676,10 +2685,13 @@ func (p *printer) printStmt(stmt js_ast.Stmt) {
 				p.printNewline()
 				p.printIndent()
 			}
-			p.printIdentifier(item.OriginalName)
+			p.printClauseAlias(item.OriginalName)
 			if item.OriginalName != item.Alias {
-				p.print(" as ")
-				p.printIdentifier(item.Alias)
+				p.printSpace()
+				p.printSpaceBeforeIdentifier()
+				p.print("as")
+				p.printSpace()
+				p.printClauseAlias(item.Alias)
 			}
 		}
 
@@ -2930,10 +2942,12 @@ func (p *printer) printStmt(stmt js_ast.Stmt) {
 					p.printNewline()
 					p.printIndent()
 				}
-				p.printIdentifier(item.Alias)
+				p.printClauseAlias(item.Alias)
 				name := p.renamer.NameForSymbol(item.Name.Ref)
 				if name != item.Alias {
-					p.print(" as ")
+					p.printSpace()
+					p.printSpaceBeforeIdentifier()
+					p.print("as ")
 					p.printIdentifier(name)
 				}
 			}

--- a/internal/js_printer/js_printer_test.go
+++ b/internal/js_printer/js_printer_test.go
@@ -726,9 +726,14 @@ func TestMinify(t *testing.T) {
 	expectPrintedMinify(t, "import a from 'path'", "import a from\"path\";")
 	expectPrintedMinify(t, "import * as ns from 'path'", "import*as ns from\"path\";")
 	expectPrintedMinify(t, "import {a, b as c} from 'path'", "import{a,b as c}from\"path\";")
+	expectPrintedMinify(t, "import {a, ' ' as c} from 'path'", "import{a,\" \"as c}from\"path\";")
 
 	expectPrintedMinify(t, "export * as ns from 'path'", "export*as ns from\"path\";")
+	expectPrintedMinify(t, "export * as ' ' from 'path'", "export*as\" \"from\"path\";")
 	expectPrintedMinify(t, "export {a, b as c} from 'path'", "export{a,b as c}from\"path\";")
+	expectPrintedMinify(t, "export {' ', '-' as ';'} from 'path'", "export{\" \",\"-\"as\";\"}from\"path\";")
+	expectPrintedMinify(t, "let a, b; export {a, b as c}", "let a,b;export{a,b as c};")
+	expectPrintedMinify(t, "let a, b; export {a, b as ' '}", "let a,b;export{a,b as\" \"};")
 
 	// Print some strings using template literals when minifying
 	expectPrinted(t, "x = '\\n'", "x = \"\\n\";\n")

--- a/scripts/compat-table.js
+++ b/scripts/compat-table.js
@@ -154,6 +154,7 @@ mergeVersions('ImportMeta', { es2020: true })
 mergeVersions('NullishCoalescing', { es2020: true })
 mergeVersions('OptionalChain', { es2020: true })
 mergeVersions('TopLevelAwait', {})
+mergeVersions('ArbitraryModuleNamespaceNames', {})
 
 // Manually copied from https://caniuse.com/?search=export%20*%20as
 mergeVersions('ExportStarAs', {
@@ -188,6 +189,12 @@ mergeVersions('DynamicImport', {
   ios11: true,
   node13_2: true, // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
   safari11_1: true,
+})
+
+// From https://github.com/tc39/ecma262/pull/2154#issuecomment-825201030
+mergeVersions('ArbitraryModuleNamespaceNames', {
+  chrome90: true,
+  node16: true,
 })
 
 for (const test of [...es5.tests, ...es6.tests, ...stage4.tests, ...stage1to3.tests]) {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -230,6 +230,35 @@
     }),
   )
 
+  // Test arbitrary module namespace identifier names
+  // See https://github.com/tc39/ecma262/pull/2154
+  tests.push(
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {'*' as star} from './export.js'; if (star !== 123) throw 'fail'`,
+      'export.js': `let foo = 123; export {foo as '*'}`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {'\\0' as bar} from './export.js'; if (bar !== 123) throw 'fail'`,
+      'export.js': `let foo = 123; export {foo as '\\0'}`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {'\\uD800\\uDC00' as bar} from './export.js'; if (bar !== 123) throw 'fail'`,
+      'export.js': `let foo = 123; export {foo as '\\uD800\\uDC00'}`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {'🍕' as bar} from './export.js'; if (bar !== 123) throw 'fail'`,
+      'export.js': `let foo = 123; export {foo as '🍕'}`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {' ' as bar} from './export.js'; if (bar !== 123) throw 'fail'`,
+      'export.js': `export let foo = 123; export {foo as ' '} from './export.js'`,
+    }),
+    test(['entry.js', '--bundle', '--outfile=node.js'], {
+      'entry.js': `import {'' as ab} from './export.js'; if (ab.foo !== 123 || ab.bar !== 234) throw 'fail'`,
+      'export.js': `export let foo = 123, bar = 234; export * as '' from './export.js'`,
+    }),
+  )
+
   // Tests for symlinks
   //
   // Note: These are disabled on Windows because they fail when run with GitHub
@@ -1499,7 +1528,7 @@
         let fn = async () => {
           let error
           await import('./out.js').catch(x => error = x)
-          if (!error || error.message !== 'require is not defined') throw 'fail'
+          if (!error || !error.message.includes('require is not defined')) throw 'fail'
         }
         export {fn as async}
       `,
@@ -1520,7 +1549,7 @@
         let fn = async () => {
           let error
           await import('./out.js').catch(x => error = x)
-          if (!error || error.message !== 'require is not defined') throw 'fail'
+          if (!error || !error.message.includes('require is not defined')) throw 'fail'
         }
         export {fn as async}
       `,


### PR DESCRIPTION
This introduces new JavaScript syntax:

```js
import {'🍕' as food} from 'file'
export {food as '🧀'}
```

[The proposal for this feature](https://github.com/bmeck/proposal-arbitrary-module-namespace-identifiers) appears to not be going through the regular TC39 process. It is being done as a subtle [direct pull request](https://github.com/tc39/ecma262/pull/2154) instead. It seems appropriate for esbuild to support this feature since it has been implemented in V8 and has now shipped in Chrome 90 and node 16.

According to the proposal, this feature is intended to improve interop with non-JavaScript languages which use exports that aren't valid JavaScript identifiers such as `Foo::~Foo`. In particular, WebAssembly allows any valid UTF-8 string as to be used as an export alias.

This feature was actually already partially possible in previous versions of JavaScript via the computed property syntax:

```js
import * as ns from './file.json'
console.log(ns['🍕'])
```

However, doing this is very un-ergonomic and exporting something as an arbitrary name is impossible outside of `export * from`. So this proposal is designed to fully fill out the possibility matrix and make arbitrary alias names a proper first-class feature.
