### PR TITLE
Breaking changes to fix CSS import issues

### DIFF
--- a/internal/bundler/bundler_css_test.go
+++ b/internal/bundler/bundler_css_test.go
@@ -53,27 +53,42 @@ func TestCSSAtImportExternal(t *testing.T) {
 				@import "./external2.css";
 				@import "./charset1.css";
 				@import "./charset2.css";
+				@import "./external5.css" screen;
 			`,
 			"/internal.css": `
+				@import "./external5.css" print;
 				.before { color: red }
 			`,
 			"/charset1.css": `
 				@charset "UTF-8";
+				@import "./external3.css";
+				@import "./external4.css";
+				@import "./external5.css";
+				@import "https://www.example.com/style1.css";
+				@import "https://www.example.com/style2.css";
+				@import "https://www.example.com/style3.css" print;
 				.middle { color: green }
 			`,
 			"/charset2.css": `
 				@charset "UTF-8";
+				@import "./external3.css";
+				@import "./external5.css" screen;
+				@import "https://www.example.com/style1.css";
+				@import "https://www.example.com/style3.css";
 				.after { color: blue }
 			`,
 		},
 		entryPaths: []string{"/entry.css"},
 		options: config.Options{
-			Mode:          config.ModeBundle,
-			AbsOutputFile: "/out.css",
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
 			ExternalModules: config.ExternalModules{
 				AbsPaths: map[string]bool{
 					"/external1.css": true,
 					"/external2.css": true,
+					"/external3.css": true,
+					"/external4.css": true,
+					"/external5.css": true,
 				},
 			},
 		},

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -160,7 +160,13 @@ type chunkReprJS struct {
 }
 
 type chunkReprCSS struct {
-	filesInChunkInOrder []uint32
+	externalImportsInOrder []externalImportCSS
+	filesInChunkInOrder    []uint32
+}
+
+type externalImportCSS struct {
+	path       logger.Path
+	conditions []css_ast.Token
 }
 
 // Returns a log where "log.HasErrors()" only returns true if any errors have
@@ -2659,6 +2665,165 @@ func sanitizeFilePathForVirtualModulePath(path string) string {
 	return sb.String()
 }
 
+// JavaScript modules are traversed in depth-first postorder. This is the
+// order that JavaScript modules were evaluated in before the top-level await
+// feature was introduced.
+//
+//     A
+//    / \
+//   B   C
+//    \ /
+//     D
+//
+// If A imports B and then C, B imports D, and C imports D, then the JavaScript
+// traversal order is D B C A.
+//
+// This function may deviate from ESM import order for dynamic imports (both
+// "require()" and "import()"). This is because the import order is impossible
+// to determine since the imports happen at run-time instead of compile-time.
+// In this case we just pick an arbitrary but consistent order.
+func (c *linkerContext) findImportedCSSFilesInJSOrder(entryPoint uint32) (order []uint32) {
+	visited := make(map[uint32]bool)
+	var visit func(uint32, ast.Index32)
+
+	// Include this file and all files it imports
+	visit = func(sourceIndex uint32, importerIndex ast.Index32) {
+		if visited[sourceIndex] {
+			return
+		}
+		visited[sourceIndex] = true
+		file := &c.graph.Files[sourceIndex]
+		repr := file.InputFile.Repr.(*graph.JSRepr)
+
+		// Iterate over each part in the file in order
+		for _, part := range repr.AST.Parts {
+			// Ignore dead code that has been removed from the bundle. Any code
+			// that's reachable from the entry point, even through lazy dynamic
+			// imports, could end up being activated by the bundle and needs its
+			// CSS to be included. This may change if/when code splitting is
+			// supported for CSS.
+			if !part.IsLive {
+				continue
+			}
+
+			// Traverse any files imported by this part. Note that CommonJS calls
+			// to "require()" count as imports too, sort of as if the part has an
+			// ESM "import" statement in it. This may seem weird because ESM imports
+			// are a compile-time concept while CommonJS imports are a run-time
+			// concept. But we don't want to manipulate <style> tags at run-time so
+			// this is the only way to do it.
+			for _, importRecordIndex := range part.ImportRecordIndices {
+				if record := &repr.AST.ImportRecords[importRecordIndex]; record.SourceIndex.IsValid() {
+					visit(record.SourceIndex.GetIndex(), ast.MakeIndex32(sourceIndex))
+				}
+			}
+		}
+
+		// Iterate over the associated CSS imports in postorder
+		if repr.CSSSourceIndex.IsValid() {
+			order = append(order, repr.CSSSourceIndex.GetIndex())
+		}
+	}
+
+	// Include all files reachable from the entry point
+	visit(entryPoint, ast.Index32{})
+
+	return
+}
+
+// CSS files are traversed in depth-first reversed reverse preorder. This is
+// because unlike JavaScript import statements, CSS "@import" rules are
+// evaluated every time instead of just the first time. However, evaluating a
+// CSS file multiple times is equivalent to evaluating it once at the last
+// location. So we drop all but the last evaluation in the order.
+//
+//     A
+//    / \
+//   B   C
+//    \ /
+//     D
+//
+// If A imports B and then C, B imports D, and C imports D, then the CSS
+// traversal order is B D C A.
+func (c *linkerContext) findImportedFilesInCSSOrder(entryPoints []uint32) (externalOrder []externalImportCSS, internalOrder []uint32) {
+	type externalImportsCSS struct {
+		unconditional bool
+		conditions    [][]css_ast.Token
+	}
+
+	visited := make(map[uint32]bool)
+	externals := make(map[logger.Path]externalImportsCSS)
+	var visit func(uint32, ast.Index32)
+
+	// Include this file and all files it imports
+	visit = func(sourceIndex uint32, importerIndex ast.Index32) {
+		if !visited[sourceIndex] {
+			visited[sourceIndex] = true
+			repr := c.graph.Files[sourceIndex].InputFile.Repr.(*graph.CSSRepr)
+			topLevelRules := repr.AST.Rules
+
+			// Iterate in reverse preorder (will be reversed again later)
+			internalOrder = append(internalOrder, sourceIndex)
+
+			// Iterate in the inverse order of top-level "@import" rules
+		outer:
+			for i := len(topLevelRules) - 1; i >= 0; i-- {
+				if atImport, ok := topLevelRules[i].(*css_ast.RAtImport); ok {
+					if record := &repr.AST.ImportRecords[atImport.ImportRecordIndex]; record.SourceIndex.IsValid() {
+						// Follow internal dependencies
+						visit(record.SourceIndex.GetIndex(), ast.MakeIndex32(sourceIndex))
+					} else {
+						// Record external dependencies
+						external := externals[record.Path]
+
+						// Check for an unconditional import. An unconditional import
+						// should always mask all conditional imports that are overridden
+						// by the unconditional import.
+						if external.unconditional {
+							continue
+						}
+
+						if len(atImport.ImportConditions) == 0 {
+							external.unconditional = true
+						} else {
+							// Check for a conditional import. A conditional import does not
+							// mask an earlier unconditional import because re-evaluating a
+							// CSS file can have observable results.
+							for _, tokens := range external.conditions {
+								if css_ast.TokensEqualIgnoringWhitespace(tokens, atImport.ImportConditions) {
+									continue outer
+								}
+							}
+							external.conditions = append(external.conditions, atImport.ImportConditions)
+						}
+
+						externals[record.Path] = external
+						externalOrder = append(externalOrder, externalImportCSS{
+							path:       record.Path,
+							conditions: atImport.ImportConditions,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Include all files reachable from any entry point
+	for _, entryPoint := range entryPoints {
+		visit(entryPoint, ast.Index32{})
+	}
+
+	// Reverse the order afterward when traversing in CSS order
+	for i, j := 0, len(internalOrder)-1; i < j; i, j = i+1, j-1 {
+		internalOrder[i], internalOrder[j] = internalOrder[j], internalOrder[i]
+	}
+	for i, j := 0, len(externalOrder)-1; i < j; i, j = i+1, j-1 {
+		externalOrder[i], externalOrder[j] = externalOrder[j], externalOrder[i]
+	}
+
+	return
+}
+
 func (c *linkerContext) computeChunks() []chunkInfo {
 	c.timer.Begin("Compute chunks")
 	defer c.timer.End("Compute chunks")
@@ -2674,7 +2839,8 @@ func (c *linkerContext) computeChunks() []chunkInfo {
 		// always generated even if the resulting file is empty
 		entryBits := helpers.NewBitSet(uint(len(c.graph.EntryPoints())))
 		entryBits.SetBit(uint(i))
-		info := chunkInfo{
+		key := entryBits.String()
+		chunk := chunkInfo{
 			entryBits:             entryBits,
 			isEntryPoint:          true,
 			sourceIndex:           entryPoint.SourceIndex,
@@ -2684,56 +2850,62 @@ func (c *linkerContext) computeChunks() []chunkInfo {
 
 		switch file.InputFile.Repr.(type) {
 		case *graph.JSRepr:
-			info.chunkRepr = &chunkReprJS{}
-			jsChunks[entryBits.String()] = info
+			chunk.chunkRepr = &chunkReprJS{}
+			jsChunks[key] = chunk
+
+			// If this JS entry point has an associated CSS entry point, generate it
+			// now. This is essentially done by generating a virtual CSS file that
+			// only contains "@import" statements in the order that the files were
+			// discovered in JS source order, where JS source order is arbitrary but
+			// consistent for dynamic imports. Then we run the CSS import order
+			// algorithm to determine the final CSS file order for the chunk.
+			if cssSourceIndices := c.findImportedCSSFilesInJSOrder(entryPoint.SourceIndex); len(cssSourceIndices) > 0 {
+				externalOrder, internalOrder := c.findImportedFilesInCSSOrder(cssSourceIndices)
+				cssFilesWithPartsInChunk := make(map[uint32]bool)
+				for _, sourceIndex := range internalOrder {
+					cssFilesWithPartsInChunk[uint32(sourceIndex)] = true
+				}
+				cssChunks[key] = chunkInfo{
+					entryBits:             entryBits,
+					isEntryPoint:          true,
+					sourceIndex:           entryPoint.SourceIndex,
+					entryPointBit:         uint(i),
+					filesWithPartsInChunk: cssFilesWithPartsInChunk,
+					chunkRepr: &chunkReprCSS{
+						externalImportsInOrder: externalOrder,
+						filesInChunkInOrder:    internalOrder,
+					},
+				}
+			}
 
 		case *graph.CSSRepr:
-			info.chunkRepr = &chunkReprCSS{}
-			cssChunks[entryBits.String()] = info
+			externalOrder, internalOrder := c.findImportedFilesInCSSOrder([]uint32{entryPoint.SourceIndex})
+			for _, sourceIndex := range internalOrder {
+				chunk.filesWithPartsInChunk[uint32(sourceIndex)] = true
+			}
+			chunk.chunkRepr = &chunkReprCSS{
+				externalImportsInOrder: externalOrder,
+				filesInChunkInOrder:    internalOrder,
+			}
+			cssChunks[key] = chunk
 		}
 	}
 
-	// Figure out which files are in which chunk
+	// Figure out which JS files are in which chunk
 	for _, sourceIndex := range c.graph.ReachableFiles {
-		file := &c.graph.Files[sourceIndex]
-		if !file.IsLive {
-			// Ignore this file if it's not included in the bundle
-			continue
-		}
-
-		key := file.EntryBits.String()
-		var chunk chunkInfo
-		var ok bool
-
-		switch file.InputFile.Repr.(type) {
-		case *graph.JSRepr:
-			chunk, ok = jsChunks[key]
-			if !ok {
-				chunk.entryBits = file.EntryBits
-				chunk.filesWithPartsInChunk = make(map[uint32]bool)
-				chunk.chunkRepr = &chunkReprJS{}
-				jsChunks[key] = chunk
-			}
-
-		case *graph.CSSRepr:
-			chunk, ok = cssChunks[key]
-			if !ok {
-				chunk.entryBits = file.EntryBits
-				chunk.filesWithPartsInChunk = make(map[uint32]bool)
-				chunk.chunkRepr = &chunkReprCSS{}
-
-				// Check whether this is the CSS file to go with a JS entry point
-				if jsChunk, ok := jsChunks[key]; ok && jsChunk.isEntryPoint {
-					chunk.isEntryPoint = true
-					chunk.sourceIndex = jsChunk.sourceIndex
-					chunk.entryPointBit = jsChunk.entryPointBit
+		if file := &c.graph.Files[sourceIndex]; file.IsLive {
+			if _, ok := file.InputFile.Repr.(*graph.JSRepr); ok {
+				key := file.EntryBits.String()
+				chunk, ok := jsChunks[key]
+				if !ok {
+					chunk.entryBits = file.EntryBits
+					chunk.filesWithPartsInChunk = make(map[uint32]bool)
+					chunk.chunkRepr = &chunkReprJS{}
+					jsChunks[key] = chunk
 				}
-
-				cssChunks[key] = chunk
+				chunk.filesWithPartsInChunk[uint32(sourceIndex)] = true
 			}
 		}
-
-		chunk.filesWithPartsInChunk[uint32(sourceIndex)] = true
 	}
 
 	// Sort the chunks for determinism. This matters because we use chunk indices
@@ -2776,34 +2948,10 @@ func (c *linkerContext) computeChunks() []chunkInfo {
 		}
 	}
 
-	// Determine the order of files within the chunk ahead of time. This may
-	// generate additional CSS chunks from JS chunks that import CSS files.
-	{
-		for _, chunk := range sortedChunks {
-			js, jsParts, css := c.chunkFileOrder(&chunk)
-
-			switch chunkRepr := chunk.chunkRepr.(type) {
-			case *chunkReprJS:
-				chunkRepr.filesInChunkInOrder = js
-				chunkRepr.partsInChunkInOrder = jsParts
-
-				// If JS files include CSS files, make a sibling chunk for the CSS
-				if len(css) > 0 {
-					sortedChunks = append(sortedChunks, chunkInfo{
-						entryBits:             chunk.entryBits,
-						isEntryPoint:          chunk.isEntryPoint,
-						sourceIndex:           chunk.sourceIndex,
-						entryPointBit:         chunk.entryPointBit,
-						filesWithPartsInChunk: make(map[uint32]bool),
-						chunkRepr: &chunkReprCSS{
-							filesInChunkInOrder: css,
-						},
-					})
-				}
-
-			case *chunkReprCSS:
-				chunkRepr.filesInChunkInOrder = css
-			}
+	// Determine the order of JS files (and parts) within the chunk ahead of time
+	for _, chunk := range sortedChunks {
+		if chunkRepr, ok := chunk.chunkRepr.(*chunkReprJS); ok {
+			chunkRepr.filesInChunkInOrder, chunkRepr.partsInChunkInOrder = c.findImportedPartsInJSOrder(&chunk)
 		}
 	}
 
@@ -2902,7 +3050,7 @@ func (c *linkerContext) shouldIncludePart(repr *graph.JSRepr, part js_ast.Part) 
 	return true
 }
 
-func (c *linkerContext) chunkFileOrder(chunk *chunkInfo) (js []uint32, jsParts []partRange, css []uint32) {
+func (c *linkerContext) findImportedPartsInJSOrder(chunk *chunkInfo) (js []uint32, jsParts []partRange) {
 	sorted := make(chunkOrderArray, 0, len(chunk.filesWithPartsInChunk))
 
 	// Attach information to the files for use with sorting
@@ -2933,10 +3081,10 @@ func (c *linkerContext) chunkFileOrder(chunk *chunkInfo) (js []uint32, jsParts [
 
 		visited[sourceIndex] = true
 		file := &c.graph.Files[sourceIndex]
-		isFileInThisChunk := chunk.entryBits.Equals(file.EntryBits)
 
-		switch repr := file.InputFile.Repr.(type) {
-		case *graph.JSRepr:
+		if repr, ok := file.InputFile.Repr.(*graph.JSRepr); ok {
+			isFileInThisChunk := chunk.entryBits.Equals(file.EntryBits)
+
 			// Wrapped files can't be split because they are all inside the wrapper
 			canFileBeSplit := repr.Meta.Wrap == graph.WrapNone
 
@@ -2985,19 +3133,6 @@ func (c *linkerContext) chunkFileOrder(chunk *chunkInfo) (js []uint32, jsParts [
 						partIndexEnd:   uint32(len(repr.AST.Parts)),
 					})
 				}
-			}
-
-		case *graph.CSSRepr:
-			if isFileInThisChunk {
-				// All imported files come first
-				for _, record := range repr.AST.ImportRecords {
-					if record.SourceIndex.IsValid() {
-						visit(record.SourceIndex.GetIndex())
-					}
-				}
-
-				// Then this file comes afterward
-				css = append(css, sourceIndex)
 			}
 		}
 	}
@@ -4591,15 +4726,9 @@ func (c *linkerContext) generateGlobalNamePrefix() string {
 }
 
 type compileResultCSS struct {
-	printedCSS      string
-	sourceIndex     uint32
-	hasCharset      bool
-	externalImports []externalImportCSS
-}
-
-type externalImportCSS struct {
-	record     ast.ImportRecord
-	conditions []css_ast.Token
+	printedCSS  string
+	sourceIndex uint32
+	hasCharset  bool
 }
 
 func (c *linkerContext) generateChunkCSS(chunks []chunkInfo, chunkIndex int, chunkWaitGroup *sync.WaitGroup) {
@@ -4628,20 +4757,14 @@ func (c *linkerContext) generateChunkCSS(chunks []chunkInfo, chunkIndex int, chu
 			file := &c.graph.Files[sourceIndex]
 			ast := file.InputFile.Repr.(*graph.CSSRepr).AST
 
-			// Filter out "@import" rules
+			// Filter out "@charset" and "@import" rules
 			rules := make([]css_ast.R, 0, len(ast.Rules))
 			for _, rule := range ast.Rules {
-				switch r := rule.(type) {
+				switch rule.(type) {
 				case *css_ast.RAtCharset:
 					compileResult.hasCharset = true
 					continue
 				case *css_ast.RAtImport:
-					if record := ast.ImportRecords[r.ImportRecordIndex]; !record.SourceIndex.IsValid() {
-						compileResult.externalImports = append(compileResult.externalImports, externalImportCSS{
-							record:     record,
-							conditions: r.ImportConditions,
-						})
-					}
 					continue
 				}
 				rules = append(rules, rule)
@@ -4670,30 +4793,31 @@ func (c *linkerContext) generateChunkCSS(chunks []chunkInfo, chunkIndex int, chu
 
 	// Generate any prefix rules now
 	{
-		ast := css_ast.AST{}
+		tree := css_ast.AST{}
 
 		// "@charset" is the only thing that comes before "@import"
 		for _, compileResult := range compileResults {
 			if compileResult.hasCharset {
-				ast.Rules = append(ast.Rules, &css_ast.RAtCharset{Encoding: "UTF-8"})
+				tree.Rules = append(tree.Rules, &css_ast.RAtCharset{Encoding: "UTF-8"})
 				break
 			}
 		}
 
 		// Insert all external "@import" rules at the front. In CSS, all "@import"
 		// rules must come first or the browser will just ignore them.
-		for _, compileResult := range compileResults {
-			for _, external := range compileResult.externalImports {
-				ast.Rules = append(ast.Rules, &css_ast.RAtImport{
-					ImportRecordIndex: uint32(len(ast.ImportRecords)),
-					ImportConditions:  external.conditions,
-				})
-				ast.ImportRecords = append(ast.ImportRecords, external.record)
-			}
+		for _, external := range chunkRepr.externalImportsInOrder {
+			tree.Rules = append(tree.Rules, &css_ast.RAtImport{
+				ImportRecordIndex: uint32(len(tree.ImportRecords)),
+				ImportConditions:  external.conditions,
+			})
+			tree.ImportRecords = append(tree.ImportRecords, ast.ImportRecord{
+				Kind: ast.ImportAt,
+				Path: external.path,
+			})
 		}
 
-		if len(ast.Rules) > 0 {
-			css := css_printer.Print(ast, css_printer.Options{
+		if len(tree.Rules) > 0 {
+			css := css_printer.Print(tree, css_printer.Options{
 				RemoveWhitespace: c.options.RemoveWhitespace,
 			})
 			if len(css) > 0 {

--- a/internal/bundler/snapshots/snapshots_css.txt
+++ b/internal/bundler/snapshots/snapshots_css.txt
@@ -42,34 +42,38 @@ export {
 };
 
 ---------- /out/c.css ----------
+/* shared.css */
+body {
+  background: black;
+}
+
 /* c.css */
 body {
   color: red;
 }
 
 ---------- /out/d.css ----------
-/* d.css */
-body {
-  color: blue;
-}
-
----------- /out/chunk-C7T4PGKL.css ----------
 /* shared.css */
 body {
   background: black;
 }
 
+/* d.css */
+body {
+  color: blue;
+}
+
 ================================================================================
 TestCSSAtImport
 ---------- /out.css ----------
-/* shared.css */
-.shared {
-  color: black;
-}
-
 /* a.css */
 .a {
   color: green;
+}
+
+/* shared.css */
+.shared {
+  color: black;
 }
 
 /* b.css */
@@ -106,10 +110,17 @@ TestCSSAtImportExtensionOrderCollision
 
 ================================================================================
 TestCSSAtImportExternal
----------- /out.css ----------
+---------- /out/entry.css ----------
 @charset "UTF-8";
-@import "./external1.css";
-@import "./external2.css";
+@import "../external1.css";
+@import "../external2.css";
+@import "../external4.css";
+@import "../external5.css";
+@import "https://www.example.com/style2.css";
+@import "../external3.css";
+@import "https://www.example.com/style1.css";
+@import "https://www.example.com/style3.css";
+@import "../external5.css" screen;
 
 /* internal.css */
 .before {
@@ -218,14 +229,14 @@ console.log("a");
 console.log("b");
 
 ---------- /out/entry.css ----------
-/* a.css */
-.a {
-  color: red;
-}
-
 /* b.css */
 .b {
   color: blue;
+}
+
+/* a.css */
+.a {
+  color: red;
 }
 
 ================================================================================


### PR DESCRIPTION
This PR fixes two separate issues:

* Fix bundled CSS import order (fixes #465)

    JS and CSS use different import ordering algorithms. In JS, importing a file that has already been imported is a no-op but in CSS, importing a file that has already been imported re-imports the file. A simple way to imagine this is to view each `@import` rule in CSS as being replaced by the contents of that file similar to `#include` in C/C++. However, this is incorrect in the case of `@import` cycles because it would cause infinite expansion. A more accurate way to imagine this is that in CSS, a file is evaluated at the *last* `@import` location while in JS, a file is evaluated at the *first* `import` location.

    Previously esbuild followed JS import order rules for CSS but now esbuild will follow CSS import order rules. This is a breaking change because it means your CSS may behave differently when bundled. Note that CSS import order rules are somewhat unintuitive because evaluation order matters. In CSS, using `@import` multiple times can end up unintentionally erasing overriding styles. For example, consider the following files:

    ```css
    /* entry.css */
    @import "./color.css";
    @import "./background.css";
    ```

    ```css
    /* color.css */
    @import "./reset.css";
    body {
      color: white;
    }
    ```

    ```css
    /* background.css */
    @import "./reset.css";
    body {
      background: black;
    }
    ```

    ```css
    /* reset.css */
    body {
      background: white;
      color: black;
    }
    ```

    Because of how CSS import order works, `entry.css` will now be bundled like this:

    ```css
    /* color.css */
    body {
      color: white;
    }

    /* reset.css */
    body {
      background: white;
      color: black;
    }

    /* background.css */
    body {
      background: black;
    }
    ```

    This means the body will unintuitively be all black! The file `reset.css` is evaluated at the location of the *last* `@import` instead of the *first* `@import`. The fix for this case is to remove the nested imports of `reset.css` and to import `reset.css` exactly once at the top of `entry.css`.

    Note that while the evaluation order of external CSS imports is preserved with respect to other external CSS imports, the evaluation order of external CSS imports is *not* preserved with respect to other internal CSS imports. All external CSS imports are "hoisted" to the top of the bundle. The alternative would be to generate many smaller chunks which is usually undesirable. So in this case esbuild's CSS bundling behavior will not match the browser.

* Fix bundled CSS when using JS code splitting (fixes #608)

    Previously esbuild generated incorrect CSS output when JS code splitting was enabled and the JS code being bundled imported CSS files. CSS code that was reachable via multiple JS entry points was split off into a shared CSS chunk, but that chunk was not actually imported anywhere so the shared CSS was missing. This happened because both CSS and JS code splitting were experimental features that are still in progress and weren't tested together.

    Now esbuild's CSS output should contain all reachable CSS code when JS code splitting is enabled. Note that this does *not* mean code splitting works for CSS files. Each CSS output file simply contains the transitive set of all CSS reachable from the JS entry point including through dynamic `import()` and `require()` expressions. Specifically, the bundler constructs a virtual CSS file for each JS entry point consisting only of `@import` rules for each CSS file imported into a JS file. These `@import` rules are constructed in JS source order, but then the bundler uses CSS import order from that point forward to bundle this virtual CSS file into the final CSS output file.

    This model makes the most sense when CSS files are imported into JS files via JS `import` statements. Importing CSS via `import()` and `require()` (either directly or transitively through multiple intermediate JS files) should still "work" in the sense that all reachable CSS should be included in the output, but in this case esbuild will pick an arbitrary (but consistent) import order. The import order may not match the order that the JS files are evaluated in because JS evaluation order of dynamic imports is only determined at run-time while CSS bundling happens at compile-time.

    It's possible to implement code splitting for CSS such that CSS code used between multiple entry points is shared. However, CSS lacks a mechanism for "lazily" importing code (i.e. disconnecting the import location with the evaluation location) so CSS code splitting could potentially need to generate a huge number of very small chunks to preserve import order. It's unclear if this would end up being a net win or not as far as browser download time. So sharing-based code splitting is currently not supported for CSS.

    It's theoretically possible to implement code splitting for CSS such that CSS from a dynamically-imported JS file (e.g. via `import()`) is placed into a separate chunk. However, due to how `@import` order works this would in theory end up re-evaluating all shared dependencies which could overwrite overloaded styles and unintentionally change the way the page is rendered. For example, constructing a single-page app architecture such that each page is JS-driven and can transition to other JS-driven pages via `import()` could end up with pages that look different depending on what order you visit them in. This is clearly undesirable. The simple way to address this is to just not support dynamic-import code splitting for CSS either.
