### PR TITLE
Further changes to the behavior of the `browser` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 
     Previously this code incorrectly generated an error since `hover = 2` was incorrectly eagerly validated as a default argument. With this release, the reporting of the default argument error when targeting `es5` is now done lazily and only when it's determined that the parenthesized code should actually be interpreted as an arrow function parameter list.
 
+* Further changes to the behavior of the `browser` field ([#1209](https://github.com/evanw/esbuild/issues/1209))
+
+    This release includes some changes to how the `browser` field in `package.json` is interpreted to better match how Browserify, Webpack, Parcel, and Rollup behave. The interpretation of this map in esbuild is intended to be applied if and only if it's applied by any one of these bundlers. However, there were some cases where esbuild applied the mapping and none of the other bundlers did, which could lead to build failures. These cases have been added to my [growing list of `browser` field test cases](https://github.com/evanw/package-json-browser-tests) and esbuild's behavior should now be consistent with other bundlers again.
+
 ## 0.11.15
 
 * Provide options for how to handle legal comments ([#919](https://github.com/evanw/esbuild/issues/919))

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -618,7 +618,7 @@ func (r resolverQuery) resolveWithoutSymlinks(sourceDir string, importPath strin
 			return &ResolveResult{PathPair: PathPair{Primary: logger.Path{Text: absPath, Namespace: "file"}}, IsExternal: true}, DebugMeta{}
 		}
 
-		// Check the "browser" map for the first time (1 out of 2)
+		// Check the "browser" map
 		if importDirInfo := r.dirInfoCached(r.fs.Dir(absPath)); importDirInfo != nil {
 			if remapped, ok := r.checkBrowserMap(importDirInfo, absPath, absolutePathKind); ok {
 				if remapped == nil {
@@ -696,23 +696,6 @@ func (r resolverQuery) resolveWithoutSymlinks(sourceDir string, importPath strin
 		} else {
 			// Note: node's "self references" are not currently supported
 			return nil, debug
-		}
-	}
-
-	// Check the "browser" map for the second time (2 out of 2)
-	for _, path := range result.PathPair.iter() {
-		if resultDirInfo := r.dirInfoCached(r.fs.Dir(path.Text)); resultDirInfo != nil {
-			if remapped, ok := r.checkBrowserMap(resultDirInfo, path.Text, absolutePathKind); ok {
-				if remapped == nil {
-					path.Flags |= logger.PathDisabled
-				} else {
-					if remappedResult, ok, _, _ := r.resolveWithoutRemapping(resultDirInfo.enclosingBrowserScope, *remapped, kind); ok {
-						*path = remappedResult.Primary
-					} else {
-						return nil, DebugMeta{}
-					}
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
This release includes some changes to how the `browser` field in `package.json` is interpreted to better match how Browserify, Webpack, Parcel, and Rollup behave. The interpretation of this map in esbuild is intended to be applied if and only if it's applied by any one of these bundlers. However, there were some cases where esbuild applied the mapping and none of the other bundlers did, which could lead to build failures. These cases have been added to my [growing list of `browser` field test cases](https://github.com/evanw/package-json-browser-tests) and esbuild's behavior should now be consistent with other bundlers again.

Fixes: #1209
