### PR TITLE
recover from unexpected brace at top-level

### DIFF
--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -197,7 +197,15 @@ loop:
 		}
 
 		switch p.current().Kind {
-		case css_lexer.TEndOfFile, css_lexer.TCloseBrace:
+		case css_lexer.TEndOfFile:
+			break loop
+
+		case css_lexer.TCloseBrace:
+			if context.isTopLevel {
+				p.unexpected()
+				p.advance()
+				continue
+			}
 			break loop
 
 		case css_lexer.TWhitespace:

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1612,3 +1612,20 @@ func TestFont(t *testing.T) {
 	expectPrintedMangleMinify(t, "a { font: italic small-caps bold ultra-condensed 1rem/1.2 'aaa bbb' }", "a{font:italic small-caps 700 ultra-condensed 1rem/1.2 aaa bbb}")
 	expectPrintedMangleMinify(t, "a { font: italic small-caps bold ultra-condensed 1rem / 1.2 'aaa bbb' }", "a{font:italic small-caps 700 ultra-condensed 1rem/1.2 aaa bbb}")
 }
+
+func TestWarningUnexpectedCloseBrace(t *testing.T) {
+	expectParseError(t, ".red {\n  color: red;\n}\n}\n.blue {\n  color: blue;\n}\n.green {\n color: green;\n}\n",
+		`<stdin>: WARNING: Unexpected "}"
+`)
+	expectPrinted(t, ".red {\n  color: red;\n}\n}\n.blue {\n  color: blue;\n}\n.green {\n color: green;\n}\n",
+		`.red {
+  color: red;
+}
+.blue {
+  color: blue;
+}
+.green {
+  color: green;
+}
+`)
+}


### PR DESCRIPTION
When minifying, esbuild will currently truncate output when it encounters an unexpected `}` at the top-level of the css.

Given CSS like...

```
.red {
  color: red;
}
}
.blue {
  color: blue;
}
.green {
  color: green;
}
```

This produces...
```
bin/esbuild --loader=css --minify <rgb.css
▲ [WARNING] Expected end of file but found "}"

    <stdin>:4:0:
      4 │ }
        ╵ ^

1 warning
.red{color:red}
```

This PR attempts to recover from the situation (more like the best-effort recovery seen in other minification processors and/or css parsers), instead producing the following...
```
bin/esbuild --loader=css --minify <rgb.css
▲ [WARNING] Unexpected "}"

    <stdin>:4:0:
      4 │ }
        ╵ ^

1 warning
.red{color:red}.blue{color:#00f}.green{color:green}
```