### PR TITLE
refactor(deno): use denoflate instead of compress

### DIFF
--- a/lib/deno/external.d.ts
+++ b/lib/deno/external.d.ts
@@ -1,11 +1,3 @@
-declare module 'https://deno.land/x/compress@v0.3.3/mod.ts' {
-  export interface InflateOptions {
-    windowBits?: number;
-    dictionary?: Uint8Array;
-    chunkSize?: number;
-    to?: string;
-    raw?: boolean;
-  }
-
-  export function gunzip(input: Uint8Array, options?: InflateOptions): Uint8Array
+declare module "https://deno.land/x/denoflate@1.2.1/mod.ts" {
+  export function gunzip(input: Uint8Array): Uint8Array;
 }

--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -1,6 +1,6 @@
 import * as types from "../shared/types"
 import * as common from "../shared/common"
-import * as compress from "https://deno.land/x/compress@v0.3.3/mod.ts"
+import * as denoflate from "https://deno.land/x/denoflate@1.2.1/mod.ts"
 
 declare const ESBUILD_VERSION: string
 
@@ -108,7 +108,7 @@ function getCachePath(name: string): { finalPath: string, finalDir: string } {
 
 function extractFileFromTarGzip(buffer: Uint8Array, file: string): Uint8Array {
   try {
-    buffer = compress.gunzip(buffer)
+    buffer = denoflate.gunzip(buffer)
   } catch (err) {
     throw new Error(`Invalid gzip data in archive: ${err && err.message || err}`)
   }


### PR DESCRIPTION
deno.land/x/denoflate is about 10% smaller, and a lot more polished and
up to date than deno.land/x/compress.

