### PR TITLE
Annotate module wrapper functions in debug builds

### DIFF
--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -107,8 +107,10 @@ console.log("unused import");
 TestImportReExportOfNamespaceImport
 ---------- /out.js ----------
 // Users/user/project/node_modules/pkg/foo.js
-var require_foo = __commonJS((exports, module) => {
-  module.exports = 123;
+var require_foo = __commonJS({
+  "Users/user/project/node_modules/pkg/foo.js"(exports, module) {
+    module.exports = 123;
+  }
 });
 
 // Users/user/project/node_modules/pkg/index.js
@@ -147,9 +149,11 @@ __export(index_main_exports, {
   foo: () => foo
 });
 var foo;
-var init_index_main = __esm(() => {
-  foo = 123;
-  console.log("this should be kept");
+var init_index_main = __esm({
+  "Users/user/project/node_modules/demo-pkg/index-main.js"() {
+    foo = 123;
+    console.log("this should be kept");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -191,9 +195,11 @@ __export(index_main_exports, {
   foo: () => foo
 });
 var foo;
-var init_index_main = __esm(() => {
-  foo = 123;
-  console.log("this should be kept");
+var init_index_main = __esm({
+  "Users/user/project/node_modules/demo-pkg/index-main.js"() {
+    foo = 123;
+    console.log("this should be kept");
+  }
 });
 
 // Users/user/project/src/require-demo-pkg.js
@@ -237,13 +243,17 @@ TestPackageJsonSideEffectsFalseAllFork
 ---------- /out.js ----------
 // Users/user/project/node_modules/c/index.js
 var foo;
-var init_c = __esm(() => {
-  foo = "foo";
+var init_c = __esm({
+  "Users/user/project/node_modules/c/index.js"() {
+    foo = "foo";
+  }
 });
 
 // Users/user/project/node_modules/b/index.js
-var init_b = __esm(() => {
-  init_c();
+var init_b = __esm({
+  "Users/user/project/node_modules/b/index.js"() {
+    init_c();
+  }
 });
 
 // Users/user/project/node_modules/a/index.js
@@ -251,8 +261,10 @@ var a_exports = {};
 __export(a_exports, {
   foo: () => foo
 });
-var init_a = __esm(() => {
-  init_b();
+var init_a = __esm({
+  "Users/user/project/node_modules/a/index.js"() {
+    init_b();
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -317,9 +329,11 @@ console.log(foo);
 TestPackageJsonSideEffectsFalseKeepBareImportAndRequireCommonJS
 ---------- /out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports) => {
-  exports.foo = 123;
-  console.log("hello");
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
+    exports.foo = 123;
+    console.log("hello");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -335,9 +349,11 @@ __export(demo_pkg_exports, {
   foo: () => foo
 });
 var foo;
-var init_demo_pkg = __esm(() => {
-  foo = 123;
-  console.log("hello");
+var init_demo_pkg = __esm({
+  "Users/user/project/node_modules/demo-pkg/index.js"() {
+    foo = 123;
+    console.log("hello");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -348,9 +364,11 @@ console.log("unused import");
 TestPackageJsonSideEffectsFalseKeepNamedImportCommonJS
 ---------- /out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports) => {
-  exports.foo = 123;
-  console.log("hello");
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
+    exports.foo = 123;
+    console.log("hello");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -371,9 +389,11 @@ console.log(foo);
 TestPackageJsonSideEffectsFalseKeepStarImportCommonJS
 ---------- /out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports) => {
-  exports.foo = 123;
-  console.log("hello");
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
+    exports.foo = 123;
+    console.log("hello");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -408,18 +428,24 @@ TestPackageJsonSideEffectsFalseOneFork
 ---------- /out.js ----------
 // Users/user/project/node_modules/c/index.js
 var foo;
-var init_c = __esm(() => {
-  foo = "foo";
+var init_c = __esm({
+  "Users/user/project/node_modules/c/index.js"() {
+    foo = "foo";
+  }
 });
 
 // Users/user/project/node_modules/d/index.js
-var init_d = __esm(() => {
+var init_d = __esm({
+  "Users/user/project/node_modules/d/index.js"() {
+  }
 });
 
 // Users/user/project/node_modules/b/index.js
-var init_b = __esm(() => {
-  init_c();
-  init_d();
+var init_b = __esm({
+  "Users/user/project/node_modules/b/index.js"() {
+    init_c();
+    init_d();
+  }
 });
 
 // Users/user/project/node_modules/a/index.js
@@ -427,8 +453,10 @@ var a_exports = {};
 __export(a_exports, {
   foo: () => foo
 });
-var init_a = __esm(() => {
-  init_b();
+var init_a = __esm({
+  "Users/user/project/node_modules/a/index.js"() {
+    init_b();
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -489,9 +517,11 @@ console.log("unused import");
 TestPackageJsonSideEffectsTrueKeepCommonJS
 ---------- /out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports) => {
-  exports.foo = 123;
-  console.log("hello");
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
+    exports.foo = 123;
+    console.log("hello");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -639,9 +669,11 @@ TestTreeShakingInESMWrapper
 ---------- /out.js ----------
 // lib.js
 var keep1, keep2;
-var init_lib = __esm(() => {
-  keep1 = () => "keep1";
-  keep2 = () => "keep2";
+var init_lib = __esm({
+  "lib.js"() {
+    keep1 = () => "keep1";
+    keep2 = () => "keep2";
+  }
 });
 
 // cjs.js
@@ -650,9 +682,11 @@ __export(cjs_exports, {
   default: () => cjs_default
 });
 var cjs_default;
-var init_cjs = __esm(() => {
-  init_lib();
-  cjs_default = keep2();
+var init_cjs = __esm({
+  "cjs.js"() {
+    init_lib();
+    cjs_default = keep2();
+  }
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -230,7 +230,9 @@ __export(foo_exports, {
 function foo() {
   return "foo";
 }
-var init_foo = __esm(() => {
+var init_foo = __esm({
+  "foo.js"() {
+  }
 });
 
 // bar.js
@@ -241,7 +243,9 @@ __export(bar_exports, {
 function bar() {
   return "bar";
 }
-var init_bar = __esm(() => {
+var init_bar = __esm({
+  "bar.js"() {
+  }
 });
 
 // entry.js
@@ -253,8 +257,10 @@ var {bar: bar2} = (init_bar(), bar_exports);
 TestConditionalImport
 ---------- /out/a.js ----------
 // import.js
-var require_import = __commonJS((exports) => {
-  exports.foo = 213;
+var require_import = __commonJS({
+  "import.js"(exports) {
+    exports.foo = 213;
+  }
 });
 
 // a.js
@@ -262,8 +268,10 @@ x ? import("a") : y ? Promise.resolve().then(() => __toModule(require_import()))
 
 ---------- /out/b.js ----------
 // import.js
-var require_import = __commonJS((exports) => {
-  exports.foo = 213;
+var require_import = __commonJS({
+  "import.js"(exports) {
+    exports.foo = 213;
+  }
 });
 
 // b.js
@@ -273,8 +281,10 @@ x ? y ? import("a") : Promise.resolve().then(() => __toModule(require_import()))
 TestConditionalRequire
 ---------- /out.js ----------
 // b.js
-var require_b = __commonJS((exports) => {
-  exports.foo = 213;
+var require_b = __commonJS({
+  "b.js"(exports) {
+    exports.foo = 213;
+  }
 });
 
 // a.js
@@ -384,8 +394,10 @@ function test5() {
 TestDotImport
 ---------- /out.js ----------
 // index.js
-var require_index = __commonJS((exports) => {
-  exports.x = 123;
+var require_index = __commonJS({
+  "index.js"(exports) {
+    exports.x = 123;
+  }
 });
 
 // entry.js
@@ -409,8 +421,10 @@ TestDynamicImportWithTemplateIIFE
 ---------- /out.js ----------
 (() => {
   // b.js
-  var require_b = __commonJS((exports) => {
-    exports.x = 123;
+  var require_b = __commonJS({
+    "b.js"(exports) {
+      exports.x = 123;
+    }
   });
 
   // a.js
@@ -422,17 +436,21 @@ TestDynamicImportWithTemplateIIFE
 TestES6FromCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = function() {
-    return "foo";
-  };
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = function() {
+      return "foo";
+    };
+  }
 });
 
 // bar.js
-var require_bar = __commonJS((exports) => {
-  exports.bar = function() {
-    return "bar";
-  };
+var require_bar = __commonJS({
+  "bar.js"(exports) {
+    exports.bar = function() {
+      return "bar";
+    };
+  }
 });
 
 // entry.js
@@ -445,7 +463,9 @@ TestEmptyExportClauseBundleAsCommonJSIssue910
 ---------- /out.js ----------
 // types.mjs
 var types_exports = {};
-var init_types = __esm(() => {
+var init_types = __esm({
+  "types.mjs"() {
+  }
 });
 
 // entry.js
@@ -477,10 +497,12 @@ TestExportFSNodeInCommonJSModule
 // entry.js
 import * as fs from "fs";
 import {readFileSync} from "fs";
-var require_entry = __commonJS((exports) => {
-  exports.fs = fs;
-  exports.readFileSync = readFileSync;
-  exports.foo = 123;
+var require_entry = __commonJS({
+  "entry.js"(exports) {
+    exports.fs = fs;
+    exports.readFileSync = readFileSync;
+    exports.foo = 123;
+  }
 });
 export default require_entry();
 
@@ -489,8 +511,10 @@ TestExportFormsCommonJS
 ---------- /out.js ----------
 // a.js
 var abc;
-var init_a = __esm(() => {
-  abc = void 0;
+var init_a = __esm({
+  "a.js"() {
+    abc = void 0;
+  }
 });
 
 // b.js
@@ -499,8 +523,10 @@ __export(b_exports, {
   xyz: () => xyz
 });
 var xyz;
-var init_b = __esm(() => {
-  xyz = null;
+var init_b = __esm({
+  "b.js"() {
+    xyz = null;
+  }
 });
 
 // commonjs.js
@@ -519,15 +545,17 @@ __export(commonjs_exports, {
 function Fn() {
 }
 var commonjs_default, v, l, c, Class;
-var init_commonjs = __esm(() => {
-  init_a();
-  init_b();
-  commonjs_default = 123;
-  v = 234;
-  l = 234;
-  c = 234;
-  Class = class {
-  };
+var init_commonjs = __esm({
+  "commonjs.js"() {
+    init_a();
+    init_b();
+    commonjs_default = 123;
+    v = 234;
+    l = 234;
+    c = 234;
+    Class = class {
+    };
+  }
 });
 
 // c.js
@@ -536,10 +564,12 @@ __export(c_exports, {
   default: () => c_default2
 });
 var c_default, c_default2;
-var init_c = __esm(() => {
-  c_default = class {
-  };
-  c_default2 = c_default;
+var init_c = __esm({
+  "c.js"() {
+    c_default = class {
+    };
+    c_default2 = c_default;
+  }
 });
 
 // d.js
@@ -548,11 +578,13 @@ __export(d_exports, {
   default: () => d_default
 });
 var Foo, d_default;
-var init_d = __esm(() => {
-  Foo = class {
-  };
-  d_default = Foo;
-  Foo.prop = 123;
+var init_d = __esm({
+  "d.js"() {
+    Foo = class {
+    };
+    d_default = Foo;
+    Foo.prop = 123;
+  }
 });
 
 // e.js
@@ -562,7 +594,9 @@ __export(e_exports, {
 });
 function e_default() {
 }
-var init_e = __esm(() => {
+var init_e = __esm({
+  "e.js"() {
+  }
 });
 
 // f.js
@@ -572,8 +606,10 @@ __export(f_exports, {
 });
 function foo() {
 }
-var init_f = __esm(() => {
-  foo.prop = 123;
+var init_f = __esm({
+  "f.js"() {
+    foo.prop = 123;
+  }
 });
 
 // g.js
@@ -583,7 +619,9 @@ __export(g_exports, {
 });
 async function g_default() {
 }
-var init_g = __esm(() => {
+var init_g = __esm({
+  "g.js"() {
+  }
 });
 
 // h.js
@@ -593,8 +631,10 @@ __export(h_exports, {
 });
 async function foo2() {
 }
-var init_h = __esm(() => {
-  foo2.prop = 123;
+var init_h = __esm({
+  "h.js"() {
+    foo2.prop = 123;
+  }
 });
 
 // entry.js
@@ -757,7 +797,9 @@ __export(a_exports, {
   ns: () => ns
 });
 import * as ns from "x";
-var init_a = __esm(() => {
+var init_a = __esm({
+  "a.js"() {
+  }
 });
 
 // b.js
@@ -766,7 +808,9 @@ __export(b_exports, {
   ns: () => ns2
 });
 import * as ns2 from "x";
-var init_b = __esm(() => {
+var init_b = __esm({
+  "b.js"() {
+  }
 });
 
 // c.js
@@ -775,7 +819,9 @@ __export(c_exports, {
   ns: () => ns3
 });
 import * as ns3 from "x";
-var init_c = __esm(() => {
+var init_c = __esm({
+  "c.js"() {
+  }
 });
 
 // d.js
@@ -784,14 +830,18 @@ __export(d_exports, {
   ns: () => ns4
 });
 import {ns as ns4} from "x";
-var init_d = __esm(() => {
+var init_d = __esm({
+  "d.js"() {
+  }
 });
 
 // e.js
 var e_exports = {};
 import * as x_star from "x";
-var init_e = __esm(() => {
-  __reExport(e_exports, x_star);
+var init_e = __esm({
+  "e.js"() {
+    __reExport(e_exports, x_star);
+  }
 });
 
 // entry.js
@@ -963,8 +1013,10 @@ console.log(import.meta.url, import.meta.path);
 TestImportMissingCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.x = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.x = 123;
+  }
 });
 
 // entry.js
@@ -975,8 +1027,10 @@ console.log((0, import_foo.default)(import_foo.x, import_foo.y));
 TestImportMissingNeitherES6NorCommonJS
 ---------- /out/named.js ----------
 // foo.js
-var require_foo = __commonJS(() => {
-  console.log("no exports here");
+var require_foo = __commonJS({
+  "foo.js"() {
+    console.log("no exports here");
+  }
 });
 
 // named.js
@@ -985,8 +1039,10 @@ console.log((0, import_foo.default)(void 0, void 0));
 
 ---------- /out/star.js ----------
 // foo.js
-var require_foo = __commonJS(() => {
-  console.log("no exports here");
+var require_foo = __commonJS({
+  "foo.js"() {
+    console.log("no exports here");
+  }
 });
 
 // star.js
@@ -995,8 +1051,10 @@ console.log(ns.default(void 0, void 0));
 
 ---------- /out/star-capture.js ----------
 // foo.js
-var require_foo = __commonJS(() => {
-  console.log("no exports here");
+var require_foo = __commonJS({
+  "foo.js"() {
+    console.log("no exports here");
+  }
 });
 
 // star-capture.js
@@ -1009,8 +1067,10 @@ console.log("no exports here");
 
 ---------- /out/require.js ----------
 // foo.js
-var require_foo = __commonJS(() => {
-  console.log("no exports here");
+var require_foo = __commonJS({
+  "foo.js"() {
+    console.log("no exports here");
+  }
 });
 
 // require.js
@@ -1018,8 +1078,10 @@ console.log(require_foo());
 
 ---------- /out/import.js ----------
 // foo.js
-var require_foo = __commonJS(() => {
-  console.log("no exports here");
+var require_foo = __commonJS({
+  "foo.js"() {
+    console.log("no exports here");
+  }
 });
 
 // import.js
@@ -1211,8 +1273,10 @@ console.log(/* @__PURE__ */ React.createElement("]", null));
 TestJSXImportsCommonJS
 ---------- /out.js ----------
 // custom-react.js
-var require_custom_react = __commonJS((exports, module) => {
-  module.exports = {};
+var require_custom_react = __commonJS({
+  "custom-react.js"(exports, module) {
+    module.exports = {};
+  }
 });
 
 // entry.jsx
@@ -1697,7 +1761,7 @@ console.log(shared_default);
 ================================================================================
 TestMinifiedBundleCommonJS
 ---------- /out.js ----------
-var n=e(r=>{r.foo=function(){return 123}});var u=e((j,t)=>{t.exports={test:!0}});var{foo:c}=n();console.log(c(),u());
+var t=r(n=>{n.foo=function(){return 123}});var s=r((l,u)=>{u.exports={test:!0}});var{foo:c}=t();console.log(c(),s());
 
 ================================================================================
 TestMinifiedBundleES6
@@ -1853,10 +1917,12 @@ console.log(foo);
 TestNestedCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_foo = __commonJS({
+  "foo.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // entry.js
@@ -1870,10 +1936,12 @@ nestedScope();
 TestNestedES6FromCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.fn = function() {
-    return 123;
-  };
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.fn = function() {
+      return 123;
+    };
+  }
 });
 
 // entry.js
@@ -1910,10 +1978,12 @@ TestNestedScopeBug
 TestNewExpressionCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports, module) => {
-  var Foo = class {
-  };
-  module.exports = {Foo};
+var require_foo = __commonJS({
+  "foo.js"(exports, module) {
+    var Foo = class {
+    };
+    module.exports = {Foo};
+  }
 });
 
 // entry.js
@@ -1923,10 +1993,12 @@ new (require_foo()).Foo();
 TestNodeModules
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -1959,8 +2031,10 @@ console.log("test");
 TestReExportCommonJSAsES6
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.bar = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.bar = 123;
+  }
 });
 
 // entry.js
@@ -2142,8 +2216,10 @@ try {
 TestRequireChildDirCommonJS
 ---------- /out.js ----------
 // Users/user/project/src/dir/index.js
-var require_dir = __commonJS((exports, module) => {
-  module.exports = 123;
+var require_dir = __commonJS({
+  "Users/user/project/src/dir/index.js"(exports, module) {
+    module.exports = 123;
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -2173,12 +2249,14 @@ return require("fs");
 TestRequireJson
 ---------- /out.js ----------
 // test.json
-var require_test = __commonJS((exports, module) => {
-  module.exports = {
-    a: true,
-    b: 123,
-    c: [null]
-  };
+var require_test = __commonJS({
+  "test.json"(exports, module) {
+    module.exports = {
+      a: true,
+      b: 123,
+      c: [null]
+    };
+  }
 });
 
 // entry.js
@@ -2188,8 +2266,10 @@ console.log(require_test());
 TestRequireMainCacheCommonJS
 ---------- /out.js ----------
 // is-main.js
-var require_is_main = __commonJS((exports2, module2) => {
-  module2.exports = require.main === module2;
+var require_is_main = __commonJS({
+  "is-main.js"(exports2, module2) {
+    module2.exports = require.main === module2;
+  }
 });
 
 // entry.js
@@ -2201,8 +2281,10 @@ console.log("cache:", require.cache);
 TestRequireParentDirCommonJS
 ---------- /out.js ----------
 // Users/user/project/src/index.js
-var require_src = __commonJS((exports, module) => {
-  module.exports = 123;
+var require_src = __commonJS({
+  "Users/user/project/src/index.js"(exports, module) {
+    module.exports = 123;
+  }
 });
 
 // Users/user/project/src/dir/entry.js
@@ -2258,8 +2340,10 @@ console.log(true);
 TestRequireTxt
 ---------- /out.js ----------
 // test.txt
-var require_test = __commonJS((exports, module) => {
-  module.exports = "This is a test.";
+var require_test = __commonJS({
+  "test.txt"(exports, module) {
+    module.exports = "This is a test.";
+  }
 });
 
 // entry.js
@@ -2269,13 +2353,15 @@ console.log(require_test());
 TestRequireWithCallInsideTry
 ---------- /out.js ----------
 // entry.js
-var require_entry = __commonJS((exports) => {
-  try {
-    const supportsColor = require("supports-color");
-    if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
-      exports.colors = [];
+var require_entry = __commonJS({
+  "entry.js"(exports) {
+    try {
+      const supportsColor = require("supports-color");
+      if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
+        exports.colors = [];
+      }
+    } catch (error) {
     }
-  } catch (error) {
   }
 });
 export default require_entry();
@@ -2284,8 +2370,10 @@ export default require_entry();
 TestRequireWithTemplate
 ---------- /out.js ----------
 // b.js
-var require_b = __commonJS((exports) => {
-  exports.x = 123;
+var require_b = __commonJS({
+  "b.js"(exports) {
+    exports.x = 123;
+  }
 });
 
 // a.js
@@ -2337,10 +2425,12 @@ export {
 TestSimpleCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_foo = __commonJS({
+  "foo.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // entry.js
@@ -2634,45 +2724,47 @@ var bar2;
 TestThisOutsideFunction
 ---------- /out.js ----------
 // entry.js
-var require_entry = __commonJS((exports) => {
-  if (shouldBeExportsNotThis) {
-    console.log(exports);
-    console.log((x = exports) => exports);
-    console.log({x: exports});
-    console.log(class extends exports.foo {
-    });
-    console.log(class {
-      [exports.foo];
-    });
-    console.log(class {
-      [exports.foo]() {
-      }
-    });
-    console.log(class {
-      static [exports.foo];
-    });
-    console.log(class {
-      static [exports.foo]() {
-      }
-    });
-  }
-  if (shouldBeThisNotExports) {
-    console.log(class {
-      foo = this;
-    });
-    console.log(class {
-      foo() {
-        this;
-      }
-    });
-    console.log(class {
-      static foo = this;
-    });
-    console.log(class {
-      static foo() {
-        this;
-      }
-    });
+var require_entry = __commonJS({
+  "entry.js"(exports) {
+    if (shouldBeExportsNotThis) {
+      console.log(exports);
+      console.log((x = exports) => exports);
+      console.log({x: exports});
+      console.log(class extends exports.foo {
+      });
+      console.log(class {
+        [exports.foo];
+      });
+      console.log(class {
+        [exports.foo]() {
+        }
+      });
+      console.log(class {
+        static [exports.foo];
+      });
+      console.log(class {
+        static [exports.foo]() {
+        }
+      });
+    }
+    if (shouldBeThisNotExports) {
+      console.log(class {
+        foo = this;
+      });
+      console.log(class {
+        foo() {
+          this;
+        }
+      });
+      console.log(class {
+        static foo = this;
+      });
+      console.log(class {
+        static foo() {
+          this;
+        }
+      });
+    }
   }
 });
 export default require_entry();
@@ -2693,8 +2785,10 @@ console.log(file1_default, file2_default);
 TestThisWithES6Syntax
 ---------- /out.js ----------
 // cjs.js
-var require_cjs = __commonJS((exports) => {
-  console.log(exports);
+var require_cjs = __commonJS({
+  "cjs.js"(exports) {
+    console.log(exports);
+  }
 });
 
 // dummy.js
@@ -2703,117 +2797,145 @@ __export(dummy_exports, {
   dummy: () => dummy
 });
 var dummy;
-var init_dummy = __esm(() => {
-  dummy = 123;
+var init_dummy = __esm({
+  "dummy.js"() {
+    dummy = 123;
+  }
 });
 
 // es6-import-assign.ts
-var require_es6_import_assign = __commonJS((exports) => {
-  var x2 = (init_dummy(), dummy_exports);
-  console.log(exports);
+var require_es6_import_assign = __commonJS({
+  "es6-import-assign.ts"(exports) {
+    var x2 = (init_dummy(), dummy_exports);
+    console.log(exports);
+  }
 });
 
 // es6-import-dynamic.js
-var require_es6_import_dynamic = __commonJS((exports) => {
-  Promise.resolve().then(() => init_dummy());
-  console.log(exports);
+var require_es6_import_dynamic = __commonJS({
+  "es6-import-dynamic.js"(exports) {
+    Promise.resolve().then(() => init_dummy());
+    console.log(exports);
+  }
 });
 
 // es6-expr-import-dynamic.js
-var require_es6_expr_import_dynamic = __commonJS((exports) => {
-  Promise.resolve().then(() => init_dummy());
-  console.log(exports);
+var require_es6_expr_import_dynamic = __commonJS({
+  "es6-expr-import-dynamic.js"(exports) {
+    Promise.resolve().then(() => init_dummy());
+    console.log(exports);
+  }
 });
 
 // es6-export-assign.ts
-var require_es6_export_assign = __commonJS((exports, module) => {
-  console.log(exports);
-  module.exports = 123;
+var require_es6_export_assign = __commonJS({
+  "es6-export-assign.ts"(exports, module) {
+    console.log(exports);
+    module.exports = 123;
+  }
 });
 
 // es6-ns-export-variable.ts
-var require_es6_ns_export_variable = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    ns2.foo = 123;
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_variable = __commonJS({
+  "es6-ns-export-variable.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      ns2.foo = 123;
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-function.ts
-var require_es6_ns_export_function = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    function foo() {
-    }
-    ns2.foo = foo;
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_function = __commonJS({
+  "es6-ns-export-function.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      function foo() {
+      }
+      ns2.foo = foo;
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-async-function.ts
-var require_es6_ns_export_async_function = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    async function foo() {
-    }
-    ns2.foo = foo;
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_async_function = __commonJS({
+  "es6-ns-export-async-function.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      async function foo() {
+      }
+      ns2.foo = foo;
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-enum.ts
-var require_es6_ns_export_enum = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    let Foo3;
-    (function(Foo4) {
-    })(Foo3 = ns2.Foo || (ns2.Foo = {}));
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_enum = __commonJS({
+  "es6-ns-export-enum.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      let Foo3;
+      (function(Foo4) {
+      })(Foo3 = ns2.Foo || (ns2.Foo = {}));
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-const-enum.ts
-var require_es6_ns_export_const_enum = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    let Foo3;
-    (function(Foo4) {
-    })(Foo3 = ns2.Foo || (ns2.Foo = {}));
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_const_enum = __commonJS({
+  "es6-ns-export-const-enum.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      let Foo3;
+      (function(Foo4) {
+      })(Foo3 = ns2.Foo || (ns2.Foo = {}));
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-module.ts
-var require_es6_ns_export_module = __commonJS((exports) => {
-  console.log(exports);
+var require_es6_ns_export_module = __commonJS({
+  "es6-ns-export-module.ts"(exports) {
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-namespace.ts
-var require_es6_ns_export_namespace = __commonJS((exports) => {
-  console.log(exports);
+var require_es6_ns_export_namespace = __commonJS({
+  "es6-ns-export-namespace.ts"(exports) {
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-class.ts
-var require_es6_ns_export_class = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    class Foo3 {
-    }
-    ns2.Foo = Foo3;
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_class = __commonJS({
+  "es6-ns-export-class.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      class Foo3 {
+      }
+      ns2.Foo = Foo3;
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // es6-ns-export-abstract-class.ts
-var require_es6_ns_export_abstract_class = __commonJS((exports) => {
-  var ns;
-  (function(ns2) {
-    class Foo3 {
-    }
-    ns2.Foo = Foo3;
-  })(ns || (ns = {}));
-  console.log(exports);
+var require_es6_ns_export_abstract_class = __commonJS({
+  "es6-ns-export-abstract-class.ts"(exports) {
+    var ns;
+    (function(ns2) {
+      class Foo3 {
+      }
+      ns2.Foo = Foo3;
+    })(ns || (ns = {}));
+    console.log(exports);
+  }
 });
 
 // entry.js
@@ -2937,30 +3059,38 @@ TestTopLevelAwaitAllowedImportWithoutSplitting
 ---------- /out.js ----------
 // c.js
 var c_exports = {};
-var init_c = __esm(async () => {
-  await 0;
+var init_c = __esm({
+  async "c.js"() {
+    await 0;
+  }
 });
 
 // b.js
 var b_exports = {};
-var init_b = __esm(async () => {
-  await init_c();
+var init_b = __esm({
+  async "b.js"() {
+    await init_c();
+  }
 });
 
 // a.js
 var a_exports = {};
-var init_a = __esm(async () => {
-  await init_b();
+var init_a = __esm({
+  async "a.js"() {
+    await init_b();
+  }
 });
 
 // entry.js
 var entry_exports = {};
-var init_entry = __esm(async () => {
-  init_a();
-  init_b();
-  init_c();
-  init_entry();
-  await 0;
+var init_entry = __esm({
+  async "entry.js"() {
+    init_a();
+    init_b();
+    init_c();
+    init_entry();
+    await 0;
+  }
 });
 await init_entry();
 
@@ -3001,18 +3131,24 @@ TestUseStrictDirectiveMinifyNoBundle
 TestWarningsInsideNodeModules
 ---------- /out.js ----------
 // return-asi.js
-var require_return_asi = __commonJS(() => {
-  return;
+var require_return_asi = __commonJS({
+  "return-asi.js"() {
+    return;
+  }
 });
 
 // node_modules/return-asi.js
-var require_return_asi2 = __commonJS(() => {
-  return;
+var require_return_asi2 = __commonJS({
+  "node_modules/return-asi.js"() {
+    return;
+  }
 });
 
 // plugin-dir/node_modules/return-asi.js
-var require_return_asi3 = __commonJS(() => {
-  return;
+var require_return_asi3 = __commonJS({
+  "plugin-dir/node_modules/return-asi.js"() {
+    return;
+  }
 });
 
 // dup-case.js

--- a/internal/bundler/snapshots/snapshots_importstar.txt
+++ b/internal/bundler/snapshots/snapshots_importstar.txt
@@ -1,8 +1,10 @@
 TestExportOtherAsNamespaceCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -16,8 +18,10 @@ var ns = __toModule(require_foo());
 TestExportOtherCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -31,8 +35,10 @@ var import_foo = __toModule(require_foo());
 TestExportOtherNestedCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -64,9 +70,11 @@ __export(exports, {
   foo: () => foo
 });
 var foo;
-var init_entry = __esm(() => {
-  foo = 123;
-  console.log((init_entry(), exports));
+var init_entry = __esm({
+  "entry.js"() {
+    foo = 123;
+    console.log((init_entry(), exports));
+  }
 });
 init_entry();
 
@@ -110,11 +118,11 @@ var foo = 123;
 TestExportSelfCommonJSMinified
 ---------- /out.js ----------
 // entry.js
-var r = n((t, e) => {
-  e.exports = {foo: 123};
-  console.log(r());
+var l = n((c, r) => {
+  r.exports = {foo: 123};
+  console.log(l());
 });
-module.exports = r();
+module.exports = l();
 
 ================================================================================
 TestExportSelfES6
@@ -252,8 +260,10 @@ console.log(internal_default, void 0);
 TestImportExportOtherAsNamespaceCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -322,10 +332,12 @@ console.log(value);
 TestImportSelfCommonJS
 ---------- /out.js ----------
 // entry.js
-var require_entry = __commonJS((exports) => {
-  var import_entry = __toModule(require_entry());
-  exports.foo = 123;
-  console.log(import_entry.foo);
+var require_entry = __commonJS({
+  "entry.js"(exports) {
+    var import_entry = __toModule(require_entry());
+    exports.foo = 123;
+    console.log(import_entry.foo);
+  }
 });
 module.exports = require_entry();
 
@@ -338,8 +350,10 @@ __export(foo_exports, {
   foo: () => foo
 });
 var foo;
-var init_foo = __esm(() => {
-  foo = 123;
+var init_foo = __esm({
+  "foo.js"() {
+    foo = 123;
+  }
 });
 
 // entry.js
@@ -365,8 +379,10 @@ console.log(foo_exports, foo, foo2);
 TestImportStarCommonJSCapture
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -378,8 +394,10 @@ console.log(ns, ns.foo, foo);
 TestImportStarCommonJSNoCapture
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -391,8 +409,10 @@ console.log(ns.foo, ns.foo, foo2);
 TestImportStarCommonJSUnused
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.js
@@ -619,8 +639,10 @@ console.log(JSON.stringify(folders_exports));
 TestNamespaceImportMissingCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.x = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.x = 123;
+  }
 });
 
 // entry.js
@@ -665,8 +687,10 @@ console.log(void 0);
 TestNamespaceImportUnusedMissingCommonJS
 ---------- /out.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.x = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.x = 123;
+  }
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_importstar_ts.txt
+++ b/internal/bundler/snapshots/snapshots_importstar_ts.txt
@@ -6,8 +6,10 @@ __export(foo_exports, {
   foo: () => foo
 });
 var foo;
-var init_foo = __esm(() => {
-  foo = 123;
+var init_foo = __esm({
+  "foo.ts"() {
+    foo = 123;
+  }
 });
 
 // entry.js
@@ -33,8 +35,10 @@ console.log(foo_exports, foo, foo2);
 TestTSImportStarCommonJSCapture
 ---------- /out.js ----------
 // foo.ts
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.ts"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.ts
@@ -46,8 +50,10 @@ console.log(ns, ns.foo, foo);
 TestTSImportStarCommonJSNoCapture
 ---------- /out.js ----------
 // foo.ts
-var require_foo = __commonJS((exports) => {
-  exports.foo = 123;
+var require_foo = __commonJS({
+  "foo.ts"(exports) {
+    exports.foo = 123;
+  }
 });
 
 // entry.ts

--- a/internal/bundler/snapshots/snapshots_loader.txt
+++ b/internal/bundler/snapshots/snapshots_loader.txt
@@ -1,8 +1,10 @@
 TestAutoDetectMimeTypeFromExtension
 ---------- /out.js ----------
 // test.svg
-var require_test = __commonJS((exports, module) => {
-  module.exports = "data:image/svg+xml;base64,YQBigGP/ZA==";
+var require_test = __commonJS({
+  "test.svg"(exports, module) {
+    module.exports = "data:image/svg+xml;base64,YQBigGP/ZA==";
+  }
 });
 
 // entry.js
@@ -18,8 +20,10 @@ console.log(/* @__PURE__ */ React.createElement("div", null));
 TestLoaderBase64CommonJSAndES6
 ---------- /out.js ----------
 // x.b64
-var require_x = __commonJS((exports, module) => {
-  module.exports = "eA==";
+var require_x = __commonJS({
+  "x.b64"(exports, module) {
+    module.exports = "eA==";
+  }
 });
 
 // y.b64
@@ -33,8 +37,10 @@ console.log(x_b64, y_default);
 TestLoaderDataURLCommonJSAndES6
 ---------- /out.js ----------
 // x.txt
-var require_x = __commonJS((exports, module) => {
-  module.exports = "data:text/plain;charset=utf-8;base64,eA==";
+var require_x = __commonJS({
+  "x.txt"(exports, module) {
+    module.exports = "data:text/plain;charset=utf-8;base64,eA==";
+  }
 });
 
 // y.txt
@@ -50,8 +56,10 @@ TestLoaderFile
 <svg></svg>
 ---------- /out/entry.js ----------
 // test.svg
-var require_test = __commonJS((exports, module) => {
-  module.exports = "./test-IPILGNO5.svg";
+var require_test = __commonJS({
+  "test.svg"(exports, module) {
+    module.exports = "./test-IPILGNO5.svg";
+  }
 });
 
 // entry.js
@@ -65,8 +73,10 @@ y
 x
 ---------- /out.js ----------
 // x.txt
-var require_x = __commonJS((exports, module) => {
-  module.exports = "./x-LSAMBFUD.txt";
+var require_x = __commonJS({
+  "x.txt"(exports, module) {
+    module.exports = "./x-LSAMBFUD.txt";
+  }
 });
 
 // y.txt
@@ -82,13 +92,17 @@ TestLoaderFileMultipleNoCollision
 test
 ---------- /dist/out.js ----------
 // a/test.txt
-var require_test = __commonJS((exports, module) => {
-  module.exports = "./test-J7OMUXO3.txt";
+var require_test = __commonJS({
+  "a/test.txt"(exports, module) {
+    module.exports = "./test-J7OMUXO3.txt";
+  }
 });
 
 // b/test.txt
-var require_test2 = __commonJS((exports, module) => {
-  module.exports = "./test-J7OMUXO3.txt";
+var require_test2 = __commonJS({
+  "b/test.txt"(exports, module) {
+    module.exports = "./test-J7OMUXO3.txt";
+  }
 });
 
 // entry.js
@@ -98,8 +112,10 @@ console.log(require_test(), require_test2());
 TestLoaderJSONCommonJSAndES6
 ---------- /out.js ----------
 // x.json
-var require_x = __commonJS((exports, module) => {
-  module.exports = {x: true};
+var require_x = __commonJS({
+  "x.json"(exports, module) {
+    module.exports = {x: true};
+  }
 });
 
 // y.json
@@ -169,8 +185,10 @@ export {
 TestLoaderJSONNoBundleIIFE
 ---------- /out.js ----------
 (() => {
-  var require_test = __commonJS((exports, module) => {
-    module.exports = {test: 123, "invalid-identifier": true};
+  var require_test = __commonJS({
+    "test.json"(exports, module) {
+      module.exports = {test: 123, "invalid-identifier": true};
+    }
   });
   require_test();
 })();
@@ -197,8 +215,10 @@ console.log("b:", data_default);
 TestLoaderTextCommonJSAndES6
 ---------- /out.js ----------
 // x.txt
-var require_x = __commonJS((exports, module) => {
-  module.exports = "x";
+var require_x = __commonJS({
+  "x.txt"(exports, module) {
+    module.exports = "x";
+  }
 });
 
 // y.txt
@@ -212,8 +232,10 @@ console.log(x_txt, y_default);
 TestRequireCustomExtensionBase64
 ---------- /out.js ----------
 // test.custom
-var require_test = __commonJS((exports, module) => {
-  module.exports = "YQBigGP/ZA==";
+var require_test = __commonJS({
+  "test.custom"(exports, module) {
+    module.exports = "YQBigGP/ZA==";
+  }
 });
 
 // entry.js
@@ -223,8 +245,10 @@ console.log(require_test());
 TestRequireCustomExtensionDataURL
 ---------- /out.js ----------
 // test.custom
-var require_test = __commonJS((exports, module) => {
-  module.exports = "data:application/octet-stream;base64,YQBigGP/ZA==";
+var require_test = __commonJS({
+  "test.custom"(exports, module) {
+    module.exports = "data:application/octet-stream;base64,YQBigGP/ZA==";
+  }
 });
 
 // entry.js
@@ -234,13 +258,17 @@ console.log(require_test());
 TestRequireCustomExtensionPreferLongest
 ---------- /out.js ----------
 // test.txt
-var require_test = __commonJS((exports, module) => {
-  module.exports = "test.txt";
+var require_test = __commonJS({
+  "test.txt"(exports, module) {
+    module.exports = "test.txt";
+  }
 });
 
 // test.base64.txt
-var require_test_base64 = __commonJS((exports, module) => {
-  module.exports = "dGVzdC5iYXNlNjQudHh0";
+var require_test_base64 = __commonJS({
+  "test.base64.txt"(exports, module) {
+    module.exports = "dGVzdC5iYXNlNjQudHh0";
+  }
 });
 
 // entry.js
@@ -250,8 +278,10 @@ console.log(require_test(), require_test_base64());
 TestRequireCustomExtensionString
 ---------- /out.js ----------
 // test.custom
-var require_test = __commonJS((exports, module) => {
-  module.exports = "#include <stdio.h>";
+var require_test = __commonJS({
+  "test.custom"(exports, module) {
+    module.exports = "#include <stdio.h>";
+  }
 });
 
 // entry.js

--- a/internal/bundler/snapshots/snapshots_lower.txt
+++ b/internal/bundler/snapshots/snapshots_lower.txt
@@ -119,10 +119,12 @@ class Derived extends Base {
 TestLowerAsyncThis2016CommonJS
 ---------- /out.js ----------
 // entry.js
-var require_entry = __commonJS((exports) => {
-  exports.foo = () => __async(exports, null, function* () {
-    return exports;
-  });
+var require_entry = __commonJS({
+  "entry.js"(exports) {
+    exports.foo = () => __async(exports, null, function* () {
+      return exports;
+    });
+  }
 });
 export default require_entry();
 

--- a/internal/bundler/snapshots/snapshots_packagejson.txt
+++ b/internal/bundler/snapshots/snapshots_packagejson.txt
@@ -1,10 +1,12 @@
 TestPackageJsonBadMain
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -33,10 +35,12 @@ console.log(browser2);
 TestPackageJsonBrowserMapAvoidMissing
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/component-indexof/index.js
-var require_component_indexof = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 234;
-  };
+var require_component_indexof = __commonJS({
+  "Users/user/project/node_modules/component-indexof/index.js"(exports, module) {
+    module.exports = function() {
+      return 234;
+    };
+  }
 });
 
 // Users/user/project/node_modules/component-classes/index.js
@@ -51,15 +55,19 @@ var index;
 TestPackageJsonBrowserMapModuleDisabled
 ---------- /Users/user/project/out.js ----------
 // (disabled):Users/user/project/node_modules/node-pkg/index.js
-var require_node_pkg = __commonJS(() => {
+var require_node_pkg = __commonJS({
+  "(disabled):Users/user/project/node_modules/node-pkg/index.js"() {
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  var fn2 = require_node_pkg();
-  module.exports = function() {
-    return fn2();
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    var fn2 = require_node_pkg();
+    module.exports = function() {
+      return fn2();
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -70,18 +78,22 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapModuleToModule
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/node-pkg-browser/index.js
-var require_node_pkg_browser = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_node_pkg_browser = __commonJS({
+  "Users/user/project/node_modules/node-pkg-browser/index.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  var fn2 = require_node_pkg_browser();
-  module.exports = function() {
-    return fn2();
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    var fn2 = require_node_pkg_browser();
+    module.exports = function() {
+      return fn2();
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -92,18 +104,22 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapModuleToRelative
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/node-pkg-browser.js
-var require_node_pkg_browser = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_node_pkg_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/node-pkg-browser.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  var fn2 = require_node_pkg_browser();
-  module.exports = function() {
-    return fn2();
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    var fn2 = require_node_pkg_browser();
+    module.exports = function() {
+      return fn2();
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -114,15 +130,19 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapNativeModuleDisabled
 ---------- /Users/user/project/out.js ----------
 // (disabled):fs
-var require_fs = __commonJS(() => {
+var require_fs = __commonJS({
+  "(disabled):fs"() {
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  var fs = require_fs();
-  module.exports = function() {
-    return fs.readFile();
-  };
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    var fs = require_fs();
+    module.exports = function() {
+      return fs.readFile();
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -133,15 +153,19 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapRelativeDisabled
 ---------- /Users/user/project/out.js ----------
 // (disabled):Users/user/project/node_modules/demo-pkg/util-node
-var require_util_node = __commonJS(() => {
+var require_util_node = __commonJS({
+  "(disabled):Users/user/project/node_modules/demo-pkg/util-node"() {
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  var util = require_util_node();
-  module.exports = function(obj) {
-    return util.inspect(obj);
-  };
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    var util = require_util_node();
+    module.exports = function(obj) {
+      return util.inspect(obj);
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -152,16 +176,20 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapRelativeToModule
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/util-browser/index.js
-var require_util_browser = __commonJS((exports, module) => {
-  module.exports = "util-browser";
+var require_util_browser = __commonJS({
+  "Users/user/project/node_modules/util-browser/index.js"(exports, module) {
+    module.exports = "util-browser";
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  var util = require_util_browser();
-  module.exports = function() {
-    return ["main", util];
-  };
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    var util = require_util_browser();
+    module.exports = function() {
+      return ["main", util];
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -172,16 +200,20 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserMapRelativeToRelative
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/lib/util-browser.js
-var require_util_browser = __commonJS((exports, module) => {
-  module.exports = "util-browser";
+var require_util_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/lib/util-browser.js"(exports, module) {
+    module.exports = "util-browser";
+  }
 });
 
 // Users/user/project/node_modules/demo-pkg/main-browser.js
-var require_main_browser = __commonJS((exports, module) => {
-  var util = require_util_browser();
-  module.exports = function() {
-    return ["main-browser", util];
-  };
+var require_main_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main-browser.js"(exports, module) {
+    var util = require_util_browser();
+    module.exports = function() {
+      return ["main-browser", util];
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -246,10 +278,12 @@ console.log(browser2);
 TestPackageJsonBrowserOverMainNode
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -260,10 +294,12 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserOverModuleBrowser
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.browser.js
-var require_main_browser = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_main_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.browser.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -274,10 +310,12 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserString
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/browser.js
-var require_browser = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/browser.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -288,10 +326,12 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonBrowserWithMainNode
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -313,8 +353,10 @@ console.log(main_browser_esm_default());
 TestPackageJsonDualPackageHazardImportAndRequireBrowser
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.browser.js
-var require_main_browser = __commonJS((exports, module) => {
-  module.exports = "browser main";
+var require_main_browser = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.browser.js"(exports, module) {
+    module.exports = "browser main";
+  }
 });
 
 // Users/user/project/src/test-main.js
@@ -333,8 +375,10 @@ __export(module_exports, {
   default: () => module_default
 });
 var module_default;
-var init_module = __esm(() => {
-  module_default = "module";
+var init_module = __esm({
+  "Users/user/project/node_modules/demo-pkg/module.js"() {
+    module_default = "module";
+  }
 });
 
 // Users/user/project/src/test-main.js
@@ -348,8 +392,10 @@ console.log(module_default);
 TestPackageJsonDualPackageHazardImportAndRequireImplicitMain
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/index.js
-var require_demo_pkg = __commonJS((exports, module) => {
-  module.exports = "index";
+var require_demo_pkg = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/index.js"(exports, module) {
+    module.exports = "index";
+  }
 });
 
 // Users/user/project/src/test-index.js
@@ -368,8 +414,10 @@ __export(module_exports, {
   default: () => module_default
 });
 var module_default;
-var init_module = __esm(() => {
-  module_default = "module";
+var init_module = __esm({
+  "Users/user/project/node_modules/demo-pkg/module.js"() {
+    module_default = "module";
+  }
 });
 
 // Users/user/project/src/test-index.js
@@ -383,8 +431,10 @@ console.log(module_default);
 TestPackageJsonDualPackageHazardImportAndRequireSameFile
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = "main";
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = "main";
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -395,8 +445,10 @@ console.log(import_demo_pkg.default, require_main());
 TestPackageJsonDualPackageHazardImportAndRequireSeparateFiles
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = "main";
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = "main";
+  }
 });
 
 // Users/user/project/src/test-main.js
@@ -419,8 +471,10 @@ console.log(module_default);
 TestPackageJsonDualPackageHazardRequireOnly
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = "main";
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = "main";
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -481,8 +535,10 @@ console.log("SUCCESS");
 TestPackageJsonExportsRequireOverImport
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/pkg/require.js
-var require_require = __commonJS(() => {
-  console.log("SUCCESS");
+var require_require = __commonJS({
+  "Users/user/project/node_modules/pkg/require.js"() {
+    console.log("SUCCESS");
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -492,10 +548,12 @@ require_require();
 TestPackageJsonMain
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/custom-main.js
-var require_custom_main = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_custom_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/custom-main.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -506,8 +564,10 @@ console.log((0, import_demo_pkg.default)());
 TestPackageJsonMainFieldsA
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/a.js
-var require_a = __commonJS((exports, module) => {
-  module.exports = "a";
+var require_a = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/a.js"(exports, module) {
+    module.exports = "a";
+  }
 });
 
 // Users/user/project/src/entry.js
@@ -538,10 +598,12 @@ console.log(main_esm_default());
 TestPackageJsonNeutralExplicitMainFields
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/main.js
-var require_main = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_main = __commonJS({
+  "Users/user/project/node_modules/demo-pkg/main.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/entry.js

--- a/internal/bundler/snapshots/snapshots_splitting.txt
+++ b/internal/bundler/snapshots/snapshots_splitting.txt
@@ -205,22 +205,24 @@ TestSplittingDynamicAndNotDynamicCommonJSIntoES6
 import {
   __toModule,
   require_foo
-} from "./chunk-DOF77JFX.js";
+} from "./chunk-NCSI7JR5.js";
 
 // entry.js
 var import_foo = __toModule(require_foo());
-import("./foo-RHEBPILD.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
+import("./foo-UF4SFHDB.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
 
----------- /out/foo-RHEBPILD.js ----------
+---------- /out/foo-UF4SFHDB.js ----------
 import {
   require_foo
-} from "./chunk-DOF77JFX.js";
+} from "./chunk-NCSI7JR5.js";
 export default require_foo();
 
----------- /out/chunk-DOF77JFX.js ----------
+---------- /out/chunk-NCSI7JR5.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.bar = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.bar = 123;
+  }
 });
 
 export {
@@ -258,12 +260,14 @@ export {
 TestSplittingDynamicCommonJSIntoES6
 ---------- /out/entry.js ----------
 // entry.js
-import("./foo-BQWGKGO4.js").then(({default: {bar}}) => console.log(bar));
+import("./foo-B5AKBR53.js").then(({default: {bar}}) => console.log(bar));
 
----------- /out/foo-BQWGKGO4.js ----------
+---------- /out/foo-B5AKBR53.js ----------
 // foo.js
-var require_foo = __commonJS((exports) => {
-  exports.bar = 123;
+var require_foo = __commonJS({
+  "foo.js"(exports) {
+    exports.bar = 123;
+  }
 });
 export default require_foo();
 
@@ -313,7 +317,7 @@ TestSplittingHybridESMAndCJSIssue617
 import {
   foo,
   init_a
-} from "./chunk-XSW6IF3B.js";
+} from "./chunk-LGBOX6O3.js";
 init_a();
 export {
   foo
@@ -323,7 +327,7 @@ export {
 import {
   a_exports,
   init_a
-} from "./chunk-XSW6IF3B.js";
+} from "./chunk-LGBOX6O3.js";
 
 // b.js
 var bar = (init_a(), a_exports);
@@ -331,14 +335,16 @@ export {
   bar
 };
 
----------- /out/chunk-XSW6IF3B.js ----------
+---------- /out/chunk-LGBOX6O3.js ----------
 // a.js
 var a_exports = {};
 __export(a_exports, {
   foo: () => foo
 });
 var foo;
-var init_a = __esm(() => {
+var init_a = __esm({
+  "a.js"() {
+  }
 });
 
 export {
@@ -479,7 +485,7 @@ TestSplittingSharedCommonJSIntoES6
 ---------- /out/a.js ----------
 import {
   require_shared
-} from "./chunk-JWGRGYBR.js";
+} from "./chunk-WD5UYFOD.js";
 
 // a.js
 var {foo} = require_shared();
@@ -488,16 +494,18 @@ console.log(foo);
 ---------- /out/b.js ----------
 import {
   require_shared
-} from "./chunk-JWGRGYBR.js";
+} from "./chunk-WD5UYFOD.js";
 
 // b.js
 var {foo} = require_shared();
 console.log(foo);
 
----------- /out/chunk-JWGRGYBR.js ----------
+---------- /out/chunk-WD5UYFOD.js ----------
 // shared.js
-var require_shared = __commonJS((exports) => {
-  exports.foo = 123;
+var require_shared = __commonJS({
+  "shared.js"(exports) {
+    exports.foo = 123;
+  }
 });
 
 export {

--- a/internal/bundler/snapshots/snapshots_ts.txt
+++ b/internal/bundler/snapshots/snapshots_ts.txt
@@ -195,10 +195,12 @@ export {
 TestTSExportEquals
 ---------- /out.js ----------
 // b.ts
-var require_b = __commonJS((exports, module) => {
-  function foo() {
+var require_b = __commonJS({
+  "b.ts"(exports, module) {
+    function foo() {
+    }
+    module.exports = [123, foo];
   }
-  module.exports = [123, foo];
 });
 
 // a.ts
@@ -301,7 +303,7 @@ console.log(a, b, c, d, e, real);
 ================================================================================
 TestTSMinifiedBundleCommonJS
 ---------- /out.js ----------
-var n=e(r=>{r.foo=function(){return 123}});var u=e((j,t)=>{t.exports={test:!0}});var{foo:c}=n();console.log(c(),u());
+var t=r(n=>{n.foo=function(){return 123}});var s=r((l,u)=>{u.exports={test:!0}});var{foo:c}=t();console.log(c(),s());
 
 ================================================================================
 TestTSMinifiedBundleES6

--- a/internal/bundler/snapshots/snapshots_tsconfig.txt
+++ b/internal/bundler/snapshots/snapshots_tsconfig.txt
@@ -1,10 +1,12 @@
 TestJsconfigJsonBaseUrl
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/src/lib/util.js
-var require_util = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_util = __commonJS({
+  "Users/user/project/src/lib/util.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/app/entry.js
@@ -200,10 +202,12 @@ console.log(test_default);
 TestTsconfigJsonAbsoluteBaseUrl
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/src/lib/util.js
-var require_util = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_util = __commonJS({
+  "Users/user/project/src/lib/util.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/app/entry.js
@@ -214,10 +218,12 @@ console.log((0, import_util.default)());
 TestTsconfigJsonBaseUrl
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/src/lib/util.js
-var require_util = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_util = __commonJS({
+  "Users/user/project/src/lib/util.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/app/entry.js
@@ -228,10 +234,12 @@ console.log((0, import_util.default)());
 TestTsconfigJsonCommentAllowed
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/src/lib/util.js
-var require_util = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_util = __commonJS({
+  "Users/user/project/src/lib/util.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/app/entry.js
@@ -293,10 +301,12 @@ console.log("good");
 TestTsconfigJsonTrailingCommaAllowed
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/src/lib/util.js
-var require_util = __commonJS((exports, module) => {
-  module.exports = function() {
-    return 123;
-  };
+var require_util = __commonJS({
+  "Users/user/project/src/lib/util.js"(exports, module) {
+    module.exports = function() {
+      return 123;
+    };
+  }
 });
 
 // Users/user/project/src/app/entry.js

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,7 @@ type Options struct {
 	RemoveWhitespace  bool
 	MinifyIdentifiers bool
 	MangleSyntax      bool
+	ProfilerNames     bool
 	CodeSplitting     bool
 	WatchMode         bool
 	AllowOverwrite    bool

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -141,11 +141,23 @@ func code(isES6 bool) string {
 			return target
 		}
 
-		// This is for lazily-initialized ESM code
-		export var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+		// This is for lazily-initialized ESM code. This has two implementations, a
+		// compact one for minified code and a verbose one that generates friendly
+		// names in V8's profiler and in stack traces.
+		export var __esm = __profiler
+			&& ((fn, res) => function __init() {
+				return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res
+			})
+			|| ((fn, res) => () => (fn && (res = fn(fn = 0)), res))
 
-		// Wraps a CommonJS closure and returns a require() function
-		export var __commonJS = (cb, mod) => () => (mod || cb((mod = {exports: {}}).exports, mod), mod.exports)
+		// Wraps a CommonJS closure and returns a require() function. This has two
+		// implementations, a compact one for minified code and a verbose one that
+		// generates friendly names in V8's profiler and in stack traces.
+		export var __commonJS = __profiler
+			&& ((cb, mod) => function __require() {
+				return mod || (0, cb[Object.keys(cb)[0]])((mod = {exports: {}}).exports, mod), mod.exports
+			})
+			|| ((cb, mod) => () => (mod || cb((mod = {exports: {}}).exports, mod), mod.exports))
 
 		// Used to implement ES6 exports to CommonJS
 		export var __export = (target, all) => {


### PR DESCRIPTION
Sometimes esbuild needs to wrap certain modules in a function when bundling. This is done both for lazy evaluation and for CommonJS modules that use a top-level `return` statement. Previously these functions were all anonymous, so stack traces for errors thrown during initialization looked like this:

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
    at getElectronPath (out.js:16:13)
    at out.js:19:21
    at out.js:1:45
    at out.js:24:3
    at out.js:1:45
    at out.js:29:3
    at out.js:1:45
    at Object.<anonymous> (out.js:33:1)
```

This release adds names to these anonymous functions when minification is disabled. The above stack trace now looks like this:

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
    at getElectronPath (out.js:19:15)
    at node_modules/electron/index.js (out.js:22:23)
    at __require (out.js:2:44)
    at src/base/window.js (out.js:29:5)
    at __require (out.js:2:44)
    at src/base/kiosk.js (out.js:36:5)
    at __require (out.js:2:44)
    at Object.<anonymous> (out.js:41:1)
```

This is similar to Webpack's development-mode behavior:

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
    at getElectronPath (out.js:23:11)
    at Object../node_modules/electron/index.js (out.js:27:18)
    at __webpack_require__ (out.js:96:41)
    at Object../src/base/window.js (out.js:49:1)
    at __webpack_require__ (out.js:96:41)
    at Object../src/base/kiosk.js (out.js:38:1)
    at __webpack_require__ (out.js:96:41)
    at out.js:109:1
    at out.js:111:3
    at Object.<anonymous> (out.js:113:12)
```

These descriptive function names will additionally be available when using a profiler such as the one included in the "Performance" tab in Chrome Developer Tools. Previously all functions were named `(anonymous)` which made it difficult to investigate performance issues during bundle initialization.

Closes #1236
