### PR TITLE
Provide options for how to handle legal comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+* Provide options for how to handle legal comments ([#919](https://github.com/evanw/esbuild/issues/919))
+
+    A "legal comment" is considered to be any comment that contains `@license` or `@preserve` or that starts with `//!` or `/*!`. These comments are preserved in output files by esbuild since that follows the intent of the original authors of the code.
+
+    However, some people want to remove the automatically-generated license information before they distribute their code. To facilitate this, esbuild now provides several options for how to handle legal comments (via `--legal-comments=` in the CLI and `legalComments` in the JS API):
+
+    * `none`: Do not preserve any legal comments
+    * `inline`: Preserve all statement-level legal comments
+    * `eof`: Move all statement-level legal comments to the end of the file
+    * `linked`: Move all statement-level legal comments to a `.LICENSE.txt` file and link to them with a comment
+    * `external`: Move all statement-level legal comments to a `.LICENSE.txt` file but to not link to them
+
+    The default behavior is `eof` when bundling and `inline` otherwise.
+
 ## 0.11.14
 
 * Implement arbitrary module namespace identifiers

--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -65,6 +65,9 @@ var helpText = func(colors logger.Colors) string {
   --jsx-factory=...         What to use for JSX instead of React.createElement
   --jsx-fragment=...        What to use for JSX instead of React.Fragment
   --keep-names              Preserve "name" on functions and classes
+  --legal-comments=...      Where to place license comments (none | inline |
+                            eof | linked | external, default eof when bundling
+                            and inline otherwise)
   --log-level=...           Disable logging (verbose | debug | info | warning |
                             error | silent, default info)
   --log-limit=...           Maximum message count or 0 to disable (default 10)

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -2885,7 +2885,7 @@ func TestImportMetaNoBundle(t *testing.T) {
 	})
 }
 
-func TestDeduplicateCommentsInBundle(t *testing.T) {
+func TestLegalCommentsNone(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.js": `
@@ -2899,9 +2899,72 @@ func TestDeduplicateCommentsInBundle(t *testing.T) {
 		},
 		entryPaths: []string{"/entry.js"},
 		options: config.Options{
-			Mode:             config.ModeBundle,
-			RemoveWhitespace: true,
-			AbsOutputFile:    "/out.js",
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+			LegalComments: config.LegalCommentsNone,
+		},
+	})
+}
+
+func TestLegalCommentsInline(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import './a'
+				import './b'
+				import './c'
+			`,
+			"/a.js": `console.log('in a') //! Copyright notice 1`,
+			"/b.js": `console.log('in b') //! Copyright notice 1`,
+			"/c.js": `console.log('in c') //! Copyright notice 2`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+			LegalComments: config.LegalCommentsInline,
+		},
+	})
+}
+
+func TestLegalCommentsLinked(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import './a'
+				import './b'
+				import './c'
+			`,
+			"/a.js": `console.log('in a') //! Copyright notice 1`,
+			"/b.js": `console.log('in b') //! Copyright notice 1`,
+			"/c.js": `console.log('in c') //! Copyright notice 2`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+			LegalComments: config.LegalCommentsLinkedWithComment,
+		},
+	})
+}
+
+func TestLegalCommentsExternal(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import './a'
+				import './b'
+				import './c'
+			`,
+			"/a.js": `console.log('in a') //! Copyright notice 1`,
+			"/b.js": `console.log('in b') //! Copyright notice 1`,
+			"/c.js": `console.log('in c') //! Copyright notice 2`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+			LegalComments: config.LegalCommentsExternalWithoutComment,
 		},
 	})
 }

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -340,13 +340,6 @@ for (const e of x)
   console.log(e);
 
 ================================================================================
-TestDeduplicateCommentsInBundle
----------- /out.js ----------
-console.log("in a");console.log("in b");console.log("in c");
-//! Copyright notice 1
-//! Copyright notice 2
-
-================================================================================
 TestDefineImportMeta
 ---------- /out.js ----------
 // entry.js
@@ -1226,6 +1219,66 @@ new clsStmtKeep();
 var clsExprKeep = /* @__PURE__ */ __name(class {
 }, "keep");
 new clsExprKeep();
