### PR TITLE
Fix using JS synchronous API from from non-main threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Fix using JS synchronous API from from non-main threads ([#1406](https://github.com/evanw/esbuild/issues/1406))
+
+    This release fixes an issue with the new implementation of the synchronous JS API calls (`transformSync` and `buildSync`) when they are used from a thread other than the main thread. The problem happened because esbuild's new implementation uses node's `worker_threads` library internally and non-main threads were incorrectly assumed to be esbuild's internal thread instead of potentially another unrelated thread. Now esbuild's synchronous JS APIs should work correctly when called from non-main threads.
+
 ## 0.12.12
 
 * Fix `file` loader import paths when subdirectories are present ([#1044](https://github.com/evanw/esbuild/issues/1044))

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2481,7 +2481,7 @@ async function main() {
   // Time out these tests after 5 minutes. This exists to help debug test hangs in CI.
   let minutes = 5
   let timeout = setTimeout(() => {
-    console.error(`❌ js api tests timed out after ${minutes} minutes, exiting...`)
+    console.error(`❌ plugin tests timed out after ${minutes} minutes, exiting...`)
     process.exit(1)
   }, minutes * 60 * 1000)
 

--- a/scripts/register-test.js
+++ b/scripts/register-test.js
@@ -32,32 +32,54 @@ fs.writeFileSync(register, `
   };
 `)
 
-async function main() {
-  let result
-  let promise = new Promise((resolve, reject) => child_process.execFile('node', ['-r', register, entry], (err, stdout) => {
-    if (err) {
-      reject(err)
-    } else {
-      result = stdout
-      resolve()
-    }
-  }))
-  let timeout
-  let wait = new Promise((_, reject) => {
-    timeout = setTimeout(() => reject(new Error('This test timed out')), 60 * 1000)
-  })
-  await Promise.race([promise, wait])
-  clearTimeout(timeout)
-  assert.strictEqual(result, `in entry.ts\nin other.ts\n`)
+let tests = {
+  async fromMainThread() {
+    let result = await new Promise((resolve, reject) => child_process.execFile('node', ['-r', register, entry], (err, stdout) => {
+      if (err) reject(err)
+      else resolve(stdout)
+    }))
+    assert.strictEqual(result, `in entry.ts\nin other.ts\n`)
+  },
 }
 
-main().then(
-  () => {
-    console.log(`✅ register test passed`)
-    removeRecursiveSync(rootTestDir)
-  },
-  e => {
-    console.error(`❌ register test failed: ${e && e.message || e}`)
+async function main() {
+  // Time out these tests after 5 minutes. This exists to help debug test hangs in CI.
+  let minutes = 5
+  let timeout = setTimeout(() => {
+    console.error(`❌ register tests timed out after ${minutes} minutes, exiting...`)
     process.exit(1)
-  },
-)
+  }, minutes * 60 * 1000)
+
+  const runTest = async ([name, fn]) => {
+    let testDir = path.join(rootTestDir, name)
+    try {
+      fs.mkdirSync(testDir)
+      await fn({ esbuild, testDir })
+      removeRecursiveSync(testDir)
+      return true
+    } catch (e) {
+      console.error(`❌ ${name}: ${e && e.message || e}`)
+      return false
+    }
+  }
+
+  // Run all tests in serial
+  let allTestsPassed = true
+  for (let test of Object.entries(tests)) {
+    if (!await runTest(test)) {
+      allTestsPassed = false
+    }
+  }
+
+  if (!allTestsPassed) {
+    console.error(`❌ register tests failed`)
+    process.exit(1)
+  } else {
+    console.log(`✅ register tests passed`)
+    removeRecursiveSync(rootTestDir)
+  }
+
+  clearTimeout(timeout);
+}
+
+main().catch(e => setTimeout(() => { throw e }))


### PR DESCRIPTION
This PR fixes an issue with the new implementation of the synchronous JS API calls (`transformSync` and `buildSync`) when they are used from a thread other than the main thread. The problem happened because esbuild's new implementation uses node's `worker_threads` library internally and non-main threads were incorrectly assumed to be esbuild's internal thread instead of potentially another unrelated thread. Now esbuild's synchronous JS APIs should work correctly when called from non-main threads.

Fixes #1406
