### PR TITLE
Add "isEntryPoint" to OutputFile and "entryPoints" to metafile

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -929,6 +929,9 @@ func encodeOutputFiles(outputFiles []api.OutputFile) []interface{} {
 		values[i] = value
 		value["path"] = outputFile.Path
 		value["contents"] = outputFile.Contents
+		if outputFile.IsEntryPoint {
+			value["isEntryPoint"] = true
+		}
 	}
 	return values
 }

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -2200,6 +2200,7 @@ func (b *Bundle) generateMetadataJSON(results []graph.OutputFile, allReachableFi
 	// Write outputs
 	isFirst = true
 	paths := make(map[string]bool)
+	var entryPoints []string
 	for _, result := range results {
 		if len(result.JSONMetadataChunk) > 0 {
 			path := b.res.PrettyPath(logger.Path{Text: result.AbsPath, Namespace: "file"})
@@ -2216,10 +2217,26 @@ func (b *Bundle) generateMetadataJSON(results []graph.OutputFile, allReachableFi
 			paths[path] = true
 			sb.WriteString(fmt.Sprintf("%s: ", js_printer.QuoteForJSON(path, asciiOnly)))
 			sb.WriteString(result.JSONMetadataChunk)
+			if result.IsEntryPoint {
+				entryPoints = append(entryPoints, path)
+			}
 		}
 	}
 
-	sb.WriteString("\n  }\n}\n")
+	sb.WriteString("\n  },\n  \"entryPoints\": [")
+	if len(entryPoints) > 0 {
+		isFirst = true
+		for _, entryPoint := range entryPoints {
+			if isFirst {
+				isFirst = false
+				sb.WriteString("\n    ")
+			} else {
+				sb.WriteString(",\n    ")
+			}
+			sb.WriteString(fmt.Sprintf("%s", js_printer.QuoteForJSON(entryPoint, asciiOnly)))
+		}
+	}
+	sb.WriteString("\n  ]\n}\n")
 	return sb.String()
 }
 

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -73,9 +73,10 @@ type chunkInfo struct {
 	entryBits             helpers.BitSet
 
 	// This information is only useful if "isEntryPoint" is true
-	isEntryPoint  bool
-	sourceIndex   uint32 // An index into "c.sources"
-	entryPointBit uint   // An index into "c.graph.EntryPoints"
+	isEntryPoint              bool
+	sourceIndex               uint32 // An index into "c.sources"
+	entryPointBit             uint   // An index into "c.graph.EntryPoints"
+	isUserSpecifiedEntryPoint bool
 
 	// For code splitting
 	crossChunkImports []chunkImport
@@ -490,6 +491,7 @@ func (c *linkerContext) generateChunksInParallel(chunks []chunkInfo) []graph.Out
 				Contents:          outputContents,
 				JSONMetadataChunk: jsonMetadataChunk,
 				IsExecutable:      chunk.isExecutable,
+				IsEntryPoint:      chunk.isUserSpecifiedEntryPoint,
 			})
 
 			results[chunkIndex] = outputFiles
