### PR TITLE
feat: support type-only ImportEqualsStmt

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -6032,11 +6032,19 @@ func (p *parser) parseStmt(opts parseStmtOpts) js_ast.Stmt {
 					case js_lexer.TIdentifier:
 						if p.lexer.Identifier != "from" {
 							// "import type foo from 'bar';"
+							defaultName = p.lexer.Identifier
+							stmt.DefaultName = &js_ast.LocRef{Loc: p.lexer.Loc(), Ref: p.storeNameInRef(defaultName)}
 							p.lexer.Next()
-							p.lexer.ExpectContextualKeyword("from")
-							p.parsePath()
-							p.lexer.ExpectOrInsertSemicolon()
-							return js_ast.Stmt{Loc: loc, Data: &js_ast.STypeScript{}}
+
+							if p.lexer.Token == js_lexer.TEquals {
+								p.parseTypeScriptImportEqualsStmt(loc, opts, stmt.DefaultName.Loc, defaultName)
+								return js_ast.Stmt{Loc: loc, Data: &js_ast.STypeScript{}}
+							} else {
+								p.lexer.ExpectContextualKeyword("from")
+								p.parsePath()
+								p.lexer.ExpectOrInsertSemicolon()
+								return js_ast.Stmt{Loc: loc, Data: &js_ast.STypeScript{}}
+							}
 						}
 
 					case js_lexer.TAsterisk:

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -1449,6 +1449,7 @@ func TestTSTypeOnlyImport(t *testing.T) {
 	expectPrintedTS(t, "import type * as foo from 'bar'\nx", "x;\n")
 	expectPrintedTS(t, "import type {foo, bar as baz} from 'bar'; x", "x;\n")
 	expectPrintedTS(t, "import type {'foo' as bar} from 'bar'\nx", "x;\n")
+	expectPrintedTS(t, "import type foo = require('bar'); x", "x;\n")
 
 	expectPrintedTS(t, "import type = bar; type", "const type = bar;\ntype;\n")
 	expectPrintedTS(t, "import type = foo.bar; type", "const type = foo.bar;\ntype;\n")
@@ -1467,6 +1468,8 @@ func TestTSTypeOnlyImport(t *testing.T) {
 
 	expectParseErrorTS(t, "import type foo, * as foo from 'bar'", "<stdin>: error: Expected \"from\" but found \",\"\n")
 	expectParseErrorTS(t, "import type foo, {foo} from 'bar'", "<stdin>: error: Expected \"from\" but found \",\"\n")
+	expectParseErrorTS(t, "import type * as foo = require('bar')", "<stdin>: error: Expected \"from\" but found \"=\"\n")
+	expectParseErrorTS(t, "import type {foo} = require('bar')", "<stdin>: error: Expected \"from\" but found \"=\"\n")
 }
 
 func TestTSTypeOnlyExport(t *testing.T) {


### PR DESCRIPTION
This is a TypeScript 4.2 feature:

```ts
import type React = require('react')
```

[TypeScript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBDAnmApnASighgY3gXjihQEcBXYYgCgHJjcYaBKIA)

Ref: https://github.com/microsoft/TypeScript/pull/41573