### PR TITLE
inline math.MaxInt constants (go 1.13 compatibility)

### DIFF
--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"io/ioutil"
-	"math"
 	"math/rand"
 	"os"
 	"regexp"
@@ -29,6 +28,11 @@ import (
 	"github.com/evanw/esbuild/internal/js_parser"
 	"github.com/evanw/esbuild/internal/logger"
 	"github.com/evanw/esbuild/internal/resolver"
+)
+
+const (
+	intSize = 32 << (^uint(0) >> 63)
+	maxInt  = 1<<(intSize-1) - 1
 )
 
 func validatePathTemplate(template string) []config.PathTemplate {
@@ -1755,7 +1759,7 @@ func analyzeMetafileImpl(metafile string, opts AnalyzeMetafileOptions) string {
 					for _, importPath := range importsForPath[top].imports {
 						imported, ok := graph[importPath]
 						if !ok {
-							imported.depth = math.MaxInt
+							imported.depth = maxInt
 						}
 
 						if imported.depth > childDepth {


### PR DESCRIPTION
Since esbuild uses some newer Go API's it would be nice to accurately specify the minimum Go version for dependents. I ran into this while trying to upgrade esbuild to 0.12.26 while on Go 1.16, where Go would no longer compile with esbuild due to its [math.MaxInt usage](https://github.com/evanw/esbuild/blob/ab666a1d9697139ff9ad600c36f47592de016734/pkg/api/api_impl.go#L1758). I wish I could offer something more than this trivial change, but perhaps it will be helpful to others.

I'm far from a Go expert so if there are things to be careful with when updating this please let me know (i.e. I read through https://golang.org/doc/modules/gomod-ref and, weirdly, it sounds like Go _should_ have caught this...).

Thanks!