### PR TITLE
Allows watch mode even when build initially fails in javascript API

### DIFF
--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1099,10 +1099,6 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       };
       copyResponseToResult(response!, result);
       runOnEndCallbacks(result, logPluginError, () => {
-        if (result.errors.length > 0) {
-          return callback(failureErrorWithLog('Build failed', result.errors, result.warnings), null);
-        }
-
         // Handle incremental rebuilds
         if (response!.rebuildID !== void 0) {
           if (!rebuild) {
@@ -1174,6 +1170,10 @@ export function createChannel(streamIn: StreamIn): StreamOut {
             }
           }
           result.stop = stop;
+        }
+
+        if (result.errors.length > 0) {
+          return callback(failureErrorWithLog('Build failed', result.errors, result.warnings), null);
         }
 
         callback(null, result);


### PR DESCRIPTION
The rebuild callback is ignored if the initial build fails, even if the error that causes the build to fail is being fixed afterwards.

```
require('esbuild').build({
  entryPoints: ['app.js'],
  watch: {
    onRebuild() {
      console.log('This is never called if app.js has an error initially')
    }
  }
})
```

This pull request fixes the issue by moving the error callback after the handling of the rebuildID and watchID and before the success callback.