### PR TITLE
Add a shim function for unbundled uses of `require`

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -89,6 +89,9 @@ type ImportRecord struct {
 	// Tell the printer to wrap this call to "require()" in "__toModule(...)"
 	WrapWithToModule bool
 
+	// Tell the printer to use the runtime "__require()" instead of "require()"
+	CallRuntimeRequire bool
+
 	// True for the following cases:
 	//
 	//   try { require('x') } catch { handle }

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -288,8 +288,8 @@ var require_b = __commonJS({
 });
 
 // a.js
-x ? require("a") : y ? require_b() : require("c");
-x ? y ? require("a") : require_b() : require(c);
+x ? __require("a") : y ? require_b() : __require("c");
+x ? y ? __require("a") : require_b() : __require(c);
 
 ================================================================================
 TestConditionalRequireResolve
@@ -1964,7 +1964,7 @@ TestNestedRequireWithoutCall
 ---------- /out.js ----------
 // entry.js
 (() => {
-  const req = require;
+  const req = __require;
   req("./entry");
 })();
 
@@ -2202,11 +2202,11 @@ class Bar {
 TestRequireAndDynamicImportInvalidTemplate
 ---------- /out.js ----------
 // entry.js
-require(tag`./b`);
-require(`./${b}`);
+__require(tag`./b`);
+__require(`./${b}`);
 try {
-  require(tag`./b`);
-  require(`./${b}`);
+  __require(tag`./b`);
+  __require(`./${b}`);
 } catch {
 }
 (async () => {
@@ -2227,11 +2227,11 @@ try {
 TestRequireBadArgumentCount
 ---------- /out.js ----------
 // entry.js
-require();
-require("a", "b");
+__require();
+__require("a", "b");
 try {
-  require();
-  require("a", "b");
+  __require();
+  __require("a", "b");
 } catch {
 }
 
@@ -2360,6 +2360,32 @@ console.log(true);
 console.log(true);
 
 ================================================================================
+TestRequireShimSubstitution
+---------- /out/entry.js ----------
+// example.json
+var require_example = __commonJS({
+  "example.json"(exports, module) {
+    module.exports = {works: true};
+  }
+});
+
+// entry.js
+console.log([
+  __require,
+  typeof __require,
+  require_example(),
+  __require("./example.json", {type: "json"}),
+  __require(window.SOME_PATH),
+  require_example(),
+  __require("./example.json", {type: "json"}),
+  __require(window.SOME_PATH),
+  __require.resolve("some-path"),
+  __require.resolve(window.SOME_PATH),
+  Promise.resolve().then(() => __toModule(__require("some-path"))),
+  Promise.resolve().then(() => __toModule(__require(window.SOME_PATH)))
+]);
+
+================================================================================
 TestRequireTxt
 ---------- /out.js ----------
 // test.txt
@@ -2379,7 +2405,7 @@ TestRequireWithCallInsideTry
 var require_entry = __commonJS({
   "entry.js"(exports) {
     try {
-      const supportsColor = require("supports-color");
+      const supportsColor = __require("supports-color");
       if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
         exports.colors = [];
       }
@@ -2407,7 +2433,7 @@ console.log(require_b());
 TestRequireWithoutCall
 ---------- /out.js ----------
 // entry.js
-var req = require;
+var req = __require;
 req("./entry");
 
 ================================================================================
@@ -2416,7 +2442,7 @@ TestRequireWithoutCallInsideTry
 // entry.js
 try {
   oldLocale = globalLocale._abbr;
-  aliasedRequire = require;
+  aliasedRequire = __require;
   aliasedRequire("./locale/" + name);
   getSetGlobalLocale(oldLocale);
 } catch (e) {

--- a/internal/bundler/snapshots/snapshots_importstar.txt
+++ b/internal/bundler/snapshots/snapshots_importstar.txt
@@ -822,7 +822,7 @@ var mod = (() => {
   __export(entry_exports, {
     out: () => out
   });
-  var out = __toModule(require("foo"));
+  var out = __toModule(__require("foo"));
   return entry_exports;
 })();
 
@@ -868,7 +868,7 @@ TestReExportStarExternalIIFE
 var mod = (() => {
   // entry.js
   var entry_exports = {};
-  __reExport(entry_exports, __toModule(require("foo")));
+  __reExport(entry_exports, __toModule(__require("foo")));
   return entry_exports;
 })();
 

--- a/internal/bundler/snapshots/snapshots_splitting.txt
+++ b/internal/bundler/snapshots/snapshots_splitting.txt
@@ -205,19 +205,19 @@ TestSplittingDynamicAndNotDynamicCommonJSIntoES6
 import {
   __toModule,
   require_foo
-} from "./chunk-Y5X7B3LP.js";
+} from "./chunk-76OUUS4B.js";
 
 // entry.js
 var import_foo = __toModule(require_foo());
-import("./foo-WILI25IU.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
+import("./foo-O3QA5LZB.js").then(({default: {bar: b}}) => console.log(import_foo.bar, b));
 
----------- /out/foo-WILI25IU.js ----------
+---------- /out/foo-O3QA5LZB.js ----------
 import {
   require_foo
-} from "./chunk-Y5X7B3LP.js";
+} from "./chunk-76OUUS4B.js";
 export default require_foo();
 
----------- /out/chunk-Y5X7B3LP.js ----------
+---------- /out/chunk-76OUUS4B.js ----------
 // foo.js
 var require_foo = __commonJS({
   "foo.js"(exports) {
@@ -260,9 +260,9 @@ export {
 TestSplittingDynamicCommonJSIntoES6
 ---------- /out/entry.js ----------
 // entry.js
-import("./foo-G6GTLWFE.js").then(({default: {bar}}) => console.log(bar));
+import("./foo-WDO3WAB7.js").then(({default: {bar}}) => console.log(bar));
 
----------- /out/foo-G6GTLWFE.js ----------
+---------- /out/foo-WDO3WAB7.js ----------
 // foo.js
 var require_foo = __commonJS({
   "foo.js"(exports) {
@@ -317,7 +317,7 @@ TestSplittingHybridESMAndCJSIssue617
 import {
   foo,
   init_a
-} from "./chunk-3XIBLUW3.js";
+} from "./chunk-OU4GWHY4.js";
 init_a();
 export {
   foo
@@ -327,7 +327,7 @@ export {
 import {
   a_exports,
   init_a
-} from "./chunk-3XIBLUW3.js";
+} from "./chunk-OU4GWHY4.js";
 
 // b.js
 var bar = (init_a(), a_exports);
@@ -335,7 +335,7 @@ export {
   bar
 };
 
----------- /out/chunk-3XIBLUW3.js ----------
+---------- /out/chunk-OU4GWHY4.js ----------
 // a.js
 var a_exports = {};
 __export(a_exports, {
@@ -485,7 +485,7 @@ TestSplittingSharedCommonJSIntoES6
 ---------- /out/a.js ----------
 import {
   require_shared
-} from "./chunk-2VTMOLG3.js";
+} from "./chunk-SDUKV4IM.js";
 
 // a.js
 var {foo} = require_shared();
@@ -494,13 +494,13 @@ console.log(foo);
 ---------- /out/b.js ----------
 import {
   require_shared
-} from "./chunk-2VTMOLG3.js";
+} from "./chunk-SDUKV4IM.js";
 
 // b.js
 var {foo} = require_shared();
 console.log(foo);
 
----------- /out/chunk-2VTMOLG3.js ----------
+---------- /out/chunk-SDUKV4IM.js ----------
 // shared.js
 var require_shared = __commonJS({
   "shared.js"(exports) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,6 +375,10 @@ func IsTreeShakingEnabled(mode Mode, outputFormat Format) bool {
 	return mode == ModeBundle || (mode == ModeConvertFormat && outputFormat == FormatIIFE)
 }
 
+func ShouldCallRuntimeRequire(mode Mode, outputFormat Format) bool {
+	return mode == ModeBundle && outputFormat != FormatCommonJS
+}
+
 type InjectedDefine struct {
 	Source logger.Source
 	Data   js_ast.E

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1235,8 +1235,16 @@ func (p *printer) printRequireOrImportExpr(
 				p.print("(")
 				defer p.print(")")
 			}
-			p.printSpaceBeforeIdentifier()
-			p.print("require(")
+
+			// Potentially substitute our own "__require" stub for "require"
+			if record.CallRuntimeRequire {
+				p.printSymbol(p.options.RuntimeRequireRef)
+			} else {
+				p.printSpaceBeforeIdentifier()
+				p.print("require")
+			}
+
+			p.print("(")
 			p.addSourceMapping(record.Range.Loc)
 			p.printQuotedUTF8(record.Path.Text, true /* allowBacktick */)
 			p.print(")")
@@ -1261,8 +1269,15 @@ func (p *printer) printRequireOrImportExpr(
 				defer p.print(")")
 			}
 
-			p.printSpaceBeforeIdentifier()
-			p.print("require(")
+			// Potentially substitute our own "__require" stub for "require"
+			if record.CallRuntimeRequire {
+				p.printSymbol(p.options.RuntimeRequireRef)
+			} else {
+				p.printSpaceBeforeIdentifier()
+				p.print("require")
+			}
+
+			p.print("(")
 			defer p.print(")")
 		}
 		if len(leadingInteriorComments) > 0 {
@@ -3148,6 +3163,7 @@ type Options struct {
 	AddSourceMappings            bool
 	Indent                       int
 	ToModuleRef                  js_ast.Ref
+	RuntimeRequireRef            js_ast.Ref
 	UnsupportedFeatures          compat.JSFeature
 	RequireOrImportMetaForSource func(uint32) RequireOrImportMeta
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -115,6 +115,12 @@ func code(isES6 bool) string {
 		// Tells importing modules that this can be considered an ES6 module
 		export var __name = (target, value) => __defProp(target, 'name', { value, configurable: true })
 
+		// This fallback "require" function exists so that "typeof require" can naturally be "function"
+		export var __require = x => {
+			if (typeof require !== 'undefined') return require(x)
+			throw new Error('Dynamic require of "' + x + '" is not supported')
+		}
+
 		// For object rest patterns
 		export var __restKey = key => typeof key === 'symbol' ? key : key + ''
 		export var __objRest = (source, exclude) => {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -592,6 +592,42 @@
         setTimeout(() => require('./a'), 0)
       `,
     }),
+
+    // Test the run-time value of "typeof require"
+    test(['--bundle', 'in.js', '--outfile=out.js', '--format=iife'], {
+      'in.js': `check(typeof require)`,
+      'node.js': `
+        const out = require('fs').readFileSync(__dirname + '/out.js', 'utf8')
+        const check = x => value = x
+        let value
+        new Function('check', 'require', out)(check)
+        if (value !== 'function') throw 'fail'
+      `,
+    }),
+    test(['--bundle', 'in.js', '--outfile=out.js', '--format=esm'], {
+      'in.js': `check(typeof require)`,
+      'node.js': `
+        import fs from 'fs'
+        import path from 'path'
+        import url from 'url'
+        const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+        const out = fs.readFileSync(__dirname + '/out.js', 'utf8')
+        const check = x => value = x
+        let value
+        new Function('check', 'require', out)(check)
+        if (value !== 'function') throw 'fail'
+      `,
+    }),
+    test(['--bundle', 'in.js', '--outfile=out.js', '--format=cjs'], {
+      'in.js': `check(typeof require)`,
+      'node.js': `
+        const out = require('fs').readFileSync(__dirname + '/out.js', 'utf8')
+        const check = x => value = x
+        let value
+        new Function('check', 'require', out)(check)
+        if (value !== 'undefined') throw 'fail'
+      `,
+    }),
   )
 
   // Test internal CommonJS export

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -1967,11 +1967,10 @@ console.log("success");
       write: false,
       bundle: true,
       external: ['/assets/*.png'],
+      platform: 'node',
     })
-    assert.strictEqual(outputFiles[0].text, `(() => {
-  // <stdin>
-  require("/assets/file.png");
-})();
+    assert.strictEqual(outputFiles[0].text, `// <stdin>
+require("/assets/file.png");
 `)
   },
 

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -1772,6 +1772,7 @@ let pluginTests = {
         bundle: true,
         write: false,
         logLevel: 'silent',
+        platform: 'node',
         plugins: [{
           name: 'plugin',
           setup(build) {


### PR DESCRIPTION
Modules in CommonJS format automatically get three variables injected into their scope: `module`, `exports`, and `require`. These allow the code to import other modules and to export things from itself. The bundler automatically rewrites uses of `module` and `exports` to refer to the module's exports and certain uses of `require` to a helper function that loads the imported module.

Not all uses of `require` can be converted though, and un-converted uses of `require` will end up in the output. This is problematic because `require` is only present at run-time if the output is run as a CommonJS module. Otherwise `require` is undefined, which means esbuild's behavior is inconsistent between compile-time and run-time. The `module` and `exports` variables are objects at compile-time and run-time but `require` is a function at compile-time and undefined at run-time. This causes code that checks for `typeof require` to have inconsistent behavior:

```js
if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
  console.log('CommonJS detected')
}
```

In the above example, ideally `CommonJS detected` would always be printed since the code is being bundled with a CommonJS-aware bundler. To fix this, esbuild will now substitute references to `require` with a stub `__require` function when bundling if the output format is something other than CommonJS. This should ensure that `require` is now consistent between compile-time and run-time. When bundled, code that uses unbundled references to `require` will now look something like this:

```js
var __require = (x) => {
  if (typeof require !== "undefined")
    return require(x);
  throw new Error('Dynamic require of "' + x + '" is not supported');
};
var __commonJS = (cb, mod) => () => (mod || cb((mod = {exports: {}}).exports, mod), mod.exports);
var require_example = __commonJS((exports, module) => {
  if (typeof __require === "function" && typeof exports === "object" && typeof module === "object") {
    console.log("CommonJS detected");
  }
});
require_example();
```

Fixes #1202
