### PR TITLE
Also should be configurable

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -171,7 +171,7 @@ func code(isES6 bool) string {
 		export var __export = (target, all) => {
 			__markAsModule(target)
 			for (var name in all)
-				__defProp(target, name, { get: all[name], enumerable: true })
+				__defProp(target, name, { get: all[name], enumerable: true, configurable: true })
 		}
 		export var __reExport = (target, module, desc) => {
 			if (module && typeof module === 'object' || typeof module === 'function')


### PR DESCRIPTION
I encountered an error and could not prompt to redefine, then I used replace and it worked well.

```shell
typeerror cannot redefine property default
```

```js
content.replace('{ get: all[name], enumerable: true }',`{ get: all[name], enumerable: true, configurable: true }`)
```


Actually I don’t like Object.defineproperty, but if you have to, add a parameter to cover more situations.