### PR TITLE
Fix a bug in __require

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -117,7 +117,8 @@ func code(isES6 bool) string {
 		export var __name = (target, value) => __defProp(target, 'name', { value, configurable: true })
 
 		// This fallback "require" function exists so that "typeof require" can naturally be "function"
-		export var __require = typeof require !== 'undefined' ? require : x => {
+		export var __require = x => {
+			if (typeof require !== 'undefined') return require(x)
 			throw new Error('Dynamic require of "' + x + '" is not supported')
 		}
 


### PR DESCRIPTION
This reverts commit 1dea2db919c016bf0b11dcc6aa94a108a604591b,
which introduced an optimization based on the invalid assumption that the `require` function will always be either already defined when `__require` is defined, or never.

Fixes https://github.com/sveltejs/kit/issues/2400