### PR TITLE
Don't emit "duplicate label" error across function scopes.

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -8796,6 +8796,10 @@ func (p *parser) visitAndAppendStmt(stmts []js_ast.Stmt, stmt js_ast.Stmt) []js_
 						fmt.Sprintf("The original label %q is here", name))})
 				break
 			}
+			if scope.Kind == js_ast.ScopeFunctionBody {
+				// Labels are only visible within the function they are defined in.
+				break
+			}
 		}
 
 		p.currentScope.Label = js_ast.LocRef{Loc: s.Name.Loc, Ref: ref}

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -1903,6 +1903,7 @@ func TestLabels(t *testing.T) {
 	expectPrinted(t, "x: y: z: 1", "x:\n  y:\n    z:\n      1;\n")
 	expectPrinted(t, "x: 1; y: 2; x: 3", "x:\n  1;\ny:\n  2;\nx:\n  3;\n")
 	expectParseError(t, "x: y: x: 1", "<stdin>: error: Duplicate label \"x\"\n<stdin>: note: The original label \"x\" is here\n")
+	expectPrinted(t, "x: (function(){ x: 1; })()", "x:\n  (function() {\n    x:\n      1;\n  })();\n")
 }
 
 func TestArrow(t *testing.T) {


### PR DESCRIPTION
The code below is legal in JavaScript because labelled continue/break
operators don't work across function boundaries:

```js
l:
while(true) {
  (function() {
    l:
    while (true) {
      break l;
    }
  })();
  break l;
}
```

Prior to this commit, esbuild would emit a "duplicate label" error for
the inner label `l`. After this change search for possible duplicate
will stop either when reaching the outermost scope (old behavior) or
after reaching nearest function body scope (new behavior).