### PR TITLE
Improve watch mode accuracy

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -697,7 +697,9 @@ func runOnResolvePlugins(
 				fsCache.ReadFile(fs, file)
 			}
 			for _, dir := range result.AbsWatchDirs {
-				fs.ReadDirectory(dir)
+				if entries, err, _ := fs.ReadDirectory(dir); err == nil {
+					entries.SortedKeys()
+				}
 			}
 
 			// Stop now if there was an error
@@ -812,7 +814,9 @@ func runOnLoadPlugins(
 				fsCache.ReadFile(fs, file)
 			}
 			for _, dir := range result.AbsWatchDirs {
-				fs.ReadDirectory(dir)
+				if entries, err, _ := fs.ReadDirectory(dir); err == nil {
+					entries.SortedKeys()
+				}
 			}
 
 			// Stop now if there was an error

--- a/internal/fs/fs_mock.go
+++ b/internal/fs/fs_mock.go
@@ -29,7 +29,7 @@ func MockFS(input map[string]string) FS {
 			kDir := path.Dir(k)
 			dir, ok := dirs[kDir]
 			if !ok {
-				dir = DirEntries{kDir, make(map[string]*Entry)}
+				dir = DirEntries{kDir, make(map[string]*Entry), nil}
 				dirs[kDir] = dir
 			}
 			if kDir == k {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -796,7 +796,7 @@ func (r resolverQuery) dirInfoCached(path string) *dirInfo {
 		if cached == nil {
 			r.debugLogs.addNote(fmt.Sprintf("Failed to read directory %q", path))
 		} else {
-			count := cached.entries.Len()
+			count := len(cached.entries.SortedKeys())
 			entries := "entries"
 			if count == 1 {
 				entries = "entry"

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1212,11 +1212,11 @@ func (w *watcher) tryToFindDirtyPath() string {
 
 	// Always check all recent items every iteration
 	for i, path := range w.recentItems {
-		if w.data.Paths[path]() {
+		if dirtyPath := w.data.Paths[path](); dirtyPath != "" {
 			// Move this path to the back of the list (i.e. the "most recent" position)
 			copy(w.recentItems[i:], w.recentItems[i+1:])
 			w.recentItems[len(w.recentItems)-1] = path
-			return path
+			return dirtyPath
 		}
 	}
 
@@ -1230,7 +1230,7 @@ func (w *watcher) tryToFindDirtyPath() string {
 
 	// Check if any of the entries in this iteration have been modified
 	for _, path := range toCheck {
-		if w.data.Paths[path]() {
+		if dirtyPath := w.data.Paths[path](); dirtyPath != "" {
 			// Mark this item as recent by adding it to the back of the list
 			w.recentItems = append(w.recentItems, path)
 			if len(w.recentItems) > maxRecentItemCount {
@@ -1238,7 +1238,7 @@ func (w *watcher) tryToFindDirtyPath() string {
 				copy(w.recentItems, w.recentItems[1:])
 				w.recentItems = w.recentItems[:maxRecentItemCount]
 			}
-			return path
+			return dirtyPath
 		}
 	}
 	return ""

--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -193,7 +193,7 @@ func (h *apiHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		if h.servedir != "" && kind != fs.FileEntry {
 			if entries, err, _ := h.fs.ReadDirectory(h.fs.Join(h.servedir, queryPath)); err == nil {
 				kind = fs.DirEntry
-				for _, name := range entries.UnorderedKeys() {
+				for _, name := range entries.SortedKeys() {
 					entry, _ := entries.Get(name)
 					switch entry.Kind(h.fs) {
 					case fs.DirEntry:


### PR DESCRIPTION
Watch mode is enabled by `--watch` and causes esbuild to become a long-running process that automatically rebuilds output files when input files are changed. It's implemented by recording all calls to esbuild's internal file system interface and then invalidating the build whenever these calls would return different values. For example, a call to esbuild's internal `ReadFile()` function is considered to be different if either the presence of the file has changed (e.g. the file didn't exist before but now exists) or the presence of the file stayed the same but the content of the file has changed.

Previously esbuild's watch mode operated at the `ReadFile()` and `ReadDirectory()` level. When esbuild checked whether a directory entry existed or not (e.g. whether a directory contains a `node_modules` subdirectory or a `package.json` file), it called `ReadDirectory()` which then caused the build to depend on that directory's set of entries. This meant the build would be invalidated even if a new unrelated entry was added or removed, since that still changes the set of entries. This is problematic when using esbuild in environments that constantly create and destroy temporary directory entries in your project directory. In that case, esbuild's watch mode would constantly rebuild as the directory was constantly considered to be dirty.

With this PR, watch mode now operates at the `ReadFile()` and `ReadDirectory().Get()` level. So when esbuild checks whether a directory entry exists or not, the build should now only depend on the presence status for that one directory entry. This should avoid unnecessary rebuilds due to unrelated directory entries being added or removed. The log messages generated using `--watch` will now also mention the specific directory entry whose presence status was changed if a build is invalidated for this reason.

Note that this optimization does not apply to plugins using the `watchDirs` return value because those paths are only specified at the directory level and do not describe individual directory entries. You can use `watchFiles` or `watchDirs` on the individual entries inside the directory to get a similar effect instead.

Fixes #1113
