### PR TITLE
separate "ignore annotations" from "tree shaking"

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -72,6 +72,8 @@ var helpText = func(colors logger.Colors) string {
   --footer:T=...            Text to be appended to each output file of type T
                             where T is one of: css | js
   --global-name=...         The name of the global for the IIFE format
+  --ignore-annotations      Enable this to work with packages that have
+                            incorrect tree-shaking annotations
   --inject:F                Import the file F into all input files and
                             automatically replace matching globals with imports
   --jsx-factory=...         What to use for JSX instead of React.createElement
@@ -105,8 +107,7 @@ var helpText = func(colors logger.Colors) string {
   --sourcemap=external      Do not link to the source map with a comment
   --sourcemap=inline        Emit the source map with an inline data URL
   --sources-content=false   Omit "sourcesContent" in generated source maps
-  --tree-shaking=...        Set to "ignore-annotations" to work with packages
-                            that have incorrect tree-shaking annotations
+  --tree-shaking=...        Force tree shaking on or off (false | true)
   --tsconfig=...            Use this tsconfig.json file instead of other ones
   --version                 Print the current version (` + esbuildVersion + `) and exit
 

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -2310,7 +2310,7 @@ func (cache *runtimeCache) parseRuntime(options *config.Options) (source logger.
 
 		// Always do tree shaking for the runtime because we never want to
 		// include unnecessary runtime code
-		Mode: config.ModeBundle,
+		TreeShaking: true,
 	}))
 	if log.HasErrors() {
 		msgs := "Internal error: failed to parse runtime:\n"

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -3786,6 +3786,7 @@ func TestInjectNoBundle(t *testing.T) {
 		entryPaths: []string{"/entry.js"},
 		options: config.Options{
 			Mode:          config.ModePassThrough,
+			TreeShaking:   true,
 			AbsOutputFile: "/out.js",
 			Defines:       &defines,
 			InjectAbsPaths: []string{

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -77,6 +77,10 @@ func (s *suite) expectBundled(t *testing.T, args bundled) {
 		if args.options.AbsOutputFile != "" {
 			args.options.AbsOutputDir = path.Dir(args.options.AbsOutputFile)
 		}
+		if args.options.Mode == config.ModeBundle || (args.options.Mode == config.ModeConvertFormat && args.options.OutputFormat == config.FormatIIFE) {
+			// Apply this default to all tests since it was not configurable when the tests were written
+			args.options.TreeShaking = true
+		}
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug)
 		caches := cache.MakeCacheSet()
 		resolver := resolver.NewResolver(fs, log, caches, args.options)

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -2571,8 +2571,6 @@ func (c *linkerContext) markFileLiveForTreeShaking(sourceIndex uint32) {
 
 	switch repr := file.InputFile.Repr.(type) {
 	case *graph.JSRepr:
-		isTreeShakingEnabled := config.IsTreeShakingEnabled(c.options.Mode, c.options.OutputFormat)
-
 		// If the JavaScript stub for a CSS file is included, also include the CSS file
 		if repr.CSSSourceIndex.IsValid() {
 			c.markFileLiveForTreeShaking(repr.CSSSourceIndex.GetIndex())
@@ -2609,7 +2607,7 @@ func (c *linkerContext) markFileLiveForTreeShaking(sourceIndex uint32) {
 			// Include all parts in this file with side effects, or just include
 			// everything if tree-shaking is disabled. Note that we still want to
 			// perform tree-shaking on the runtime even if tree-shaking is disabled.
-			if !canBeRemovedIfUnused || (!part.ForceTreeShaking && !isTreeShakingEnabled && file.IsEntryPoint()) {
+			if !canBeRemovedIfUnused || (!part.ForceTreeShaking && !c.options.TreeShaking && file.IsEntryPoint()) {
 				c.markPartLiveForTreeShaking(sourceIndex, uint32(partIndex))
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,7 @@ type Options struct {
 	ASCIIOnly               bool
 	KeepNames               bool
 	IgnoreDCEAnnotations    bool
+	TreeShaking             bool
 
 	Defines  *ProcessedDefines
 	TS       TSOptions
@@ -382,10 +383,6 @@ func SubstituteTemplate(template []PathTemplate, placeholders PathPlaceholders) 
 		}
 	}
 	return result
-}
-
-func IsTreeShakingEnabled(mode Mode, outputFormat Format) bool {
-	return mode == ModeBundle || (mode == ModeConvertFormat && outputFormat == FormatIIFE)
 }
 
 func ShouldCallRuntimeRequire(mode Mode, outputFormat Format) bool {

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -336,6 +336,7 @@ type optionsThatSupportStructuralEquality struct {
 	minifyIdentifiers       bool
 	omitRuntimeForTests     bool
 	ignoreDCEAnnotations    bool
+	treeShaking             bool
 	preserveUnusedImportsTS bool
 	useDefineForClassFields config.MaybeBool
 }
@@ -361,6 +362,7 @@ func OptionsFromConfig(options *config.Options) Options {
 			minifyIdentifiers:       options.MinifyIdentifiers,
 			omitRuntimeForTests:     options.OmitRuntimeForTests,
 			ignoreDCEAnnotations:    options.IgnoreDCEAnnotations,
+			treeShaking:             options.TreeShaking,
 			preserveUnusedImportsTS: options.PreserveUnusedImportsTS,
 			useDefineForClassFields: options.UseDefineForClassFields,
 		},
@@ -13904,11 +13906,11 @@ func Parse(log logger.Log, source logger.Source, options Options) (result js_ast
 	// single pass, but it turns out it's pretty much impossible to do this
 	// correctly while handling arrow functions because of the grammar
 	// ambiguities.
-	if !config.IsTreeShakingEnabled(p.options.mode, p.options.outputFormat) {
-		// When not bundling, everything comes in a single part
+	if !p.options.treeShaking {
+		// When tree shaking is disabled, everything comes in a single part
 		parts = p.appendPart(parts, stmts)
 	} else {
-		// When bundling, each top-level statement is potentially a separate part
+		// When tree shaking is enabled, each top-level statement is potentially a separate part
 		for _, stmt := range stmts {
 			switch s := stmt.Data.(type) {
 			case *js_ast.SLocal:

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -108,7 +108,8 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   let minifyWhitespace = getFlag(options, keys, 'minifyWhitespace', mustBeBoolean);
   let minifyIdentifiers = getFlag(options, keys, 'minifyIdentifiers', mustBeBoolean);
   let charset = getFlag(options, keys, 'charset', mustBeString);
-  let treeShaking = getFlag(options, keys, 'treeShaking', mustBeStringOrBoolean);
+  let treeShaking = getFlag(options, keys, 'treeShaking', mustBeBoolean);
+  let ignoreAnnotations = getFlag(options, keys, 'ignoreAnnotations', mustBeBoolean);
   let jsx = getFlag(options, keys, 'jsx', mustBeString);
   let jsxFactory = getFlag(options, keys, 'jsxFactory', mustBeString);
   let jsxFragment = getFlag(options, keys, 'jsxFragment', mustBeString);
@@ -131,7 +132,8 @@ function pushCommonFlags(flags: string[], options: CommonOptions, keys: OptionKe
   if (minifyWhitespace) flags.push('--minify-whitespace');
   if (minifyIdentifiers) flags.push('--minify-identifiers');
   if (charset) flags.push(`--charset=${charset}`);
-  if (treeShaking !== void 0 && treeShaking !== true) flags.push(`--tree-shaking=${treeShaking}`);
+  if (treeShaking !== void 0) flags.push(`--tree-shaking=${treeShaking}`);
+  if (ignoreAnnotations) flags.push(`--ignore-annotations`);
 
   if (jsx) flags.push(`--jsx=${jsx}`);
   if (jsxFactory) flags.push(`--jsx-factory=${jsxFactory}`);

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -3,7 +3,6 @@ export type Format = 'iife' | 'cjs' | 'esm';
 export type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'css' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'binary' | 'default';
 export type LogLevel = 'verbose' | 'debug' | 'info' | 'warning' | 'error' | 'silent';
 export type Charset = 'ascii' | 'utf8';
-export type TreeShaking = true | 'ignore-annotations';
 
 interface CommonOptions {
   sourcemap?: boolean | 'inline' | 'external' | 'both';
@@ -20,7 +19,8 @@ interface CommonOptions {
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
   charset?: Charset;
-  treeShaking?: TreeShaking;
+  treeShaking?: boolean;
+  ignoreAnnotations?: boolean;
 
   jsx?: 'transform' | 'preserve';
   jsxFactory?: string;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -235,7 +235,8 @@ type TreeShaking uint8
 
 const (
 	TreeShakingDefault TreeShaking = iota
-	TreeShakingIgnoreAnnotations
+	TreeShakingFalse
+	TreeShakingTrue
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -258,6 +259,7 @@ type BuildOptions struct {
 	MinifySyntax      bool
 	Charset           Charset
 	TreeShaking       TreeShaking
+	IgnoreAnnotations bool
 	LegalComments     LegalComments
 
 	JSXMode     JSXMode
@@ -366,6 +368,7 @@ type TransformOptions struct {
 	MinifySyntax      bool
 	Charset           Charset
 	TreeShaking       TreeShaking
+	IgnoreAnnotations bool
 	LegalComments     LegalComments
 
 	JSXMode     JSXMode

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -144,10 +144,19 @@ func parseOptionsImpl(
 			}
 			name := arg[len("--tree-shaking="):]
 			switch name {
-			case "ignore-annotations":
-				*value = api.TreeShakingIgnoreAnnotations
+			case "false":
+				*value = api.TreeShakingFalse
+			case "true":
+				*value = api.TreeShakingTrue
 			default:
-				return fmt.Errorf("Invalid tree shaking value: %q (valid: ignore-annotations)", name), nil
+				return fmt.Errorf("Invalid tree shaking value: %q (valid: false, true)", name), nil
+			}
+
+		case arg == "--ignore-annotations":
+			if buildOpts != nil {
+				buildOpts.IgnoreAnnotations = true
+			} else {
+				transformOpts.IgnoreAnnotations = true
 			}
 
 		case arg == "--keep-names":


### PR DESCRIPTION
This PR introduces a breaking change that gives you more control over when tree shaking happens ("tree shaking" here refers to declaration-level dead code removal). Previously esbuild's tree shaking was automatically enabled or disabled for you depending on the situation and there was no manual override to change this. Specifically, tree shaking was only enabled either when bundling was enabled or when the output format was set to `iife` (i.e. wrapped in an immediately-invoked function expression). This was done to avoid issues with people appending code to output files in the `cjs` and `esm` formats and expecting that code to be able to reference code in the output file that isn't otherwise referenced.

You now have the ability to explicitly force-enable or force-disable tree shaking to bypass this default behavior. This is a breaking change because there is already a setting for tree shaking that does something else, and it has been moved to a separate setting instead. The previous setting allowed you to control whether or not to ignore manual side-effect annotations, which is related to tree shaking since only side-effect free code can be removed as dead code. Specifically you can annotate function calls with `/* @__PURE__ */` to indicate that they can be removed if they are not used, and you can annotate packages with `"sideEffects": false` to indicate that imports of that package can be removed if they are not used. Being able to ignore these annotations is necessary because [they are sometimes incorrect](https://github.com/tensorflow/tfjs/issues/4248). This previous setting has been moved to a separate setting because it actually impacts dead-code removal within expressions, which also applies when minifying with tree-shaking disabled.

### Old behavior

* CLI
    * Ignore side-effect annotations: `--tree-shaking=ignore-annotations`
* JS
    * Ignore side-effect annotations: `treeShaking: 'ignore-annotations'`
* Go
    * Ignore side-effect annotations: `TreeShaking: api.TreeShakingIgnoreAnnotations`

### New behavior

* CLI
    * Ignore side-effect annotations: `--ignore-annotations`
    * Force-disable tree shaking: `--tree-shaking=false`
    * Force-enable tree shaking: `--tree-shaking=true`
* JS
    * Ignore side-effect annotations: `ignoreAnnotations: true`
    * Force-disable tree shaking: `treeShaking: false`
    * Force-enable tree shaking: `treeShaking: true`
* Go
    * Ignore side-effect annotations: `IgnoreAnnotations: true`
    * Force-disable tree shaking: `TreeShaking: api.TreeShakingFalse`
    * Force-enable tree shaking: `TreeShaking: api.TreeShakingTrue`

Fixes #1610
Closes #1617
