### PR TITLE
add a `resolve` API for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
     * The behavior of this function depends on the build configuration. That's why it's a property of the `build` object instead of being a top-level API call. This also means you can't call it until all plugin `setup` functions have finished since these give plugins the opportunity to adjust the build configuration before it's frozen at the start of the build. So the new `resolve` function is going to be most useful inside your `onResolve` and/or `onLoad` callbacks.
 
+    * There is currently no attempt made to detect infinite path resolution loops. Calling `resolve` from within `onResolve` with the same parameters is almost certainly a bad idea.
+
 * Avoid CJS-to-ESM wrapper in some cases ([#1831](https://github.com/evanw/esbuild/issues/1831))
 
     Import statements are converted into `require()` calls when the output format is set to CommonJS. To convert from CommonJS semantics to ES module semantics, esbuild wraps the return value in a call to esbuild's `__toESM()` helper function. However, the conversion is only needed if it's possible that the exports named `default` or `__esModule` could be accessed.

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -28,13 +28,15 @@ type responseCallback func(interface{})
 type rebuildCallback func(uint32) []byte
 type watchStopCallback func()
 type serveStopCallback func()
+type pluginResolveCallback func(uint32, map[string]interface{}) []byte
 
 type activeBuild struct {
-	mutex     sync.Mutex
-	refCount  int
-	rebuild   rebuildCallback
-	watchStop watchStopCallback
-	serveStop serveStopCallback
+	mutex         sync.Mutex
+	refCount      int
+	rebuild       rebuildCallback
+	watchStop     watchStopCallback
+	serveStop     serveStopCallback
+	pluginResolve pluginResolveCallback
 }
 
 type serviceType struct {
@@ -56,8 +58,11 @@ func (service *serviceType) getActiveBuild(key int) *activeBuild {
 func (service *serviceType) trackActiveBuild(key int, activeBuild *activeBuild) {
 	if activeBuild.refCount > 0 {
 		service.mutex.Lock()
+		defer service.mutex.Unlock()
+		if service.activeBuilds[key] != nil {
+			panic("Internal error")
+		}
 		service.activeBuilds[key] = activeBuild
-		service.mutex.Unlock()
 
 		// This pairs with "Done()" in "decRefCount"
 		service.keepAliveWaitGroup.Add(1)
@@ -229,6 +234,27 @@ func (service *serviceType) handleIncomingPacket(bytes []byte) (result outgoingP
 		case "transform":
 			return outgoingPacket{
 				bytes: service.handleTransformRequest(p.id, request),
+			}
+
+		case "resolve":
+			key := request["key"].(int)
+			if build := service.getActiveBuild(key); build != nil {
+				build.mutex.Lock()
+				pluginResolve := build.pluginResolve
+				build.mutex.Unlock()
+				if pluginResolve != nil {
+					return outgoingPacket{
+						bytes: pluginResolve(p.id, request),
+					}
+				}
+			}
+			return outgoingPacket{
+				bytes: encodePacket(packet{
+					id: p.id,
+					value: map[string]interface{}{
+						"error": "Cannot call \"resolve\" on an inactive build",
+					},
+				}),
 			}
 
 		case "rebuild":
@@ -418,8 +444,12 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		}
 	}
 
+	activeBuild := &activeBuild{refCount: 1}
+	service.trackActiveBuild(key, activeBuild)
+	defer service.decRefCount(key, activeBuild)
+
 	if plugins, ok := request["plugins"]; ok {
-		if plugins, err := service.convertPlugins(key, plugins); err != nil {
+		if plugins, err := service.convertPlugins(key, plugins, activeBuild); err != nil {
 			return outgoingPacket{bytes: encodeErrorPacket(id, err)}
 		} else {
 			options.Plugins = plugins
@@ -427,7 +457,7 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 	}
 
 	if isServe {
-		return service.handleServeRequest(id, options, serveObj, key)
+		return service.handleServeRequest(id, options, serveObj, key, activeBuild)
 	}
 
 	resultToResponse := func(result api.BuildResult) map[string]interface{} {
@@ -466,8 +496,6 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 	options.Incremental = incremental
 	result := api.Build(options)
 	response := resultToResponse(result)
-	activeBuild := &activeBuild{refCount: 1}
-	service.trackActiveBuild(key, activeBuild)
 
 	if incremental {
 		activeBuild.rebuild = func(id uint32) []byte {
@@ -492,7 +520,6 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		activeBuild.refCount++
 	}
 
-	service.decRefCount(key, activeBuild)
 	return outgoingPacket{
 		bytes: encodePacket(packet{
 			id:    id,
@@ -501,7 +528,7 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 	}
 }
 
-func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptions, serveObj interface{}, key int) outgoingPacket {
+func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptions, serveObj interface{}, key int, activeBuild *activeBuild) outgoingPacket {
 	var serveOptions api.ServeOptions
 	serve := serveObj.(map[string]interface{})
 	if port, ok := serve["port"]; ok {
@@ -535,11 +562,8 @@ func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptio
 		"host": result.Host,
 	}
 
-	activeBuild := &activeBuild{
-		refCount:  1, // Make sure the serve doesn't finish until "Wait" finishes
-		serveStop: result.Stop,
-	}
-	service.trackActiveBuild(key, activeBuild)
+	activeBuild.refCount++ // Make sure the serve doesn't finish until "Wait" finishes
+	activeBuild.serveStop = result.Stop
 
 	// Asynchronously wait for the server to stop, then fulfil the "wait" promise
 	go func() {
@@ -566,9 +590,58 @@ func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptio
 	}
 }
 
-func (service *serviceType) convertPlugins(key int, jsPlugins interface{}) ([]api.Plugin, error) {
-	var goPlugins []api.Plugin
+func resolveKindToString(kind api.ResolveKind) string {
+	switch kind {
+	case api.ResolveEntryPoint:
+		return "entry-point"
 
+	// JS
+	case api.ResolveJSImportStatement:
+		return "import-statement"
+	case api.ResolveJSRequireCall:
+		return "require-call"
+	case api.ResolveJSDynamicImport:
+		return "dynamic-import"
+	case api.ResolveJSRequireResolve:
+		return "require-resolve"
+
+	// CSS
+	case api.ResolveCSSImportRule:
+		return "import-rule"
+	case api.ResolveCSSURLToken:
+		return "url-token"
+
+	default:
+		panic("Internal error")
+	}
+}
+
+func stringToResolveKind(kind string) (api.ResolveKind, bool) {
+	switch kind {
+	case "entry-point":
+		return api.ResolveEntryPoint, true
+
+	// JS
+	case "import-statement":
+		return api.ResolveJSImportStatement, true
+	case "require-call":
+		return api.ResolveJSRequireCall, true
+	case "dynamic-import":
+		return api.ResolveJSDynamicImport, true
+	case "require-resolve":
+		return api.ResolveJSRequireResolve, true
+
+	// CSS
+	case "import-rule":
+		return api.ResolveCSSImportRule, true
+	case "url-token":
+		return api.ResolveCSSURLToken, true
+	}
+
+	return api.ResolveEntryPoint, false
+}
+
+func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activeBuild *activeBuild) ([]api.Plugin, error) {
 	type filteredCallback struct {
 		filter     *regexp.Regexp
 		pluginName string
@@ -616,9 +689,56 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}) ([]ap
 	// We want to minimize the amount of IPC traffic. Instead of adding one Go
 	// plugin for every JavaScript plugin, we just add a single Go plugin that
 	// proxies the plugin queries to the list of JavaScript plugins in the host.
-	goPlugins = append(goPlugins, api.Plugin{
+	return []api.Plugin{{
 		Name: "JavaScript plugins",
 		Setup: func(build api.PluginBuild) {
+			activeBuild.mutex.Lock()
+			activeBuild.pluginResolve = func(id uint32, request map[string]interface{}) []byte {
+				path := request["path"].(string)
+				var options api.ResolveOptions
+				if value, ok := request["importer"]; ok {
+					options.Importer = value.(string)
+				}
+				if value, ok := request["namespace"]; ok {
+					options.Namespace = value.(string)
+				}
+				if value, ok := request["resolveDir"]; ok {
+					options.ResolveDir = value.(string)
+				}
+				if value, ok := request["kind"]; ok {
+					str := value.(string)
+					kind, ok := stringToResolveKind(str)
+					if !ok {
+						return encodePacket(packet{
+							id: id,
+							value: map[string]interface{}{
+								"error": fmt.Sprintf("Invalid kind: %q", str),
+							},
+						})
+					}
+					options.Kind = kind
+				}
+				if value, ok := request["pluginData"]; ok {
+					options.PluginData = value.(int)
+				}
+
+				result := build.Resolve(path, options)
+				return encodePacket(packet{
+					id: id,
+					value: map[string]interface{}{
+						"errors":      encodeMessages(result.Errors),
+						"warnings":    encodeMessages(result.Warnings),
+						"path":        result.Path,
+						"external":    result.External,
+						"sideEffects": result.SideEffects,
+						"namespace":   result.Namespace,
+						"suffix":      result.Suffix,
+						"pluginData":  result.PluginData,
+					},
+				})
+			}
+			activeBuild.mutex.Unlock()
+
 			build.OnStart(func() (api.OnStartResult, error) {
 				result := api.OnStartResult{}
 
@@ -651,31 +771,6 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}) ([]ap
 					return result, nil
 				}
 
-				var kind string
-				switch args.Kind {
-				case api.ResolveEntryPoint:
-					kind = "entry-point"
-
-				// JS
-				case api.ResolveJSImportStatement:
-					kind = "import-statement"
-				case api.ResolveJSRequireCall:
-					kind = "require-call"
-				case api.ResolveJSDynamicImport:
-					kind = "dynamic-import"
-				case api.ResolveJSRequireResolve:
-					kind = "require-resolve"
-
-				// CSS
-				case api.ResolveCSSImportRule:
-					kind = "import-rule"
-				case api.ResolveCSSURLToken:
-					kind = "url-token"
-
-				default:
-					panic("Internal error")
-				}
-
 				response := service.sendRequest(map[string]interface{}{
 					"command":    "on-resolve",
 					"key":        key,
@@ -684,7 +779,7 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}) ([]ap
 					"importer":   args.Importer,
 					"namespace":  args.Namespace,
 					"resolveDir": args.ResolveDir,
-					"kind":       kind,
+					"kind":       resolveKindToString(args.Kind),
 					"pluginData": args.PluginData,
 				}).(map[string]interface{})
 
@@ -813,9 +908,7 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}) ([]ap
 				return result, nil
 			})
 		},
-	})
-
-	return goPlugins, nil
+	}}, nil
 }
 
 func (service *serviceType) handleTransformRequest(id uint32, request map[string]interface{}) []byte {

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -696,6 +696,9 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 			activeBuild.pluginResolve = func(id uint32, request map[string]interface{}) []byte {
 				path := request["path"].(string)
 				var options api.ResolveOptions
+				if value, ok := request["pluginName"]; ok {
+					options.PluginName = value.(string)
+				}
 				if value, ok := request["importer"]; ok {
 					options.Importer = value.(string)
 				}

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -428,46 +428,9 @@ func parseFile(args parseArgs) {
 					// code pattern for conditionally importing a module with a graceful
 					// fallback.
 					if !didLogError && !record.Flags.Has(ast.HandlesImportErrors) {
-						hint := ""
-						if resolver.IsPackagePath(record.Path.Text) {
-							hint = fmt.Sprintf("You can mark the path %q as external to exclude it from the bundle, which will remove this error.", record.Path.Text)
-							if record.Kind == ast.ImportRequire {
-								hint += " You can also surround this \"require\" call with a try/catch block to handle this failure at run-time instead of bundle-time."
-							} else if record.Kind == ast.ImportDynamic {
-								hint += " You can also add \".catch()\" here to handle this failure at run-time instead of bundle-time."
-							}
-							if pluginName == "" && !args.fs.IsAbs(record.Path.Text) {
-								if query := args.res.ProbeResolvePackageAsRelative(absResolveDir, record.Path.Text, record.Kind); query != nil {
-									hint = fmt.Sprintf("Use the relative path %q to reference the file %q. "+
-										"Without the leading \"./\", the path %q is being interpreted as a package path instead.",
-										"./"+record.Path.Text, args.res.PrettyPath(query.PathPair.Primary), record.Path.Text)
-								}
-							}
-						}
-						if args.options.Platform != config.PlatformNode {
-							if _, ok := resolver.BuiltInNodeModules[record.Path.Text]; ok {
-								var how string
-								switch logger.API {
-								case logger.CLIAPI:
-									how = "--platform=node"
-								case logger.JSAPI:
-									how = "platform: 'node'"
-								case logger.GoAPI:
-									how = "Platform: api.PlatformNode"
-								}
-								hint = fmt.Sprintf("The package %q wasn't found on the file system but is built into node. "+
-									"Are you trying to bundle for node? You can use %q to do that, which will remove this error.", record.Path.Text, how)
-							}
-						}
-						if absResolveDir == "" && pluginName != "" {
-							hint = fmt.Sprintf("The plugin %q didn't set a resolve directory for the file %q, "+
-								"so esbuild did not search for %q on the file system.", pluginName, source.PrettyPath, record.Path.Text)
-						}
-						var notes []logger.MsgData
-						if hint != "" {
-							notes = append(notes, logger.MsgData{Text: hint})
-						}
-						debug.LogErrorMsg(args.log, &source, record.Range, fmt.Sprintf("Could not resolve %q", record.Path.Text), notes)
+						text, notes := ResolveFailureErrorTextAndNotes(args.res, record.Path.Text, record.Kind,
+							pluginName, args.fs, absResolveDir, args.options.Platform, source.PrettyPath)
+						debug.LogErrorMsg(args.log, &source, record.Range, text, notes)
 					} else if args.log.Level <= logger.LevelDebug && !didLogError && record.Flags.Has(ast.HandlesImportErrors) {
 						args.log.Add(logger.Debug, &tracker, record.Range,
 							fmt.Sprintf("Importing %q was allowed even though it could not be resolved because dynamic import failures appear to be handled here:",
@@ -503,6 +466,66 @@ func parseFile(args parseArgs) {
 	}
 
 	args.results <- result
+}
+
+func ResolveFailureErrorTextAndNotes(
+	res resolver.Resolver,
+	path string,
+	kind ast.ImportKind,
+	pluginName string,
+	fs fs.FS,
+	absResolveDir string,
+	platform config.Platform,
+	originatingFilePath string,
+) (string, []logger.MsgData) {
+	hint := ""
+
+	if resolver.IsPackagePath(path) {
+		hint = fmt.Sprintf("You can mark the path %q as external to exclude it from the bundle, which will remove this error.", path)
+		if kind == ast.ImportRequire {
+			hint += " You can also surround this \"require\" call with a try/catch block to handle this failure at run-time instead of bundle-time."
+		} else if kind == ast.ImportDynamic {
+			hint += " You can also add \".catch()\" here to handle this failure at run-time instead of bundle-time."
+		}
+		if pluginName == "" && !fs.IsAbs(path) {
+			if query := res.ProbeResolvePackageAsRelative(absResolveDir, path, kind); query != nil {
+				hint = fmt.Sprintf("Use the relative path %q to reference the file %q. "+
+					"Without the leading \"./\", the path %q is being interpreted as a package path instead.",
+					"./"+path, res.PrettyPath(query.PathPair.Primary), path)
+			}
+		}
+	}
+
+	if platform != config.PlatformNode {
+		if _, ok := resolver.BuiltInNodeModules[path]; ok {
+			var how string
+			switch logger.API {
+			case logger.CLIAPI:
+				how = "--platform=node"
+			case logger.JSAPI:
+				how = "platform: 'node'"
+			case logger.GoAPI:
+				how = "Platform: api.PlatformNode"
+			}
+			hint = fmt.Sprintf("The package %q wasn't found on the file system but is built into node. "+
+				"Are you trying to bundle for node? You can use %q to do that, which will remove this error.", path, how)
+		}
+	}
+
+	if absResolveDir == "" && pluginName != "" {
+		where := ""
+		if originatingFilePath != "" {
+			where = fmt.Sprintf(" for the file %q", originatingFilePath)
+		}
+		hint = fmt.Sprintf("The plugin %q didn't set a resolve directory%s, "+
+			"so esbuild did not search for %q on the file system.", pluginName, where, path)
+	}
+
+	var notes []logger.MsgData
+	if hint != "" {
+		notes = append(notes, logger.MsgData{Text: hint})
+	}
+	return fmt.Sprintf("Could not resolve %q", path), notes
 }
 
 func joinWithPublicPath(publicPath string, relPath string) string {

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -631,6 +631,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
     plugins: types.Plugin[],
     buildKey: number,
     stash: ObjectStash,
+    refs: Refs | null,
   ): Promise<
     | { ok: true, requestPlugins: protocol.BuildPlugin[], runOnEndCallbacks: RunOnEndCallbacks, pluginRefs: Refs }
     | { ok: false, error: any, pluginName: string }
@@ -669,6 +670,44 @@ export function createChannel(streamIn: StreamIn): StreamOut {
     let i = 0;
     let requestPlugins: protocol.BuildPlugin[] = [];
 
+    let resolve = (path: string, options: types.ResolveOptions = {}): Promise<types.ResolveResult> => {
+      if (typeof path !== 'string') throw new Error(`The path to resolve must be a string`);
+      let keys: OptionKeys = Object.create(null);
+      let importer = getFlag(options, keys, 'importer', mustBeString);
+      let namespace = getFlag(options, keys, 'namespace', mustBeString);
+      let resolveDir = getFlag(options, keys, 'resolveDir', mustBeString);
+      let kind = getFlag(options, keys, 'kind', mustBeString);
+      let pluginData = getFlag(options, keys, 'pluginData', canBeAnything);
+      checkForInvalidFlags(options, keys, 'in resolve() call');
+
+      return new Promise((resolve, reject) => {
+        const request: protocol.ResolveRequest = {
+          command: 'resolve',
+          path,
+          key: buildKey,
+        }
+        if (importer != null) request.importer = importer
+        if (namespace != null) request.namespace = namespace
+        if (resolveDir != null) request.resolveDir = resolveDir
+        if (kind != null) request.kind = kind
+        if (pluginData != null) request.pluginData = stash.store(pluginData)
+
+        sendRequest<protocol.ResolveRequest, protocol.ResolveResponse>(refs, request, (error, response) => {
+          if (error !== null) reject(new Error(error))
+          else resolve({
+            errors: replaceDetailsInMessages(response!.errors, stash),
+            warnings: replaceDetailsInMessages(response!.warnings, stash),
+            path: response!.path,
+            external: response!.external,
+            sideEffects: response!.sideEffects,
+            namespace: response!.namespace,
+            suffix: response!.suffix,
+            pluginData: stash.load(response!.pluginData),
+          })
+        })
+      })
+    }
+
     // Clone the plugin array to guard against mutation during iteration
     plugins = [...plugins];
 
@@ -691,6 +730,8 @@ export function createChannel(streamIn: StreamIn): StreamOut {
 
         let promise = setup({
           initialOptions,
+
+          resolve,
 
           onStart(callback) {
             let registeredText = `This error came from the "onStart" callback registered here:`
@@ -972,7 +1013,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       if (streamIn.isSync) return handleError(new Error('Cannot use plugins in synchronous API calls'), '');
 
       // Plugins can use async/await because they can't be run with "buildSync"
-      handlePlugins(options, plugins, key, details).then(
+      handlePlugins(options, plugins, key, details, refs).then(
         result => {
           if (!result.ok) {
             handleError(result.error, result.pluginName);

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -669,6 +669,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
     let nextCallbackID = 0;
     let i = 0;
     let requestPlugins: protocol.BuildPlugin[] = [];
+    let isSetupDone = false;
 
     // Clone the plugin array to guard against mutation during iteration
     plugins = [...plugins];
@@ -691,6 +692,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
         i++;
 
         let resolve = (path: string, options: types.ResolveOptions = {}): Promise<types.ResolveResult> => {
+          if (!isSetupDone) throw new Error('Cannot call "resolve" before plugin setup has completed');
           if (typeof path !== 'string') throw new Error(`The path to resolve must be a string`);
           let keys: OptionKeys = Object.create(null);
           let importer = getFlag(options, keys, 'importer', mustBeString);
@@ -931,6 +933,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       }
     }
 
+    isSetupDone = true;
     let refCount = 0;
     return {
       ok: true,

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -150,6 +150,7 @@ export interface ResolveRequest {
   command: 'resolve';
   key: number;
   path: string;
+  pluginName: string;
   importer?: string;
   namespace?: string;
   resolveDir?: string;

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -146,6 +146,29 @@ export interface OnStartResponse {
   warnings?: types.PartialMessage[];
 }
 
+export interface ResolveRequest {
+  command: 'resolve';
+  key: number;
+  path: string;
+  importer?: string;
+  namespace?: string;
+  resolveDir?: string;
+  kind?: string;
+  pluginData?: number;
+}
+
+export interface ResolveResponse {
+  errors: types.Message[];
+  warnings: types.Message[];
+
+  path: string;
+  external: boolean;
+  sideEffects: boolean;
+  namespace: string;
+  suffix: string;
+  pluginData: number;
+}
+
 export interface OnResolveRequest {
   command: 'on-resolve';
   key: number;

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -260,6 +260,8 @@ export interface Plugin {
 
 export interface PluginBuild {
   initialOptions: BuildOptions;
+  resolve(path: string, options?: ResolveOptions): Promise<ResolveResult>;
+
   onStart(callback: () =>
     (OnStartResult | null | void | Promise<OnStartResult | null | void>)): void;
   onEnd(callback: (result: BuildResult) =>
@@ -283,6 +285,26 @@ export interface PluginBuild {
     initialize: typeof initialize,
     version: typeof version,
   };
+}
+
+export interface ResolveOptions {
+  importer?: string;
+  namespace?: string;
+  resolveDir?: string;
+  kind?: ImportKind;
+  pluginData?: any;
+}
+
+export interface ResolveResult {
+  errors: Message[];
+  warnings: Message[];
+
+  path: string;
+  external: boolean;
+  sideEffects: boolean;
+  namespace: string;
+  suffix: string;
+  pluginData: any;
 }
 
 export interface OnStartResult {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -459,6 +459,7 @@ type PluginBuild struct {
 }
 
 type ResolveOptions struct {
+	PluginName string
 	Importer   string
 	Namespace  string
 	ResolveDir string

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -451,10 +451,31 @@ type Plugin struct {
 
 type PluginBuild struct {
 	InitialOptions *BuildOptions
+	Resolve        func(path string, options ResolveOptions) ResolveResult
 	OnStart        func(callback func() (OnStartResult, error))
 	OnEnd          func(callback func(result *BuildResult))
 	OnResolve      func(options OnResolveOptions, callback func(OnResolveArgs) (OnResolveResult, error))
 	OnLoad         func(options OnLoadOptions, callback func(OnLoadArgs) (OnLoadResult, error))
+}
+
+type ResolveOptions struct {
+	Importer   string
+	Namespace  string
+	ResolveDir string
+	Kind       ResolveKind
+	PluginData interface{}
+}
+
+type ResolveResult struct {
+	Errors   []Message
+	Warnings []Message
+
+	Path        string
+	External    bool
+	SideEffects bool
+	Namespace   string
+	Suffix      string
+	PluginData  interface{}
 }
 
 type OnStartResult struct {

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1660,7 +1660,7 @@ func loadPlugins(initialOptions *BuildOptions, fs fs.FS, log logger.Log, caches 
 			// has finished. That isn't allowed because plugin setup is allowed to
 			// change the initial options object, which can affect path resolution.
 			if buildOptions == nil {
-				return ResolveResult{Errors: []Message{{Text: "Cannot resolve paths before plugin setup has completed"}}}
+				return ResolveResult{Errors: []Message{{Text: "Cannot call \"resolve\" before plugin setup has completed"}}}
 			}
 
 			// Make a new resolver so it has its own log

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2233,7 +2233,7 @@ error: Invalid path suffix "%what" returned from plugin (must start with "?" or 
       })
       throw new Error('Expected an error to be thrown')
     } catch (e) {
-      assert(e.message.includes('Cannot call \"resolve\" on an inactive build'), e.message)
+      assert(e.message.includes('Cannot call "resolve" before plugin setup has completed'), e.message)
     }
   },
 

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2218,6 +2218,141 @@ error: Invalid path suffix "%what" returned from plugin (must start with "?" or 
     })
     assert.strictEqual(build.outputFiles[0].text, `// entry:entry\nimport "sideEffects";\n`)
   },
+
+  async callResolveTooEarlyError({ esbuild }) {
+    try {
+      await esbuild.build({
+        entryPoints: [],
+        logLevel: 'silent',
+        plugins: [{
+          name: 'plugin',
+          async setup(build) {
+            await build.resolve('foo')
+          },
+        }],
+      })
+      throw new Error('Expected an error to be thrown')
+    } catch (e) {
+      assert(e.message.includes('Cannot call \"resolve\" on an inactive build'), e.message)
+    }
+  },
+
+  async callResolveTooLateError({ esbuild }) {
+    let resolve
+    await esbuild.build({
+      entryPoints: [],
+      plugins: [{
+        name: 'plugin',
+        async setup(build) {
+          resolve = build.resolve
+        },
+      }],
+    })
+    try {
+      const result = await resolve('foo')
+      console.log(result.errors)
+      throw new Error('Expected an error to be thrown')
+    } catch (e) {
+      assert(e.message.includes('Cannot call \"resolve\" on an inactive build'), e.message)
+    }
+  },
+
+  async callResolveBadKindError({ esbuild }) {
+    try {
+      await esbuild.build({
+        entryPoints: ['entry'],
+        logLevel: 'silent',
+        plugins: [{
+          name: 'plugin',
+          async setup(build) {
+            build.onResolve({ filter: /^entry$/ }, async () => {
+              return await build.resolve('foo', { kind: 'what' })
+            })
+          },
+        }],
+      })
+      throw new Error('Expected an error to be thrown')
+    } catch (e) {
+      assert(e.message.includes('Invalid kind: "what"'), e.message)
+    }
+  },
+
+  // Test that user options are taken into account
+  async callResolveUserOptionsExternal({ esbuild, testDir }) {
+    const result = await esbuild.build({
+      stdin: { contents: `import "foo"` },
+      write: false,
+      bundle: true,
+      external: ['bar'],
+      format: 'esm',
+      plugins: [{
+        name: 'plugin',
+        async setup(build) {
+          build.onResolve({ filter: /^foo$/ }, async () => {
+            const result = await build.resolve('bar', { resolveDir: testDir })
+            assert(result.external)
+            return { path: 'baz', external: true }
+          })
+        },
+      }],
+    })
+    assert.strictEqual(result.outputFiles[0].text, `// <stdin>\nimport "baz";\n`)
+  },
+
+  async callResolveBuiltInHandler({ esbuild, testDir }) {
+    const srcDir = path.join(testDir, 'src')
+    const input = path.join(srcDir, 'input.js')
+    await mkdirAsync(srcDir, { recursive: true })
+    await writeFileAsync(input, `console.log(123)`)
+    const result = await esbuild.build({
+      entryPoints: ['entry'],
+      write: false,
+      plugins: [{
+        name: 'plugin',
+        setup(build) {
+          build.onResolve({ filter: /^entry$/ }, async () => {
+            return await build.resolve('./' + path.basename(input), { resolveDir: srcDir })
+          })
+        },
+      }],
+    })
+    assert.strictEqual(result.outputFiles[0].text, `console.log(123);\n`)
+  },
+
+  async callResolvePluginHandler({ esbuild, testDir }) {
+    const srcDir = path.join(testDir, 'src')
+    const input = path.join(srcDir, 'input.js')
+    await mkdirAsync(srcDir, { recursive: true })
+    await writeFileAsync(input, `console.log(123)`)
+    const result = await esbuild.build({
+      entryPoints: ['entry'],
+      write: false,
+      plugins: [{
+        name: 'plugin',
+        setup(build) {
+          build.onResolve({ filter: /^entry$/ }, async () => {
+            return await build.resolve('foo', {
+              importer: 'foo-importer',
+              namespace: 'foo-namespace',
+              resolveDir: 'foo-resolveDir',
+              pluginData: 'foo-pluginData',
+              kind: 'dynamic-import',
+            })
+          })
+          build.onResolve({ filter: /^foo$/ }, async (args) => {
+            assert.strictEqual(args.path, 'foo')
+            assert.strictEqual(args.importer, 'foo-importer')
+            assert.strictEqual(args.namespace, 'foo-namespace')
+            assert.strictEqual(args.resolveDir, 'foo-resolveDir')
+            assert.strictEqual(args.pluginData, 'foo-pluginData')
+            assert.strictEqual(args.kind, 'dynamic-import')
+            return { path: input }
+          })
+        },
+      }],
+    })
+    assert.strictEqual(result.outputFiles[0].text, `console.log(123);\n`)
+  },
 }
 
 // These tests have to run synchronously

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2343,7 +2343,7 @@ error: Invalid path suffix "%what" returned from plugin (must start with "?" or 
             assert.strictEqual(args.path, 'foo')
             assert.strictEqual(args.importer, 'foo-importer')
             assert.strictEqual(args.namespace, 'foo-namespace')
-            assert.strictEqual(args.resolveDir, 'foo-resolveDir')
+            assert.strictEqual(args.resolveDir, path.join(process.cwd(), 'foo-resolveDir'))
             assert.strictEqual(args.pluginData, 'foo-pluginData')
             assert.strictEqual(args.kind, 'dynamic-import')
             return { path: input }


### PR DESCRIPTION
Plugins now have access to a new API called `resolve` that runs esbuild's path resolution logic and returns the result to the caller. This lets you write plugins that can reuse esbuild's complex built-in path resolution logic to change the inputs and/or adjust the outputs. Here's an example:

```js
let examplePlugin = {
  name: 'example',
  setup(build) {
    build.onResolve({ filter: /^example$/ }, async () => {
      const result = await build.resolve('./foo', { resolveDir: '/bar' })
      if (result.errors.length > 0) return result
      return { ...result, external: true }
    })
  },
}
```

This plugin intercepts imports to the path `example`, tells esbuild to resolve the import `./foo` in the directory `/bar`, and then forces whatever path esbuild returns to be considered external. Here are some additional details:

* If you don't pass the optional `resolveDir` parameter, esbuild will still run `onResolve` plugin callbacks but will not attempt any path resolution itself. All of esbuild's path resolution logic depends on the `resolveDir` parameter including looking for packages in `node_modules` directories (since it needs to know where those `node_modules` directories might be).

* If you want to resolve a file name in a specific directory, make sure the input path starts with `./`. Otherwise the input path will be treated as a package path instead of a relative path. This behavior is identical to esbuild's normal path resolution logic.

* If path resolution fails, the `errors` property on the returned object will be a non-empty array containing the error information. This function does not always throw an error when it fails. You need to check for errors after calling it.

* The behavior of this function depends on the build configuration. That's why it's a property of the `build` object instead of being a top-level API call. This also means you can't call it until all plugin `setup` functions have finished since these give plugins the opportunity to adjust the build configuration before it's frozen at the start of the build. So the new `resolve` function is going to be most useful inside your `onResolve` and/or `onLoad` callbacks.

* There is currently no attempt made to detect infinite path resolution loops. Calling `resolve` from within `onResolve` with the same parameters is almost certainly a bad idea.

Fixes #641
Fixes #1652