+
+================================================================================
+TestLegalCommentsExternal
+---------- /out.js.LICENSE.txt ----------
+//! Copyright notice 1
+//! Copyright notice 2
+
+---------- /out.js ----------
+// a.js
+console.log("in a");
+
+// b.js
+console.log("in b");
+
+// c.js
+console.log("in c");
+
+================================================================================
+TestLegalCommentsInline
+---------- /out.js ----------
+// a.js
+console.log("in a");
+//! Copyright notice 1
+
+// b.js
+console.log("in b");
+//! Copyright notice 1
+
+// c.js
+console.log("in c");
+//! Copyright notice 2
+
+================================================================================
+TestLegalCommentsLinked
+---------- /out.js.LICENSE.txt ----------
+//! Copyright notice 1
+//! Copyright notice 2
+
+---------- /out.js ----------
+// a.js
+console.log("in a");
+
+// b.js
+console.log("in b");
+
+// c.js
+console.log("in c");
+/*! For license information please see out.js.LICENSE.txt */
+
+================================================================================
+TestLegalCommentsNone
+---------- /out.js ----------
+// a.js
+console.log("in a");
+
+// b.js
+console.log("in b");
+
+// c.js
+console.log("in c");
 
 ================================================================================
 TestLoaderDataURLApplicationJSON

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,20 @@ const (
 	SourceMapInlineAndExternal
 )
 
