### PR TITLE
fix(types): add missing "verbose" LogLevel

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -1,7 +1,7 @@
 export type Platform = 'browser' | 'node' | 'neutral';
 export type Format = 'iife' | 'cjs' | 'esm';
 export type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'css' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'binary' | 'default';
-export type LogLevel = 'debug' | 'info' | 'warning' | 'error' | 'silent';
+export type LogLevel = 'verbose' | 'debug' | 'info' | 'warning' | 'error' | 'silent';
 export type Charset = 'ascii' | 'utf8';
 export type TreeShaking = true | 'ignore-annotations';
 


### PR DESCRIPTION
According to the release https://github.com/evanw/esbuild/releases/tag/v0.11.12 you added "verbose" log level.
But I don't see new log level in the typescript declaration file.