### PR TITLE
Add support for shorten transform/translate3d

### DIFF
--- a/internal/css_parser/css_decls.go
+++ b/internal/css_parser/css_decls.go
@@ -172,6 +172,10 @@ func (p *parser) processDeclarations(rules []css_ast.R) []css_ast.R {
 			if p.options.MangleSyntax {
 				borderRadius.mangleCorner(rules, decl, i, p.options.RemoveWhitespace, borderRadiusBottomLeft)
 			}
+		case css_ast.DTransform:
+			if p.options.MangleSyntax {
+				decl.Value = p.mangleTransforms(decl.Value)
+			}
 		}
 	}
 

--- a/internal/css_parser/css_decls_transform.go
+++ b/internal/css_parser/css_decls_transform.go
@@ -1,0 +1,40 @@
+package css_parser
+
+import (
+	"strings"
+
+	"github.com/evanw/esbuild/internal/css_ast"
+	"github.com/evanw/esbuild/internal/css_lexer"
+)
+
+func (p *parser) mangleTransforms(tokens []css_ast.Token) []css_ast.Token {
+	for i, token := range tokens {
+		transformFuncName := strings.ToLower(token.Text)
+		switch transformFuncName {
+		case "translate3d":
+			token = p.mangleTranslate3d(token)
+		}
+		tokens[i] = token
+	}
+
+	return tokens
+}
+
+func (p *parser) mangleTranslate3d(token css_ast.Token) css_ast.Token {
+	transformArg := *token.Children
+	if len(transformArg) != 5 {
+		return token
+	}
+	// translate3d(0, 0, tz) => translateZ(tz)
+	var noWhitespace css_ast.WhitespaceFlags
+	argX, argY, argZ := transformArg[0], transformArg[2], transformArg[4]
+	if argX.Kind == css_lexer.TNumber && argX.Text == "0" && argY.Kind == css_lexer.TNumber && argY.Text == "0" {
+		token.Text = "translateZ"
+		argZ.Whitespace = noWhitespace
+		token.Children = &[]css_ast.Token{
+			argZ,
+		}
+	}
+
+	return token
+}

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1116,3 +1116,12 @@ func TestMangleTime(t *testing.T) {
 	expectPrintedMangle(t, "a { animation: b 1e3ms }", "a {\n  animation: b 1e3ms;\n}\n")
 	expectPrintedMangle(t, "a { animation: b 1E3ms }", "a {\n  animation: b 1E3ms;\n}\n")
 }
+
+func TestTransform(t *testing.T) {
+	expectPrintedMangle(t, "a { transform:translate3d(0, 0, 2px) }", "a {\n  transform: translateZ(2px);\n}\n")
+	expectPrintedMangle(t, "a { transform:TRANSLATE3D(0, 0, 2) }", "a {\n  transform: translateZ(2);\n}\n")
+	expectPrintedMangle(t, "a { transform:translate3d(1.5,1.5,3) }", "a {\n  transform: translate3d(1.5, 1.5, 3);\n}\n")
+	expectPrintedMangle(t, "a { transform:translate3d(var(--foo)) }", "a {\n  transform: translate3d(var(--foo));\n}\n")
+	expectPrintedMangle(t, "a { transform:perspective(500px) translate3d(0, 0, 2px) rotateY(3deg); }",
+		"a {\n  transform: perspective(500px) translateZ(2px) rotateY(3deg);\n}\n")
+}


### PR DESCRIPTION
Add support for minify `transform: translate3d(0, 0, tz)` to `translateZ(tz)`