+type LegalComments uint8
+
+const (
+	LegalCommentsInline LegalComments = iota
+	LegalCommentsNone
+	LegalCommentsEndOfFile
+	LegalCommentsLinkedWithComment
+	LegalCommentsExternalWithoutComment
+)
+
+func (lc LegalComments) HasExternalFile() bool {
+	return lc == LegalCommentsLinkedWithComment || lc == LegalCommentsExternalWithoutComment
+}
+
 type Loader int
 
 const (
@@ -186,6 +200,7 @@ type Options struct {
 	CodeSplitting     bool
 	WatchMode         bool
 	AllowOverwrite    bool
+	LegalComments     LegalComments
 
 	// Setting this to true disables warnings about code that is very likely to
 	// be a bug. This is used to ignore issues inside "node_modules" directories.

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -937,7 +937,8 @@ type SEmpty struct{}
 type STypeScript struct{}
 
 type SComment struct {
-	Text string
+	Text           string
+	IsLegalComment bool
 }
 
 type SDebugger struct{}

--- a/internal/js_lexer/js_lexer.go
+++ b/internal/js_lexer/js_lexer.go
@@ -2510,7 +2510,7 @@ func scanForPragmaArg(kind pragmaArg, start int, pragma string, text string) (js
 
 func (lexer *Lexer) scanCommentText() {
 	text := lexer.source.Contents[lexer.start:lexer.end]
-	hasPreserveAnnotation := len(text) > 2 && text[2] == '!'
+	hasLegalAnnotation := len(text) > 2 && text[2] == '!'
 	isMultiLineComment := text[1] == '*'
 
 	// Save the original comment text so we can subtract comments from the
@@ -2543,7 +2543,7 @@ func (lexer *Lexer) scanCommentText() {
 			if hasPrefixWithWordBoundary(rest, "__PURE__") {
 				lexer.HasPureCommentBefore = true
 			} else if hasPrefixWithWordBoundary(rest, "preserve") || hasPrefixWithWordBoundary(rest, "license") {
-				hasPreserveAnnotation = true
+				hasLegalAnnotation = true
 			} else if hasPrefixWithWordBoundary(rest, "jsx") {
 				if arg, ok := scanForPragmaArg(pragmaSkipSpaceFirst, lexer.start+i+1, "jsx", rest); ok {
 					lexer.JSXFactoryPragmaComment = arg
@@ -2560,7 +2560,7 @@ func (lexer *Lexer) scanCommentText() {
 		}
 	}
 
-	if hasPreserveAnnotation || lexer.PreserveAllCommentsBefore {
+	if hasLegalAnnotation || lexer.PreserveAllCommentsBefore {
 		if isMultiLineComment {
 			text = removeMultiLineCommentIndent(lexer.source.Contents[:lexer.start], text)
 		}

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -6331,8 +6331,11 @@ func (p *parser) parseStmtsUpTo(end js_lexer.T, opts parseStmtOpts) []js_ast.Stm
 		if len(comments) > 0 {
 			for _, comment := range comments {
 				stmts = append(stmts, js_ast.Stmt{
-					Loc:  comment.Loc,
-					Data: &js_ast.SComment{Text: comment.Text},
+					Loc: comment.Loc,
+					Data: &js_ast.SComment{
+						Text:           comment.Text,
+						IsLegalComment: true,
+					},
 				})
 			}
 		}

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -97,6 +97,7 @@ function pushLogFlags(flags: string[], options: CommonOptions, keys: OptionKeys,
 }
 
 function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKeys): void {
+  let legalComments = getFlag(options, keys, 'legalComments', mustBeString);
   let sourceRoot = getFlag(options, keys, 'sourceRoot', mustBeString);
   let sourcesContent = getFlag(options, keys, 'sourcesContent', mustBeBoolean);
   let target = getFlag(options, keys, 'target', mustBeStringOrArray);
@@ -114,6 +115,7 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   let pure = getFlag(options, keys, 'pure', mustBeArray);
   let keepNames = getFlag(options, keys, 'keepNames', mustBeBoolean);
 
+  if (legalComments) flags.push(`--legal-comments=${legalComments}`);
   if (sourceRoot !== void 0) flags.push(`--source-root=${sourceRoot}`);
   if (sourcesContent !== void 0) flags.push(`--sources-content=${sourcesContent}`);
   if (target) {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -7,6 +7,7 @@ export type TreeShaking = true | 'ignore-annotations';
 
 interface CommonOptions {
   sourcemap?: boolean | 'inline' | 'external' | 'both';
+  legalComments?: 'none' | 'inline' | 'eof' | 'linked' | 'external';
   sourceRoot?: string;
   sourcesContent?: boolean;
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -94,6 +94,17 @@ const (
 	SourcesContentExclude
 )
 
+type LegalComments uint8
+
+const (
+	LegalCommentsDefault LegalComments = iota
+	LegalCommentsNone
+	LegalCommentsInline
+	LegalCommentsEndOfFile
+	LegalCommentsLinked
+	LegalCommentsExternal
+)
+
 type Target uint8
 
 const (
@@ -237,6 +248,7 @@ type BuildOptions struct {
 	MinifySyntax      bool
 	Charset           Charset
 	TreeShaking       TreeShaking
+	LegalComments     LegalComments
 
 	JSXFactory  string
 	JSXFragment string
@@ -343,6 +355,7 @@ type TransformOptions struct {
 	MinifySyntax      bool
 	Charset           Charset
 	TreeShaking       TreeShaking
+	LegalComments     LegalComments
 
 	JSXFactory  string
 	JSXFragment string

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -95,6 +95,29 @@ func parseOptionsImpl(
 				transformOpts.MinifyIdentifiers = true
 			}
 
+		case strings.HasPrefix(arg, "--legal-comments="):
+			value := arg[len("--legal-comments="):]
+			var legalComments api.LegalComments
+			switch value {
+			case "none":
+				legalComments = api.LegalCommentsNone
+			case "inline":
+				legalComments = api.LegalCommentsInline
+			case "eof":
+				legalComments = api.LegalCommentsEndOfFile
+			case "linked":
+				legalComments = api.LegalCommentsLinked
+			case "external":
+				legalComments = api.LegalCommentsExternal
+			default:
+				return fmt.Errorf("Invalid legal comments value: %q (valid: none, inline, eof, linked, external)", value), nil
+			}
+			if buildOpts != nil {
+				buildOpts.LegalComments = legalComments
+			} else {
+				transformOpts.LegalComments = legalComments
+			}
+
 		case strings.HasPrefix(arg, "--charset="):
 			var value *api.Charset
 			if buildOpts != nil {

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -3622,6 +3622,26 @@ let transformTests = {
     assert.strictEqual(json.sourcesContent[0], input)
   },
 
+  async transformLegalComments({ esbuild }) {
+    assert.strictEqual((await esbuild.transform(`//!x\ny()`, { legalComments: 'none' })).code, `y();\n`)
+    assert.strictEqual((await esbuild.transform(`//!x\ny()`, { legalComments: 'inline' })).code, `//!x\ny();\n`)
+    assert.strictEqual((await esbuild.transform(`//!x\ny()`, { legalComments: 'eof' })).code, `y();\n//!x\n`)
+    try {
+      await esbuild.transform(``, { legalComments: 'linked' })
+      throw new Error('Expected a transform failure')
+    } catch (e) {
+      if (!e || !e.errors || !e.errors[0] || e.errors[0].text !== 'Cannot transform with linked or external legal comments')
+        throw e
+    }
+    try {
+      await esbuild.transform(``, { legalComments: 'external' })
+      throw new Error('Expected a transform failure')
+    } catch (e) {
+      if (!e || !e.errors || !e.errors[0] || e.errors[0].text !== 'Cannot transform with linked or external legal comments')
+        throw e
+    }
+  },
+
   async tsDecorators({ esbuild }) {
     const { code } = await esbuild.transform(`
       let observed = [];


### PR DESCRIPTION
A "legal comment" is considered to be any comment that contains `@license` or `@preserve` or that starts with `//!` or `/*!`. These comments are preserved in output files by esbuild since that follows the intent of the original authors of the code.

However, some people want to remove the automatically-generated license information before they distribute their code. To facilitate this, esbuild now provides several options for how to handle legal comments (via `--legal-comments=` in the CLI and `legalComments` in the JS API):

* `none`: Do not preserve any legal comments
* `inline`: Preserve all statement-level legal comments
* `eof`: Move all statement-level legal comments to the end of the file
* `linked`: Move all statement-level legal comments to a `.LICENSE.txt` file and link to them with a comment
* `external`: Move all statement-level legal comments to a `.LICENSE.txt` file but to not link to them

The default behavior is `eof` when bundling and `inline` otherwise.

Fixes #919
Closes #1033