### PR TITLE
implement "calc()" reduction for css

### DIFF
--- a/internal/css_lexer/css_lexer.go
+++ b/internal/css_lexer/css_lexer.go
@@ -39,6 +39,7 @@ const (
 	TDelimEquals
 	TDelimExclamation
 	TDelimGreaterThan
+	TDelimMinus
 	TDelimPlus
 	TDelimSlash
 	TDelimTilde
@@ -79,6 +80,7 @@ var tokenToString = []string{
 	"\"=\"",
 	"\"!\"",
 	"\">\"",
+	"\"-\"",
 	"\"+\"",
 	"\"/\"",
 	"\"~\"",
@@ -363,7 +365,7 @@ func (lexer *lexer) next() {
 				lexer.Token.Kind = lexer.consumeIdentLike()
 			} else {
 				lexer.step()
-				lexer.Token.Kind = TDelim
+				lexer.Token.Kind = TDelimMinus
 			}
 
 		case '<':

--- a/internal/css_parser/css_decls_color.go
+++ b/internal/css_parser/css_decls_color.go
@@ -230,7 +230,7 @@ func hexG(v uint32) int { return int((v >> 16) & 255) }
 func hexB(v uint32) int { return int((v >> 8) & 255) }
 func hexA(v uint32) int { return int(v & 255) }
 
-func floatToString(a float64) string {
+func floatToStringForColor(a float64) string {
 	text := fmt.Sprintf("%.03f", a)
 	for text[len(text)-1] == '0' {
 		text = text[:len(text)-1]
@@ -269,7 +269,7 @@ func lowerAlphaPercentageToNumber(token css_ast.Token) css_ast.Token {
 	if token.Kind == css_lexer.TPercentage {
 		if value, err := strconv.ParseFloat(token.Text[:len(token.Text)-1], 64); err == nil {
 			token.Kind = css_lexer.TNumber
-			token.Text = floatToString(value / 100.0)
+			token.Text = floatToStringForColor(value / 100.0)
 		}
 	}
 	return token
@@ -294,7 +294,7 @@ func (p *parser) lowerColor(token css_ast.Token) css_ast.Token {
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexR(hex))}, commaToken,
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexG(hex))}, commaToken,
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexB(hex))}, commaToken,
-						{Kind: css_lexer.TNumber, Text: floatToString(float64(hexA(hex)) / 255)},
+						{Kind: css_lexer.TNumber, Text: floatToStringForColor(float64(hexA(hex)) / 255)},
 					}
 				}
 
@@ -308,7 +308,7 @@ func (p *parser) lowerColor(token css_ast.Token) css_ast.Token {
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexR(hex))}, commaToken,
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexG(hex))}, commaToken,
 						{Kind: css_lexer.TNumber, Text: strconv.Itoa(hexB(hex))}, commaToken,
-						{Kind: css_lexer.TNumber, Text: floatToString(float64(hexA(hex)) / 255)},
+						{Kind: css_lexer.TNumber, Text: floatToStringForColor(float64(hexA(hex)) / 255)},
 					}
 				}
 			}
