### PR TITLE
Speed up ProcessDefines by like 0.03ms 

### DIFF
--- a/internal/config/globals.go
+++ b/internal/config/globals.go
@@ -871,7 +871,7 @@ func ProcessDefines(userDefines map[string]DefineData) ProcessedDefines {
 	result := ProcessedDefines{
 		// Estimate the number of identifier defines \{"([\w\d])+"\},
 		IdentifierDefines: make(map[string]DefineData, 639),
-		DotDefines:        make(map[string][]DotDefine),
+		DotDefines:        make(map[string][]DotDefine, 38),
 	}
 
 	// Mark these property accesses as free of side effects. That means they can

--- a/internal/config/globals.go
+++ b/internal/config/globals.go
@@ -869,7 +869,8 @@ func ProcessDefines(userDefines map[string]DefineData) ProcessedDefines {
 	}
 
 	result := ProcessedDefines{
-		IdentifierDefines: make(map[string]DefineData),
+		// Estimate the number of identifier defines \{"([\w\d])+"\},
+		IdentifierDefines: make(map[string]DefineData, 639),
 		DotDefines:        make(map[string][]DotDefine),
 	}
 


### PR DESCRIPTION
I thought this would have more impact but it does not

```go
func BenchmarkProcessDefines(b *testing.B) {
	smallMap := make(map[string]config.DefineData, 1)
	smallMap["process.env.NODE_ENV"] = config.DefineData{}

	for i := 0; i < b.N; i++ {
		config.ProcessDefines(smallMap)
	}

}
// Before:
// BenchmarkProcessDefines-16    	   15420	     75798 ns/op	  100711 B/op	     134 allocs/op
// After:
// BenchmarkProcessDefines-16    	   26157	     39537 ns/op	   55366 B/op	     107 allocs/op
```