### PR TITLE
feat: support module conditions when platform set to browser

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -247,6 +247,7 @@ func NewResolver(fs fs.FS, log logger.Log, caches *cache.CacheSet, options confi
 	switch options.Platform {
 	case config.PlatformBrowser:
 		esmConditionsDefault["browser"] = true
+		esmConditionsDefault["module"] = true;
 	case config.PlatformNode:
 		esmConditionsDefault["node"] = true
 	}


### PR DESCRIPTION
when use esbuild to build [tslib](https://github.com/microsoft/tslib/blob/main/package.json#L31), esbuild seems not follow module field in conditions exports, which makes treeshaking not working