### PR TITLE
Improve esbuild’s DX during performance profiling

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -142,10 +142,10 @@ func code(isES6 bool) string {
 		}
 
 		// This is for lazily-initialized ESM code
-		export var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+		export var __esm = (fn, res) => function __esmWrapper() { return fn && (res = fn(fn = 0)), res }
 
 		// Wraps a CommonJS closure and returns a require() function
-		export var __commonJS = (cb, mod) => () => (mod || cb((mod = {exports: {}}).exports, mod), mod.exports)
+		export var __commonJS = (cb, mod) => function __commonJSWrapper() { return mod || cb((mod = {exports: {}}).exports, mod), mod.exports }
 
 		// Used to implement ES6 exports to CommonJS
 		export var __export = (target, all) => {


### PR DESCRIPTION
When you’re profiling esbuild’s bundle initialization, you might stumble upon a whole bunch of `(anonymous)` functions:

<img width="1552" alt="Screen Shot 2021-05-02 at 20 43 53" src="https://user-images.githubusercontent.com/2953267/116822604-5a129000-ab88-11eb-8e0e-8338f6f14d8c.png">

Frequently, many of these functions are esbuild’s own functions which don’t have a name:

![Screen Shot 2021-05-02 at 20 43 59](https://user-images.githubusercontent.com/2953267/116822634-829a8a00-ab88-11eb-924a-149589a3d3a6.png)

This PR gives these functions a name and improves the debugging experience. Here’s how the first flamegraph looks after the change:

<img width="1552" alt="Screen Shot 2021-05-02 at 20 46 32" src="https://user-images.githubusercontent.com/2953267/116822642-8f1ee280-ab88-11eb-937f-b88d63c2f835.png">

Minification / bundle size were not considered. Also, if you’d prefer an alternative function name, I’d be happy to update the PR!
