### PR TITLE
fix: CSS import relative paths

### DIFF
--- a/internal/bundler/bundler_css_test.go
+++ b/internal/bundler/bundler_css_test.go
@@ -472,10 +472,13 @@ func TestPackageURLsInCSS(t *testing.T) {
 	css_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.css": `
+			  @import "test.css";
+
 				a { background: url(a/1.png); }
 				b { background: url(b/2.png); }
 				c { background: url(c/3.png); }
 			`,
+			"/test.css":             `.css { color: red }`,
 			"/a/1.png":              `a-1`,
 			"/node_modules/b/2.png": `b-2-node_modules`,
 			"/c/3.png":              `c-3`,

--- a/internal/bundler/snapshots/snapshots_css.txt
+++ b/internal/bundler/snapshots/snapshots_css.txt
@@ -242,6 +242,11 @@ console.log("b");
 ================================================================================
 TestPackageURLsInCSS
 ---------- /out/entry.css ----------
+/* test.css */
+.css {
+  color: red;
+}
+
 /* entry.css */
 a {
   background: url(data:image/png;base64,YS0x);

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -626,7 +626,7 @@ func (r resolverQuery) resolveWithoutSymlinks(sourceDir string, importPath strin
 	// Check both relative and package paths for CSS URL tokens, with relative
 	// paths taking precedence over package paths to match Webpack behavior.
 	isPackagePath := IsPackagePath(importPath)
-	checkRelative := !isPackagePath || r.kind == ast.ImportURL
+	checkRelative := !isPackagePath || r.kind == ast.ImportURL || r.kind == ast.ImportAt
 	checkPackage := isPackagePath
 
 	if checkRelative {


### PR DESCRIPTION
Fixes #469

CSS `@import` is missing in this commit: https://github.com/evanw/esbuild/commit/588fa611406154a901e97ac9bf9328973874444e