### PR TITLE
Use `sourceRoot` as base for `sources` paths

### DIFF
--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -4995,7 +4995,15 @@ func (c *linkerContext) generateSourceMapForChunk(
 		// Modify the absolute path to the original file to be relative to the
 		// directory that will contain the output file for this chunk
 		if item.path.Namespace == "file" {
-			if relPath, ok := c.fs.Rel(chunkAbsDir, item.path.Text); ok {
+			basePath := chunkAbsDir
+
+			// If "SourceRoot" is an absolute path, use it as the base for the
+			// relative paths
+			if sourceRootIsAbs := c.fs.IsAbs(c.options.SourceRoot); sourceRootIsAbs {
+				basePath = c.options.SourceRoot
+			}
+
+			if relPath, ok := c.fs.Rel(basePath, item.path.Text); ok {
 				// Make sure to always use forward slashes, even on Windows
 				item.prettyPath = strings.ReplaceAll(relPath, "\\", "/")
 			}

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -442,6 +442,33 @@ let buildTests = {
     assert.strictEqual(json.sourcesContent[1], content)
   },
 
+  async sourceMapWithDifferentDirectories({ esbuild, testDir }) {
+    const inputDir = path.join(testDir, "input");
+    const outputDir = path.join(testDir, "output");
+    await mkdirAsync(inputDir, { recursive: true });
+    await mkdirAsync(outputDir, { recursive: true });
+    const input = path.join(inputDir, "in.js");
+    const output = path.join(outputDir, "out.js");
+    const content = "exports.foo = 123";
+    await writeFileAsync(input, content);
+    await esbuild.build({
+      entryPoints: [input],
+      outfile: output,
+      sourcemap: true,
+      sourceRoot: inputDir,
+    });
+    const result = require(output);
+    assert.strictEqual(result.foo, 123);
+    const outputFile = await readFileAsync(output, "utf8");
+    const match = /\/\/# sourceMappingURL=(.*)/.exec(outputFile);
+    assert.strictEqual(match[1], "out.js.map");
+    const resultMap = await readFileAsync(output + ".map", "utf8");
+    const json = JSON.parse(resultMap);
+    assert.strictEqual(json.version, 3);
+    assert.strictEqual(json.sources[0], path.relative(inputDir, input));
+    assert.strictEqual(json.sourcesContent[0], content);
+  },
+
   async resolveExtensionOrder({ esbuild, testDir }) {
     const input = path.join(testDir, 'in.js');
     const inputBare = path.join(testDir, 'module.js')


### PR DESCRIPTION
When using sourcemaps, the paths in `sources` are relative to the output file. This assumes that it's always possible to navigate from the output file to each input file using relative paths, which is not the case when the input and the output files are on different drive letters on Windows.

With this PR, if a `sourceRoot` path is provided _and_ it's an absolute path, it will be used as the base for the relative paths in `sources`.

_Example:_

```
C
├─ input/
│  ├─ in.js
D
├─ output/
│  ├─ out.js
```

```js
{
  sourcemap: true,
  sourceRoot: "C:\input"
}
```

Currently, `sources` will contain `../../C/input/in.js`, which is not a valid path.

With this PR, paths are resolved relatively to `sourceRoot` (if defined), so `sources` will contain "in.js".

This will also generate shorter paths in `sources`, since the common path segments can be removed. This is one of the main reasons of using a `sourceRoot` property, as per [the spec](https://sourcemaps.info/spec.html):

> An optional source root, useful for relocating source files on a server or removing repeated values in the “sources” entry.  This value is prepended to the individual entries in the “source” field.