### PR TITLE
Add primitive types

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -24,7 +24,7 @@ interface CommonOptions {
 
   jsxFactory?: string;
   jsxFragment?: string;
-  define?: { [key: string]: string };
+  define?: { [key: string]: number | string | boolean };
   pure?: string[];
   keepNames?: boolean;
 


### PR DESCRIPTION
I'm not sure why the Define option has only `string` type for values. I think it'll be fine to support other types as well
![image](https://user-images.githubusercontent.com/5789670/116670578-8ec7f100-a9a8-11eb-9159-9fe2f6d69b28.png)