@@ -332,7 +332,7 @@ func (p *parser) lowerColor(token css_ast.Token) css_ast.Token {
 				if (text == "hsl" || text == "hsla") && len(args) > 0 {
 					if degrees, ok := degreesForAngle(args[0]); ok {
 						args[0].Kind = css_lexer.TNumber
-						args[0].Text = floatToString(degrees)
+						args[0].Text = floatToStringForColor(degrees)
 					}
 				}
 

--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -761,6 +761,11 @@ loop:
 			nested, tokens = p.convertTokensHelper(tokens, css_lexer.TCloseParen, nestedOpts)
 			token.Children = &nested
 
+			// Apply "calc" simplification rules when minifying
+			if p.options.MangleSyntax && token.Text == "calc" {
+				token = tryToReduceCalcExpression(token)
+			}
+
 			// Treat a URL function call with a string just like a URL token
 			if token.Text == "url" && len(nested) == 1 && nested[0].Kind == css_lexer.TString {
 				token.Kind = css_lexer.TURL

--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -681,8 +681,9 @@ func (p *parser) convertTokens(tokens []css_lexer.Token) []css_ast.Token {
 }
 
 type convertTokensOpts struct {
-	allowImports       bool
-	verbatimWhitespace bool
+	allowImports         bool
+	verbatimWhitespace   bool
+	isInsideCalcFunction bool
 }
 
 func (p *parser) convertTokensHelper(tokens []css_lexer.Token, close css_lexer.T, opts convertTokensOpts) ([]css_ast.Token, []css_lexer.Token) {
@@ -703,6 +704,14 @@ loop:
 		}
 		nextWhitespace = 0
 
+		// Warn about invalid "+" and "-" operators that break the containing "calc()"
+		if opts.isInsideCalcFunction && t.Kind.IsNumeric() && len(result) > 0 && result[len(result)-1].Kind.IsNumeric() &&
+			(strings.HasPrefix(token.Text, "+") || strings.HasPrefix(token.Text, "-")) {
+			// "calc(1+2)" and "calc(1-2)" are invalid
+			p.log.AddRangeWarning(&p.tracker, logger.Range{Loc: t.Range.Loc, Len: 1},
+				fmt.Sprintf("The %q operator only works if there is whitespace on both sides", token.Text[:1]))
+		}
+
 		switch t.Kind {
 		case css_lexer.TWhitespace:
 			if last := len(result) - 1; last >= 0 {
@@ -710,6 +719,20 @@ loop:
 			}
 			nextWhitespace = css_ast.WhitespaceBefore
 			continue
+
+		case css_lexer.TDelimPlus, css_lexer.TDelimMinus:
+			// Warn about invalid "+" and "-" operators that break the containing "calc()"
+			if opts.isInsideCalcFunction && len(tokens) > 0 {
+				if len(result) == 0 || result[len(result)-1].Kind == css_lexer.TComma {
+					// "calc(-(1 + 2))" is invalid
+					p.log.AddRangeWarning(&p.tracker, t.Range,
+						fmt.Sprintf("%q can only be used as an infix operator, not a prefix operator", token.Text))
+				} else if token.Whitespace != css_ast.WhitespaceBefore || tokens[0].Kind != css_lexer.TWhitespace {
+					// "calc(1- 2)" and "calc(1 -(2))" are invalid
+					p.log.AddRangeWarning(&p.tracker, t.Range,
+						fmt.Sprintf("The %q operator only works if there is whitespace on both sides", token.Text))
+				}
+			}
 
 		case css_lexer.TNumber:
 			if p.options.MangleSyntax {
@@ -758,12 +781,15 @@ loop:
 				// CSS variables require verbatim whitespace for correctness
 				nestedOpts.verbatimWhitespace = true
 			}
+			if token.Text == "calc" {
+				nestedOpts.isInsideCalcFunction = true
+			}
 			nested, tokens = p.convertTokensHelper(tokens, css_lexer.TCloseParen, nestedOpts)
 			token.Children = &nested
 
 			// Apply "calc" simplification rules when minifying
 			if p.options.MangleSyntax && token.Text == "calc" {
-				token = tryToReduceCalcExpression(token)
+				token = p.tryToReduceCalcExpression(token)
 			}
 
 			// Treat a URL function call with a string just like a URL token

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1178,6 +1178,59 @@ func TestMangleTime(t *testing.T) {
 	expectPrintedMangle(t, "a { animation: b 1E3ms }", "a {\n  animation: b 1E3ms;\n}\n")
 }
 
+func TestMangleCalc(t *testing.T) {
+	expectPrintedMangle(t, "a { b: calc(1) }", "a {\n  b: 1;\n}\n")
+	expectPrintedMangle(t, "a { b: calc((1)) }", "a {\n  b: 1;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(calc(1)) }", "a {\n  b: 1;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x + y * z) }", "a {\n  b: calc(x + y * z);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x * y + z) }", "a {\n  b: calc(x * y + z);\n}\n")
+
+	// Test sum
+	expectPrintedMangle(t, "a { b: calc(2 + 3) }", "a {\n  b: 5;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(6 - 2) }", "a {\n  b: 4;\n}\n")
+
+	// Test product
+	expectPrintedMangle(t, "a { b: calc(2 * 3) }", "a {\n  b: 6;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(6 / 2) }", "a {\n  b: 3;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(2px * 3 + 4px * 5) }", "a {\n  b: 26px;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(2 * 3px + 4 * 5px) }", "a {\n  b: 26px;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(2px * 3 - 4px * 5) }", "a {\n  b: -14px;\n}\n")
+	expectPrintedMangle(t, "a { b: calc(2 * 3px - 4 * 5px) }", "a {\n  b: -14px;\n}\n")
+
+	// Test negation
+	expectPrintedMangle(t, "a { b: calc(x + 1) }", "a {\n  b: calc(x + 1);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x - 1) }", "a {\n  b: calc(x - 1);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x + -1) }", "a {\n  b: calc(x - 1);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x - -1) }", "a {\n  b: calc(x + 1);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(1 + x) }", "a {\n  b: calc(1 + x);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(1 - x) }", "a {\n  b: calc(1 - x);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(-1 + x) }", "a {\n  b: calc(-1 + x);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(-1 - x) }", "a {\n  b: calc(-1 - x);\n}\n")
+
+	// Test inversion
+	expectPrintedMangle(t, "a { b: calc(x * 4) }", "a {\n  b: calc(x * 4);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x / 4) }", "a {\n  b: calc(x / 4);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x * 0.25) }", "a {\n  b: calc(x / 4);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(x / 0.25) }", "a {\n  b: calc(x * 4);\n}\n")
+
+	// Test operator precedence
+	expectPrintedMangle(t, "a { b: calc((a + b) + c) }", "a {\n  b: calc(a + b + c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(a + (b + c)) }", "a {\n  b: calc(a + b + c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc((a - b) - c) }", "a {\n  b: calc(a - b - c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(a - (b - c)) }", "a {\n  b: calc(a - (b - c));\n}\n")
+	expectPrintedMangle(t, "a { b: calc((a * b) * c) }", "a {\n  b: calc(a * b * c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(a * (b * c)) }", "a {\n  b: calc(a * b * c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc((a / b) / c) }", "a {\n  b: calc(a / b / c);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(a / (b / c)) }", "a {\n  b: calc(a / (b / c));\n}\n")
+	expectPrintedMangle(t, "a { b: calc(a + b * c / d - e) }", "a {\n  b: calc(a + b * c / d - e);\n}\n")
+	expectPrintedMangle(t, "a { b: calc((a + ((b * c) / d)) - e) }", "a {\n  b: calc(a + b * c / d - e);\n}\n")
+	expectPrintedMangle(t, "a { b: calc((a + b) * c / (d - e)) }", "a {\n  b: calc((a + b) * c / (d - e));\n}\n")
+
+	// Using "var()" should bail because it can expand to any number of tokens
+	expectPrintedMangle(t, "a { b: calc(1px - x + 2px) }", "a {\n  b: calc(3px - x);\n}\n")
+	expectPrintedMangle(t, "a { b: calc(1px - var(x) + 2px) }", "a {\n  b: calc(1px - var(x) + 2px);\n}\n")
+}
+
 func TestTransform(t *testing.T) {
 	expectPrintedMangle(t, "a { transform: matrix(1, 0, 0, 1, 0, 0) }", "a {\n  transform: scale(1);\n}\n")
 	expectPrintedMangle(t, "a { transform: matrix(2, 0, 0, 1, 0, 0) }", "a {\n  transform: scaleX(2);\n}\n")

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1178,6 +1178,40 @@ func TestMangleTime(t *testing.T) {
 	expectPrintedMangle(t, "a { animation: b 1E3ms }", "a {\n  animation: b 1E3ms;\n}\n")
 }
 
+func TestCalc(t *testing.T) {
+	expectParseError(t, "a { b: calc(+(2)) }", "<stdin>: warning: \"+\" can only be used as an infix operator, not a prefix operator\n")
+	expectParseError(t, "a { b: calc(-(2)) }", "<stdin>: warning: \"-\" can only be used as an infix operator, not a prefix operator\n")
+	expectParseError(t, "a { b: calc(*(2)) }", "")
+	expectParseError(t, "a { b: calc(/(2)) }", "")
+
+	expectParseError(t, "a { b: calc(1 + 2) }", "")
+	expectParseError(t, "a { b: calc(1 - 2) }", "")
+	expectParseError(t, "a { b: calc(1 * 2) }", "")
+	expectParseError(t, "a { b: calc(1 / 2) }", "")
+
+	expectParseError(t, "a { b: calc(1+ 2) }", "<stdin>: warning: The \"+\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1- 2) }", "<stdin>: warning: The \"-\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1* 2) }", "")
+	expectParseError(t, "a { b: calc(1/ 2) }", "")
+
+	expectParseError(t, "a { b: calc(1 +2) }", "<stdin>: warning: The \"+\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1 -2) }", "<stdin>: warning: The \"-\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1 *2) }", "")
+	expectParseError(t, "a { b: calc(1 /2) }", "")
+
+	expectParseError(t, "a { b: calc(1 +(2)) }", "<stdin>: warning: The \"+\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1 -(2)) }", "<stdin>: warning: The \"-\" operator only works if there is whitespace on both sides\n")
+	expectParseError(t, "a { b: calc(1 *(2)) }", "")
+	expectParseError(t, "a { b: calc(1 /(2)) }", "")
+}
+
+func TestMinifyCalc(t *testing.T) {
+	expectPrintedMangleMinify(t, "a { b: calc(x + y) }", "a{b:calc(x + y)}")
+	expectPrintedMangleMinify(t, "a { b: calc(x - y) }", "a{b:calc(x - y)}")
+	expectPrintedMangleMinify(t, "a { b: calc(x * y) }", "a{b:calc(x*y)}")
+	expectPrintedMangleMinify(t, "a { b: calc(x / y) }", "a{b:calc(x/y)}")
+}
+
 func TestMangleCalc(t *testing.T) {
 	expectPrintedMangle(t, "a { b: calc(1) }", "a {\n  b: 1;\n}\n")
 	expectPrintedMangle(t, "a { b: calc((1)) }", "a {\n  b: 1;\n}\n")

--- a/internal/css_parser/css_reduce_calc.go
+++ b/internal/css_parser/css_reduce_calc.go
@@ -1,0 +1,501 @@
+package css_parser
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/evanw/esbuild/internal/css_ast"
+	"github.com/evanw/esbuild/internal/css_lexer"
+)
+
+func tryToReduceCalcExpression(token css_ast.Token) css_ast.Token {
+	if term := tryToParseCalcTerm(*token.Children); term != nil {
+		term = term.partiallySimplify()
+		result := term.convertToToken()
+		if result.Kind == css_lexer.TOpenParen {
+			result.Kind = css_lexer.TFunction
+			result.Text = "calc"
+		}
+		return result
+	}
+	return token
+}
+
+// See: https://www.w3.org/TR/css-values-4/#calc-internal
+type calcTerm interface {
+	convertToToken() css_ast.Token
+	partiallySimplify() calcTerm
+}
+
+type calcSum struct {
+	terms []calcTerm
+}
+
+type calcProduct struct {
+	terms []calcTerm
+}
+
+type calcNegate struct {
+	term calcTerm
+}
+
+type calcInvert struct {
+	term calcTerm
+}
+
+type calcNumeric struct {
+	number float64
+	unit   string
+}
+
+type calcValue struct {
+	token css_ast.Token
+}
+
+func floatToStringForCalc(a float64) string {
+	if math.IsNaN(a) {
+		return "NaN"
+	}
+	if math.IsInf(a, 1) {
+		return "Infinity"
+	}
+	if math.IsInf(a, -1) {
+		return "-Infinity"
+	}
+	text := fmt.Sprintf("%.05f", a)
+	for text[len(text)-1] == '0' {
+		text = text[:len(text)-1]
+	}
+	if text[len(text)-1] == '.' {
+		text = text[:len(text)-1]
+	}
+	return text
+}
+
+func (c *calcSum) convertToToken() css_ast.Token {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-serialize
+	tokens := make([]css_ast.Token, 0, len(c.terms)*2)
+
+	// ALGORITHM DEVIATION: Avoid parenthesizing product nodes inside sum nodes
+	if product, ok := c.terms[0].(*calcProduct); ok {
+		tokens = append(tokens, *product.convertToToken().Children...)
+	} else {
+		tokens = append(tokens, c.terms[0].convertToToken())
+	}
+
+	for _, term := range c.terms[1:] {
+		// If child is a Negate node, append " - " to s, then serialize the Negate’s child and append the result to s.
+		if negate, ok := term.(*calcNegate); ok {
+			tokens = append(tokens, css_ast.Token{
+				Kind:       css_lexer.TDelimMinus,
+				Text:       "-",
+				Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter,
+			}, negate.term.convertToToken())
+			continue
+		}
+
+		// If child is a negative numeric value, append " - " to s, then serialize the negation of child as normal and append the result to s.
+		if numeric, ok := term.(*calcNumeric); ok && numeric.number < 0 {
+			clone := *numeric
+			clone.number = -clone.number
+			tokens = append(tokens, css_ast.Token{
+				Kind:       css_lexer.TDelimMinus,
+				Text:       "-",
+				Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter,
+			}, clone.convertToToken())
+			continue
+		}
+
+		// Otherwise, append " + " to s, then serialize child and append the result to s.
+		tokens = append(tokens, css_ast.Token{
+			Kind:       css_lexer.TDelimPlus,
+			Text:       "+",
+			Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter,
+		})
+
+		// ALGORITHM DEVIATION: Avoid parenthesizing product nodes inside sum nodes
+		if product, ok := term.(*calcProduct); ok {
+			tokens = append(tokens, *product.convertToToken().Children...)
+		} else {
+			tokens = append(tokens, term.convertToToken())
+		}
+	}
+
+	return css_ast.Token{
+		Kind:     css_lexer.TOpenParen,
+		Text:     "(",
+		Children: &tokens,
+	}
+}
+
+func (c *calcProduct) convertToToken() css_ast.Token {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-serialize
+	tokens := make([]css_ast.Token, 0, len(c.terms)*2)
+	tokens = append(tokens, c.terms[0].convertToToken())
+
+	for _, term := range c.terms[1:] {
+		// If child is an Invert node, append " / " to s, then serialize the Invert’s child and append the result to s.
+		if invert, ok := term.(*calcInvert); ok {
+			tokens = append(tokens, css_ast.Token{
+				Kind:       css_lexer.TDelimSlash,
+				Text:       "/",
+				Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter,
+			}, invert.term.convertToToken())
+			continue
+		}
+
+		// Otherwise, append " * " to s, then serialize child and append the result to s.
+		tokens = append(tokens, css_ast.Token{
+			Kind:       css_lexer.TDelimAsterisk,
+			Text:       "*",
+			Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter,
+		}, term.convertToToken())
+	}
+
+	return css_ast.Token{
+		Kind:     css_lexer.TOpenParen,
+		Text:     "(",
+		Children: &tokens,
+	}
+}
+
+func (c *calcNegate) convertToToken() css_ast.Token {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-serialize
+	return css_ast.Token{
+		Kind: css_lexer.TOpenParen,
+		Text: "(",
+		Children: &[]css_ast.Token{
+			{Kind: css_lexer.TNumber, Text: "-1"},
+			{Kind: css_lexer.TDelimSlash, Text: "*", Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter},
+			c.term.convertToToken(),
+		},
+	}
+}
+
+func (c *calcInvert) convertToToken() css_ast.Token {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-serialize
+	return css_ast.Token{
+		Kind: css_lexer.TOpenParen,
+		Text: "(",
+		Children: &[]css_ast.Token{
+			{Kind: css_lexer.TNumber, Text: "1"},
+			{Kind: css_lexer.TDelimSlash, Text: "/", Whitespace: css_ast.WhitespaceBefore | css_ast.WhitespaceAfter},
+			c.term.convertToToken(),
+		},
+	}
+}
+
+func (c *calcNumeric) convertToToken() css_ast.Token {
+	if c.unit == "" {
+		return css_ast.Token{
+			Kind: css_lexer.TNumber,
+			Text: floatToStringForCalc(c.number),
+		}
+	} else if c.unit == "%" {
+		return css_ast.Token{
+			Kind: css_lexer.TPercentage,
+			Text: floatToStringForCalc(c.number) + "%",
+		}
+	} else {
+		text := floatToStringForCalc(c.number)
+		return css_ast.Token{
+			Kind:       css_lexer.TDimension,
+			Text:       text + c.unit,
+			UnitOffset: uint16(len(text)),
+		}
+	}
+}
+
+func (c *calcValue) convertToToken() css_ast.Token {
+	t := c.token
+	t.Whitespace = 0
+	return t
+}
+
+func (c *calcSum) partiallySimplify() calcTerm {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-simplification
+
+	// For each of root’s children that are Sum nodes, replace them with their children.
+	terms := make([]calcTerm, 0, len(c.terms))
+	for _, term := range c.terms {
+		term = term.partiallySimplify()
+		if sum, ok := term.(*calcSum); ok {
+			terms = append(terms, sum.terms...)
+		} else {
+			terms = append(terms, term)
+		}
+	}
+
+	// For each set of root’s children that are numeric values with identical units, remove
+	// those children and replace them with a single numeric value containing the sum of the
+	// removed nodes, and with the same unit. (E.g. combine numbers, combine percentages,
+	// combine px values, etc.)
+	for i := 0; i < len(terms); i++ {
+		term := terms[i]
+		if numeric, ok := term.(*calcNumeric); ok {
+			end := i + 1
+			for j := end; j < len(terms); j++ {
+				term2 := terms[j]
+				if numeric2, ok := term2.(*calcNumeric); ok && numeric2.unit == numeric.unit {
+					numeric.number += numeric2.number
+				} else {
+					terms[end] = term2
+					end++
+				}
+			}
+			terms = terms[:end]
+		}
+	}
+
+	// If root has only a single child at this point, return the child.
+	if len(terms) == 1 {
+		return terms[0]
+	}
+
+	// Otherwise, return root.
+	c.terms = terms
+	return c
+}
+
+func (c *calcProduct) partiallySimplify() calcTerm {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-simplification
+
+	// For each of root’s children that are Product nodes, replace them with their children.
+	terms := make([]calcTerm, 0, len(c.terms))
+	for _, term := range c.terms {
+		term = term.partiallySimplify()
+		if product, ok := term.(*calcProduct); ok {
+			terms = append(terms, product.terms...)
+		} else {
+			terms = append(terms, term)
+		}
+	}
+
+	// If root has multiple children that are numbers (not percentages or dimensions), remove
+	// them and replace them with a single number containing the product of the removed nodes.
+	for i, term := range terms {
+		if numeric, ok := term.(*calcNumeric); ok && numeric.unit == "" {
+			end := i + 1
+			for j := end; j < len(terms); j++ {
+				term2 := terms[j]
+				if numeric2, ok := term2.(*calcNumeric); ok && numeric2.unit == "" {
+					numeric.number *= numeric2.number
+				} else {
+					terms[end] = term2
+					end++
+				}
+			}
+			terms = terms[:end]
+			break
+		}
+	}
+
+	// If root contains only numeric values and/or Invert nodes containing numeric values,
+	// and multiplying the types of all the children (noting that the type of an Invert
+	// node is the inverse of its child’s type) results in a type that matches any of the
+	// types that a math function can resolve to, return the result of multiplying all the
+	// values of the children (noting that the value of an Invert node is the reciprocal
+	// of its child’s value), expressed in the result’s canonical unit.
+	if len(terms) == 2 {
+		// Right now, only handle the case of two numbers, one of which has no unit
+		if first, ok := terms[0].(*calcNumeric); ok {
+			if second, ok := terms[1].(*calcNumeric); ok {
+				if first.unit == "" {
+					second.number *= first.number
+					return second
+				}
+				if second.unit == "" {
+					first.number *= second.number
+					return first
+				}
+			}
+		}
+	}
+
+	// ALGORITHM DEVIATION: Divide instead of multiply if the reciprocal is shorter
+	for i := 1; i < len(terms); i++ {
+		if numeric, ok := terms[i].(*calcNumeric); ok {
+			reciprocal := 1 / numeric.number
+			multiply := floatToStringForCalc(numeric.number)
+			divide := floatToStringForCalc(reciprocal)
+			if len(divide) < len(multiply) {
+				numeric.number = reciprocal
+				terms[i] = &calcInvert{term: numeric}
+			}
+		}
+	}
+
+	// If root has only a single child at this point, return the child.
+	if len(terms) == 1 {
+		return terms[0]
+	}
+
+	// Otherwise, return root.
+	c.terms = terms
+	return c
+}
+
+func (c *calcNegate) partiallySimplify() calcTerm {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-simplification
+
+	c.term = c.term.partiallySimplify()
+
+	// If root’s child is a numeric value, return an equivalent numeric value, but with the value negated (0 - value).
+	if numeric, ok := c.term.(*calcNumeric); ok {
+		numeric.number = -numeric.number
+		return numeric
+	}
+
+	// If root’s child is a Negate node, return the child’s child.
+	if negate, ok := c.term.(*calcNegate); ok {
+		return negate.term
+	}
+
+	return c
+}
+
+func (c *calcInvert) partiallySimplify() calcTerm {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-simplification
+
+	c.term = c.term.partiallySimplify()
+
+	// If root’s child is a number (not a percentage or dimension) return the reciprocal of the child’s value.
+	if numeric, ok := c.term.(*calcNumeric); ok && numeric.unit == "" {
+		numeric.number = 1 / numeric.number
+		return numeric
+	}
+
+	// If root’s child is an Invert node, return the child’s child.
+	if invert, ok := c.term.(*calcInvert); ok {
+		return invert.term
+	}
+
+	return c
+}
+
+func (c *calcNumeric) partiallySimplify() calcTerm {
+	return c
+}
+
+func (c *calcValue) partiallySimplify() calcTerm {
+	return c
+}
+
+func tryToParseCalcTerm(tokens []css_ast.Token) calcTerm {
+	// Specification: https://www.w3.org/TR/css-values-4/#calc-internal
+	terms := make([]calcTerm, len(tokens))
+
+	for i, token := range tokens {
+		var term calcTerm
+		if token.Kind == css_lexer.TFunction && token.Text == "var" {
+			// Using "var()" should bail because it can expand to any number of tokens
+			return nil
+		} else if token.Kind == css_lexer.TOpenParen || (token.Kind == css_lexer.TFunction && token.Text == "calc") {
+			term = tryToParseCalcTerm(*token.Children)
+			if term == nil {
+				return nil
+			}
+		} else if token.Kind == css_lexer.TNumber {
+			if number, err := strconv.ParseFloat(token.Text, 64); err == nil {
+				term = &calcNumeric{number: number}
+			} else {
+				term = &calcValue{token: token}
+			}
+		} else if token.Kind == css_lexer.TPercentage {
+			if number, err := strconv.ParseFloat(token.PercentageValue(), 64); err == nil {
+				term = &calcNumeric{number: number, unit: "%"}
+			} else {
+				term = &calcValue{token: token}
+			}
+		} else if token.Kind == css_lexer.TDimension {
+			if number, err := strconv.ParseFloat(token.DimensionValue(), 64); err == nil {
+				term = &calcNumeric{number: number, unit: token.DimensionUnit()}
+			} else {
+				term = &calcValue{token: token}
+			}
+		} else if token.Kind == css_lexer.TIdent && strings.EqualFold(token.Text, "Infinity") {
+			term = &calcNumeric{number: math.Inf(1)}
+		} else if token.Kind == css_lexer.TIdent && strings.EqualFold(token.Text, "-Infinity") {
+			term = &calcNumeric{number: math.Inf(-1)}
+		} else if token.Kind == css_lexer.TIdent && strings.EqualFold(token.Text, "NaN") {
+			term = &calcNumeric{number: math.NaN()}
+		} else {
+			term = &calcValue{token: token}
+		}
+		terms[i] = term
+	}
+
+	// Collect children into Product and Invert nodes
+	first := 1
+	for first+1 < len(terms) {
+		// If this is a "*" or "/" operator
+		if value, ok := terms[first].(*calcValue); ok && (value.token.Kind == css_lexer.TDelimAsterisk || value.token.Kind == css_lexer.TDelimSlash) {
+			// Scan over the run
+			last := first
+			for last+3 < len(terms) {
+				if value, ok := terms[last+2].(*calcValue); ok && (value.token.Kind == css_lexer.TDelimAsterisk || value.token.Kind == css_lexer.TDelimSlash) {
+					last += 2
+				} else {
+					break
+				}
+			}
+
+			// Generate a node for the run
+			product := calcProduct{terms: make([]calcTerm, (last-first)/2+2)}
+			for i := range product.terms {
+				term := terms[first+i*2-1]
+				if i > 0 && terms[first+i*2-2].(*calcValue).token.Kind == css_lexer.TDelimSlash {
+					term = &calcInvert{term: term}
+				}
+				product.terms[i] = term
+			}
+
+			// Replace the run with a single node
+			terms[first-1] = &product
+			terms = append(terms[:first], terms[last+2:]...)
+			continue
+		}
+		first++
+	}
+
+	// Collect children into Sum and Negate nodes
+	first = 1
+	for first+1 < len(terms) {
+		// If this is a "+" or "-" operator
+		if value, ok := terms[first].(*calcValue); ok && (value.token.Kind == css_lexer.TDelimPlus || value.token.Kind == css_lexer.TDelimMinus) {
+			// Scan over the run
+			last := first
+			for last+3 < len(terms) {
+				if value, ok := terms[last+2].(*calcValue); ok && (value.token.Kind == css_lexer.TDelimPlus || value.token.Kind == css_lexer.TDelimMinus) {
+					last += 2
+				} else {
+					break
+				}
+			}
+
+			// Generate a node for the run
+			sum := calcSum{terms: make([]calcTerm, (last-first)/2+2)}
+			for i := range sum.terms {
+				term := terms[first+i*2-1]
+				if i > 0 && terms[first+i*2-2].(*calcValue).token.Kind == css_lexer.TDelimMinus {
+					term = &calcNegate{term: term}
+				}
+				sum.terms[i] = term
+			}
+
+			// Replace the run with a single node
+			terms[first-1] = &sum
+			terms = append(terms[:first], terms[last+2:]...)
+			continue
+		}
+		first++
+	}
+
+	// This only succeeds if everything reduces to a single term
+	if len(terms) == 1 {
+		return terms[0]
+	}
+	return nil
+}


### PR DESCRIPTION
This PR implements basic simplification of `calc()` expressions in CSS when minification is enabled. The approach mainly follows the official CSS specification, which means it should behave the way browsers behave: https://www.w3.org/TR/css-values-4/#calc-func. This is a basic implementation so there are probably some `calc()` expressions that can be reduced by other tools but not by esbuild. This PR mainly focuses on setting up the parsing infrastructure for `calc()` expressions to make it straightforward to implement additional simplifications in the future. Here's an example of this new functionality:

```css
/* Input CSS */
div {
  width: calc(60px * 4 - 5px * 2);
  height: calc(100% / 4);
}

/* Output CSS (with --minify-syntax) */
div {
  width: 230px;
  height: 25%;
}
```

Expressions that can't be fully simplified will still be partially simplified into a reduced `calc()` expression:

```css
/* Input CSS */
div {
  width: calc(100% / 5 - 2 * 1em - 2 * 1px);
}

/* Output CSS (with --minify-syntax) */
div {
  width: calc(20% - 2em - 2px);
}
```

Note that this transformation doesn't attempt to modify any expression containing a `var()` CSS variable reference. These variable references can contain any number of tokens so it's not safe to move forward with a simplification assuming that `var()` is a single token. For example, `calc(2px * var(--x) * 3)` is not transformed into `calc(6px * var(--x))` in case `var(--x)` contains something like `4 + 5px` (`calc(2px * 4 + 5px * 3)` evaluates to `23px` while `calc(6px * 4 + 5px)` evaluates to `29px`).

Fixes #1607