@@ -2858,11 +2860,12 @@ func (c *linkerContext) computeChunks() []chunkInfo {
 		entryBits.SetBit(uint(i))
 		key := entryBits.String()
 		chunk := chunkInfo{
-			entryBits:             entryBits,
-			isEntryPoint:          true,
-			sourceIndex:           entryPoint.SourceIndex,
-			entryPointBit:         uint(i),
-			filesWithPartsInChunk: make(map[uint32]bool),
+			entryBits:                 entryBits,
+			isEntryPoint:              true,
+			isUserSpecifiedEntryPoint: file.IsUserSpecifiedEntryPoint(),
+			sourceIndex:               entryPoint.SourceIndex,
+			entryPointBit:             uint(i),
+			filesWithPartsInChunk:     make(map[uint32]bool),
 		}
 
 		switch file.InputFile.Repr.(type) {
@@ -2883,11 +2886,12 @@ func (c *linkerContext) computeChunks() []chunkInfo {
 					cssFilesWithPartsInChunk[uint32(sourceIndex)] = true
 				}
 				cssChunks[key] = chunkInfo{
-					entryBits:             entryBits,
-					isEntryPoint:          true,
-					sourceIndex:           entryPoint.SourceIndex,
-					entryPointBit:         uint(i),
-					filesWithPartsInChunk: cssFilesWithPartsInChunk,
+					entryBits:                 entryBits,
+					isEntryPoint:              true,
+					isUserSpecifiedEntryPoint: file.IsUserSpecifiedEntryPoint(),
+					sourceIndex:               entryPoint.SourceIndex,
+					entryPointBit:             uint(i),
+					filesWithPartsInChunk:     cssFilesWithPartsInChunk,
 					chunkRepr: &chunkReprCSS{
 						externalImportsInOrder: externalOrder,
 						filesInChunkInOrder:    internalOrder,

--- a/internal/graph/input.go
+++ b/internal/graph/input.go
@@ -42,6 +42,7 @@ type OutputFile struct {
 	JSONMetadataChunk string
 
 	IsExecutable bool
+	IsEntryPoint bool
 }
 
 type SideEffects struct {

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1532,7 +1532,7 @@ function sanitizeStringArray(values: any[], property: string): string[] {
   return result;
 }
 
-function convertOutputFiles({ path, contents }: protocol.BuildOutputFile): types.OutputFile {
+function convertOutputFiles({ path, contents, isEntryPoint }: protocol.BuildOutputFile): types.OutputFile {
   let text: string | null = null;
   return {
     path,
@@ -1541,5 +1541,6 @@ function convertOutputFiles({ path, contents }: protocol.BuildOutputFile): types
       if (text === null) text = protocol.decodeUTF8(contents);
       return text;
     },
+    isEntryPoint,
   }
 }

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -57,6 +57,7 @@ export interface BuildResponse {
 export interface BuildOutputFile {
   path: string;
   contents: Uint8Array;
+  isEntryPoint?: boolean;
 }
 
 export interface PingRequest {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -110,6 +110,7 @@ export interface OutputFile {
   path: string;
   contents: Uint8Array; // "text" as bytes
   text: string; // "contents" as text
+  isEntryPoint?: boolean;
 }
 
 export interface BuildInvalidate {
@@ -313,7 +314,8 @@ export interface Metafile {
       exports: string[]
       entryPoint?: string
     }
-  }
+  },
+  entryPoints: string[]
 }
 
 export interface FormatMessagesOptions {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -336,8 +336,9 @@ type BuildResult struct {
 }
 
 type OutputFile struct {
-	Path     string
-	Contents []byte
+	Path         string
+	Contents     []byte
+	IsEntryPoint bool
 }
 
 func Build(options BuildOptions) BuildResult {

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1017,8 +1017,9 @@ func rebuildImpl(
 						result.AbsPath = "<stdout>"
 					}
 					outputFiles[i] = OutputFile{
-						Path:     result.AbsPath,
-						Contents: result.Contents,
+						Path:         result.AbsPath,
+						Contents:     result.Contents,
+						IsEntryPoint: result.IsEntryPoint,
 					}
 				}
 			}

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -603,6 +603,9 @@ export {
   foo
 };
 `)
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[2].isEntryPoint, undefined)
   },
 
   async fileLoaderPublicPath({ esbuild, testDir }) {
@@ -753,6 +756,12 @@ body {
     const cwd = process.cwd()
     const makePath = absPath => path.relative(cwd, absPath).split(path.sep).join('/')
 
+    // Check entry points
+    assert.deepStrictEqual(json.entryPoints, [
+      makePath(outputJS),
+      makePath(outputCSS)
+    ])
+
     // Check inputs
     assert.deepStrictEqual(json.inputs[makePath(entry)].bytes, 144)
     assert.deepStrictEqual(json.inputs[makePath(entry)].imports, [
@@ -830,6 +839,8 @@ body {
     const outEntry1 = makeOutPath(path.basename(entry1));
     const outEntry2 = makeOutPath(path.basename(entry2));
     const outChunk = makeOutPath(chunk);
+
+    assert.deepStrictEqual(json.entryPoints, [outEntry1, outEntry2])
 
     assert.deepStrictEqual(json.inputs[inEntry1], { bytes: 94, imports: [{ path: inImported, kind: 'import-statement' }] })
     assert.deepStrictEqual(json.inputs[inEntry2], { bytes: 107, imports: [{ path: inImported, kind: 'import-statement' }] })
@@ -961,6 +972,8 @@ body {
     const outImport1 = makeOutPath('import1-SELM3ZIG.js');
     const outImport2 = makeOutPath('import2-3GSTEHBF.js');
     const outChunk = makeOutPath(chunk);
+
+    assert.deepStrictEqual(json.entryPoints, [outEntry])
 
     assert.deepStrictEqual(json.inputs[inEntry], {
       bytes: 112,
@@ -1197,6 +1210,9 @@ body {
 
     // Check inputs
     assert.deepStrictEqual(json, {
+      entryPoints: [
+        makePath(output),
+      ],
       inputs: {
         [makePath(entry)]: { bytes: 98, imports: [{ path: makePath(imported), kind: 'import-rule' }] },
         [makePath(image)]: { bytes: 8, imports: [] },
@@ -1242,6 +1258,10 @@ body {
     const makePath = pathname => path.relative(cwd, pathname).split(path.sep).join('/')
     const fileName = require(path.join(outdir, 'entry1.js')).default
     const fileKey = makePath(path.join(outdir, fileName))
+    assert.deepStrictEqual(json.entryPoints, [
+      makePath(path.join(outdir, 'entry1.js')),
+      makePath(path.join(outdir, 'entry2.js')),
+    ])
     assert.deepStrictEqual(json.outputs[fileKey].imports, [])
     assert.deepStrictEqual(json.outputs[fileKey].exports, [])
     assert.deepStrictEqual(json.outputs[fileKey].inputs, { [makePath(file)]: { bytesInOutput: 14 } })
@@ -1269,8 +1289,10 @@ body {
     assert.strictEqual(value.outputFiles.length, 2)
     assert.strictEqual(value.outputFiles[0].path, output + '.map')
     assert.strictEqual(value.outputFiles[0].contents.constructor, Uint8Array)
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, undefined)
     assert.strictEqual(value.outputFiles[1].path, output)
     assert.strictEqual(value.outputFiles[1].contents.constructor, Uint8Array)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
 
     const sourceMap = JSON.parse(Buffer.from(value.outputFiles[0].contents).toString())
     const js = Buffer.from(value.outputFiles[1].contents).toString()
@@ -1370,6 +1392,9 @@ export {
     assert.strictEqual(value.outputFiles[0].path, path.join(outdir, path.basename(inputA)))
     assert.strictEqual(value.outputFiles[1].path, path.join(outdir, path.basename(inputB)))
     assert.strictEqual(value.outputFiles[2].path, path.join(outdir, chunk))
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[2].isEntryPoint, undefined)
   },
 
   async splittingRelativeNestedDir({ esbuild, testDir }) {
@@ -1427,6 +1452,9 @@ export {
     assert.strictEqual(value.outputFiles[0].path, path.join(outdir, path.relative(testDir, inputA)))
     assert.strictEqual(value.outputFiles[1].path, path.join(outdir, path.relative(testDir, inputB)))
     assert.strictEqual(value.outputFiles[2].path, path.join(outdir, chunk))
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[2].isEntryPoint, undefined)
   },
 
   async splittingWithChunkPath({ esbuild, testDir }) {
@@ -1485,6 +1513,9 @@ export {
     assert.strictEqual(value.outputFiles[0].path, path.join(outdir, path.relative(testDir, inputA)))
     assert.strictEqual(value.outputFiles[1].path, path.join(outdir, path.relative(testDir, inputB)))
     assert.strictEqual(value.outputFiles[2].path, path.join(outdir, chunk))
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[2].isEntryPoint, undefined)
   },
 
   async splittingWithEntryHashes({ esbuild, testDir }) {
@@ -1546,6 +1577,9 @@ export {
     assert.strictEqual(value.outputFiles[0].path, path.join(outdir, outputA))
     assert.strictEqual(value.outputFiles[1].path, path.join(outdir, outputB))
     assert.strictEqual(value.outputFiles[2].path, path.join(outdir, chunk))
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[1].isEntryPoint, true)
+    assert.strictEqual(value.outputFiles[2].isEntryPoint, undefined)
   },
 
   async splittingWithChunkPathAndCrossChunkImportsIssue899({ esbuild, testDir }) {
@@ -1716,6 +1750,7 @@ export {
     })
     assert.strictEqual(value.outputFiles.length, 1)
     assert.strictEqual(value.outputFiles[0].path, '<stdout>')
+    assert.strictEqual(value.outputFiles[0].isEntryPoint, true)
     assert.strictEqual(Buffer.from(value.outputFiles[0].contents).toString(), `(() => {
   // scripts/.js-api-tests/stdinStdoutBundle/auxiliary.js
   var auxiliary_default = 123;


### PR DESCRIPTION
The motivation for this PR is to support plugins and higher level tooling that operate on HTML.

- The `isEntryPoint` property on `OutputFile` will be `true` if the output corresponds to a user-defined entry point, but will be falsy otherwise (dynamic chunks, additional files, sourcemaps, etc.)
- The `entryPoints` array on `Metafile` contains the array of output files that correspond to user-defined entry points. This is different from the set of `metafile.outputs` where `entryPoint` is set because `entryPoints` will include CSS output files generated from JS entry points that import CSS

**Plugin case**
With the current Build API, it is not currently possible to reliably determine which output files should be referenced by `<script>` or `<link>` tags in an HTML file for all cases. The keys of `metafile.outputs` can be used to determine which output files were generated, but since the `entryPoint` property corresponds 1:1 with an input file, CSS outputs produced from JS imports cannot be determined. It's also not possible to map entry point basenames from the initial build options because the `entryNames` option might not include the name at all.

This is solved by the `entryPoints` array on metafile because it allows plugins to determine which output files correspond to application entry points without re-implementing internal logic or dependency graph traversal. If further details are needed about any of the contained entry points, they can be used as keys in the `metafile.outputs` object.

**Higher level tooling case**
While the `entryPoints` array on metafile would be sufficient for higher level tooling that wraps the Build API, adding `isEntryPoint` to OutputFile allows the same kind of introspection without enabling metafile generation.

With this option, it would be possible to parse an HTML file for entry points, pass them to the build API, and then reliably replace the paths in the HTML output.