### PR TITLE
Added optional pixel values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 bin
 esbuild.exe
 node_modules/
+.vscode

--- a/internal/css_ast/css_ast.go
+++ b/internal/css_ast/css_ast.go
@@ -209,7 +209,7 @@ func (t Token) DimensionUnitIsSafeLength() bool {
 	switch t.DimensionUnit() {
 	// These units can be reasonably expected to be supported everywhere.
 	// Information used: https://developer.mozilla.org/en-US/docs/Web/CSS/length
-	case "cm", "em", "in", "mm", "pc", "pt", "px":
+	case "cm", "em", "in", "mm", "pc", "pt", "px", "rem", "vh", "vw":
 		return true
 	}
 	return false


### PR DESCRIPTION
Hi! 
Evan

I really admire your contribution, The emergence of esbuild has made the JavaScipt community even better.

Just now, I was looking at the source code and found that the CSS optional pixel values should also be `rem`, `vh`, `vw`, which are very common.

Hope you can see！

Thank you again for your contribution！