### PR TITLE
Abort esbuild if stdin is closed when serving

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -261,11 +262,17 @@ func main() {
 				}
 			}
 
-			// Disable the GC since we're just going to allocate a bunch of memory
-			// and then exit anyway. This speedup is not insignificant. Make sure to
-			// only do this here once we know that we're not going to be a long-lived
-			// process though.
-			if !isServe {
+			if isServe {
+				// Watch stdin and abort in case it is closed
+				go func() {
+					io.ReadAll(os.Stdin)
+					os.Exit(exitCode)
+				}()
+			} else {
+				// Disable the GC since we're just going to allocate a bunch of memory
+				// and then exit anyway. This speedup is not insignificant. Make sure to
+				// only do this here once we know that we're not going to be a long-lived
+				// process though.
 				debug.SetGCPercent(-1)
 			}
 

--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -202,7 +202,8 @@ func main() {
 	}
 
 	// Print help text when there are no arguments
-	if len(osArgs) == 0 && logger.GetTerminalInfo(os.Stdin).IsTTY {
+	isStdinTTY := logger.GetTerminalInfo(os.Stdin).IsTTY
+	if len(osArgs) == 0 && isStdinTTY {
 		logger.PrintText(os.Stdout, logger.LevelSilent, osArgs, helpText)
 		os.Exit(0)
 	}
@@ -254,26 +255,46 @@ func main() {
 			}
 		} else {
 			// Don't disable the GC if this is a long-running process
-			isServe := false
+			isServeOrWatch := false
 			for _, arg := range osArgs {
 				if arg == "--serve" || arg == "--watch" || strings.HasPrefix(arg, "--serve=") {
-					isServe = true
+					isServeOrWatch = true
 					break
 				}
 			}
 
-			if isServe {
-				// Watch stdin and abort in case it is closed
-				go func() {
-					io.ReadAll(os.Stdin)
-					os.Exit(exitCode)
-				}()
-			} else {
+			if !isServeOrWatch {
 				// Disable the GC since we're just going to allocate a bunch of memory
 				// and then exit anyway. This speedup is not insignificant. Make sure to
 				// only do this here once we know that we're not going to be a long-lived
 				// process though.
 				debug.SetGCPercent(-1)
+			} else if !isStdinTTY {
+				// If stdin isn't a TTY, watch stdin and abort in case it is closed.
+				// This is necessary when the esbuild binary executable is invoked via
+				// the Erlang VM, which doesn't provide a way to exit a child process.
+				// See: https://github.com/brunch/brunch/issues/920.
+				//
+				// We don't do this when stdin is a TTY because that interferes with
+				// the Unix background job system. If we read from stdin then Ctrl+Z
+				// to move the process to the background will incorrectly cause the
+				// job to stop. See: https://github.com/brunch/brunch/issues/998.
+				go func() {
+					// This just discards information from stdin because we don't use
+					// it and we can avoid unnecessarily allocating space for it
+					buffer := make([]byte, 512)
+					for {
+						_, err := os.Stdin.Read(buffer)
+						if err != nil {
+							// Only exit cleanly if stdin was closed cleanly
+							if err == io.EOF {
+								os.Exit(0)
+							} else {
+								os.Exit(1)
+							}
+						}
+					}
+				}()
 			}
 
 			exitCode = cli.Run(osArgs)


### PR DESCRIPTION
Most command line tools (cat, fsevents, etc) and JS CLI watchers (postcss,
webpack, etc) listen to stdin and abort when the stdin is closed (for example,
by sending Ctrl+D). This is important because there is no guarantee the
process who invokes esbuild will terminate it, but it is guaranteed the stdin
will be closed once the parent dies.

This pull requests watches the stdin when serving and exits accordingly,
in order to provide a user convenience and avoid zombie processes.

PS1: note I chose to always enable stdin watching (postcss does the same)
but you may want to gate this behaviour behind a flag (like webpack).

PS2: I noticed that you can communicate with esbuild via stdio but I am
not sure if this communication is enabled when serving. If it is, then this
needs to be revisited.

PS3: thanks for esbuild!