### PR TITLE
feat: drop catch binding when optional catch binding is supported

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -7564,6 +7564,16 @@ func (p *parser) mangleStmts(stmts []js_ast.Stmt, kind stmtsKind) []js_ast.Stmt 
 					}
 				}
 			}
+
+		case *js_ast.STry:
+			// Drop unused binding if optional catch binding is supported
+			if !p.options.unsupportedJSFeatures.Has(compat.OptionalCatchBinding) {
+				if s.Catch != nil && s.Catch.BindingOrNil.Data != nil {
+					if id, ok := s.Catch.BindingOrNil.Data.(*js_ast.BIdentifier); ok && p.symbolUses[id.Ref].CountEstimate == 0 {
+						s.Catch.BindingOrNil.Data = nil
+					}
+				}
+			}
 		}
 
 		result = append(result, stmt)

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -4804,3 +4804,10 @@ func TestASCIIOnly(t *testing.T) {
 	expectPrintedTargetASCII(t, 5, "export var π", "export var \\u03C0;\n")
 	expectParseErrorTargetASCII(t, 5, "export var 𐀀", es5)
 }
+
+func TestDropUnusedCatchBinding(t *testing.T) {
+	expectPrintedMangle(t, "try { throw 0 } catch (e) { console.log(0) }", "try {\n  throw 0;\n} catch {\n  console.log(0);\n}\n")
+	expectPrintedMangle(t, "try { throw 0 } catch (e) { console.log(0, e) }", "try {\n  throw 0;\n} catch (e) {\n  console.log(0, e);\n}\n")
+	expectPrintedMangle(t, "try { thrower() } catch ({ a }) { console.log(0) }", "try {\n  thrower();\n} catch ({ a }) {\n  console.log(0);\n}\n")
+	expectPrintedMangleTarget(t, 2018, "try { throw 0 } catch (e) { console.log(0) }", "try {\n  throw 0;\n} catch (e) {\n  console.log(0);\n}\n")
+}


### PR DESCRIPTION
This PR will slightly improve minimized result when optional catch binding is supported.

```js
try {
  throw 0
} catch (e) {}

// ----- into -----

try {
  throw 0
} catch {}
```
 
As far as I am aware, the pattern below has a side effect and cannot be dropped, but the code above will not have any. 
```js
try {
  throw {
    get a() {
      console.log(0)
      return 0;
    }
  }
} catch ({ a }) {} // prints 0
```
