### PR TITLE
fix(css): single hyphen shouldn't be treated as css identifier

### DIFF
--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -225,6 +225,7 @@ func TestEscapes(t *testing.T) {
 	expectPrinted(t, ":pseudo(cl\\,ss) {}", ":pseudo(cl\\,ss) {\n}\n")
 
 	// SSAttribute
+	expectPrinted(t, "[attr=\"-\"] {}", "[attr=\"-\"] {\n}\n")
 	expectPrinted(t, "[\\61ttr] {}", "[attr] {\n}\n")
 	expectPrinted(t, "[\\2c attr] {}", "[\\,attr] {\n}\n")
 	expectPrinted(t, "[\\,attr] {}", "[\\,attr] {\n}\n")

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -225,7 +225,6 @@ func TestEscapes(t *testing.T) {
 	expectPrinted(t, ":pseudo(cl\\,ss) {}", ":pseudo(cl\\,ss) {\n}\n")
 
 	// SSAttribute
-	expectPrinted(t, "[attr=\"-\"] {}", "[attr=\"-\"] {\n}\n")
 	expectPrinted(t, "[\\61ttr] {}", "[attr] {\n}\n")
 	expectPrinted(t, "[\\2c attr] {}", "[\\,attr] {\n}\n")
 	expectPrinted(t, "[\\,attr] {}", "[\\,attr] {\n}\n")
@@ -233,6 +232,9 @@ func TestEscapes(t *testing.T) {
 	expectPrinted(t, "[attr\\~=x] {}", "[attr\\~=x] {\n}\n")
 	expectPrinted(t, "[attr=\\2c] {}", "[attr=\",\"] {\n}\n")
 	expectPrinted(t, "[attr=\\,] {}", "[attr=\",\"] {\n}\n")
+	expectPrinted(t, "[attr=\"-\"] {}", "[attr=\"-\"] {\n}\n")
+	expectPrinted(t, "[attr=\"--\"] {}", "[attr=--] {\n}\n")
+	expectPrinted(t, "[attr=\"-a\"] {}", "[attr=-a] {\n}\n")
 	expectPrinted(t, "[\\6es|attr] {}", "[ns|attr] {\n}\n")
 	expectPrinted(t, "[ns|\\61ttr] {}", "[ns|attr] {\n}\n")
 	expectPrinted(t, "[\\2cns|attr] {}", "[\\,ns|attr] {\n}\n")

--- a/internal/css_printer/css_printer.go
+++ b/internal/css_printer/css_printer.go
@@ -275,13 +275,15 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 				p.print(s.MatcherOp)
 				printAsIdent := false
 
-				// Print the value as an identifier if it's possible
-				if css_lexer.WouldStartIdentifierWithoutEscapes(s.MatcherValue) {
-					printAsIdent = true
-					for _, c := range s.MatcherValue {
-						if !css_lexer.IsNameContinue(c) {
-							printAsIdent = false
-							break
+				if s.MatcherValue != "-" {
+					// Print the value as an identifier if it's possible
+					if css_lexer.WouldStartIdentifierWithoutEscapes(s.MatcherValue) {
+						printAsIdent = true
+						for _, c := range s.MatcherValue {
+							if !css_lexer.IsNameContinue(c) {
+								printAsIdent = false
+								break
+							}
 						}
 					}
 				}


### PR DESCRIPTION
close #1308 

## CSS spec

In [CSS Selector level 4](https://drafts.csswg.org/selectors-4/#attribute-selectors): 

> Attribute values must be [`<ident-token>`](https://drafts.csswg.org/css-syntax-3/#ref-for-typedef-ident-token%E2%91%A0)s or [`<string-token>`](https://drafts.csswg.org/css-syntax-3/#ref-for-typedef-string-token%E2%91%A0)

According to  [`<ident-token>`](https://drafts.csswg.org/css-syntax-3/#ref-for-typedef-ident-token%E2%91%A0) rules,  single hyphen `-` without quotes is not valid `ident-token` which means `"-"` shouldn't be unwrapped as `-`. On the other hand, `"-"` is a valid [`<string-token>`](https://drafts.csswg.org/css-syntax-3/#ref-for-typedef-string-token%E2%91%A0) and a valid part of CSS attribute selector.


Extra helpful informations about `CSS escape` in [w3c](https://www.w3.org/International/questions/qa-escapes#cssescapes)

cc @evanw 