### PR TITLE
fix cache condition in iswin_wasm

### DIFF
--- a/internal/fs/iswin_wasm.go
+++ b/internal/fs/iswin_wasm.go
@@ -12,7 +12,7 @@ var cachedIfWindows bool
 
 func CheckIfWindows() bool {
 	if !checkedIfWindows {
-		cachedIfWindows = false
+		checkedIfWindows = true
 
 		// Hack: Assume that we're on Windows if we're running WebAssembly and
 		// the "C:\\" directory exists. This is a workaround for a bug in Go's


### PR DESCRIPTION
unless I am mistaken, the boolean dance here does not match the intentions : in its current version, `checkedIfWindows` is never set to true to each individual call to `CheckIfWindows()` will trigger a call to `os.Stat()`