### PR TITLE
add support for "module", "production", and "development" package exports conditionals

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -229,7 +230,7 @@ func NewResolver(fs fs.FS, log logger.Log, caches *cache.CacheSet, options confi
 
 	// Generate the condition sets for interpreting the "exports" field
 	esmConditionsDefault := map[string]bool{"default": true}
-	esmConditionsImport := map[string]bool{"import": true}
+	esmConditionsImport := map[string]bool{"import": true, "module": true}
 	esmConditionsRequire := map[string]bool{"require": true}
 	for _, condition := range options.Conditions {
 		esmConditionsDefault[condition] = true
@@ -239,6 +240,12 @@ func NewResolver(fs fs.FS, log logger.Log, caches *cache.CacheSet, options confi
 		esmConditionsDefault["browser"] = true
 	case config.PlatformNode:
 		esmConditionsDefault["node"] = true
+	}
+	switch os.Getenv("NODE_ENV") {
+		case "production":
+			esmConditionsDefault["production"] = true
+		case "development":
+			esmConditionsDefault["development"] = true
 	}
 	for key := range esmConditionsDefault {
 		esmConditionsImport[key] = true


### PR DESCRIPTION
Sometimes library authors like to ship both a "development" and "production" version of their libraries. Typically, the development version has more robust error handling and more complete developer tools while the production version is optimized for small bundle size. 

In order to accomplish this, packages typically have an entrypoint that looks something like this: 

```js
'use strict';

if (process.env.NODE_ENV === "production") {
  module.exports = require("./my-lib.prod.js");
} else {
  module.exports = require("./my-lib.dev.js");
}
```

This works great for cjs based environments because it allows conditional code importing. This doesn't work so well for esm based environments which requires the import statements to be at the top level. 

To help solve these and other related issues, a convention has been created for "package exports conditionals" where the 	`exports` field in the package json describe the conditions in which a certain file should be imported.

While esbuild has basic support for package exports conditions (thanks btw!), this PR extends the default support to support a few other common cases:

1.  Support `production` and `development` conditions baed on `NODE_ENV` convention
2. Make `imports` condition synonymous with `module`.

> More info can be found here: https://webpack.js.org/guides/package-exports/#optimizations