### PR TITLE
inline certain no-op function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,26 @@
     function o(n){return n}export const foo=function(){};
     ```
 
+* Inline calls to empty functions when minifying ([#290](https://github.com/evanw/esbuild/issues/290))
+
+    An empty function is a function that just returns its argument. It most commonly arises when most of the function body is eliminated as dead code. This release replaces calls to empty functions with their arguments when minifying, resulting in slightly smaller code. Tree shaking has not yet been updated to remove empty functions that are now unreferenced. Here's an example:
+
+    ```ts
+    // Original code
+    function assertFoo(val: Foo | null): asserts val is Foo {
+      if (window.DEBUG && val === null) throw new Error('null assertion failed');
+    }
+    const val = getFoo();
+    assertFoo(val);
+    console.log(val.bar);
+
+    // Old output (with --minify --define:window.DEBUG=false)
+    function assertFoo(o){}const val=getFoo();assertFoo(val),console.log(val.bar);
+
+    // New output (with --minify --define:window.DEBUG=false)
+    function assertFoo(o){}const val=getFoo();val,void 0,console.log(val.bar);
+    ```
+
 ## 0.14.9
 
 * Implement cross-module tree shaking of TypeScript enum values ([#128](https://github.com/evanw/esbuild/issues/128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
     function assertFoo(o){}const val=getFoo();assertFoo(val),console.log(val.bar);
 
     // New output (with --minify --define:window.DEBUG=false)
-    function assertFoo(o){}const val=getFoo();void 0,console.log(val.bar);
+    function assertFoo(o){}const val=getFoo();console.log(val.bar);
     ```
 
 ## 0.14.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,28 @@
 
     WARNING: Using this flag can introduce bugs into your code! This flag removes the entire call expression including all call arguments. If any of those arguments had important side effects, using this flag will change the behavior of your code. Be very careful when using this flag. If you want to remove console API calls without removing arguments with side effects (which does not introduce bugs), you should mark the relevant API calls as pure instead like this: `--pure:console.log --minify`.
 
+* Inline calls to identity functions when minifying ([#907](https://github.com/evanw/esbuild/issues/907))
+
+    An identity function is a function that just returns its argument. It most commonly arises when most of the function body is eliminated as dead code. This release replaces calls to identity functions with their argument when minifying, resulting in slightly smaller code. Tree shaking has not yet been updated to remove identity functions that are now unreferenced. Here's an example:
+
+    ```js
+    // Original code
+    function logCalls(fn) {
+      if (window.DEBUG) return function(...args) {
+        console.log('calling', fn.name, 'with', ...args)
+        return fn.apply(this, args)
+      }
+      return fn
+    }
+    export const foo = logCalls(function foo() {})
+
+    // Old output (with --minify --define:window.DEBUG=false)
+    function o(n){return n}export const foo=o(function(){});
+
+    // New output (with --minify --define:window.DEBUG=false)
+    function o(n){return n}export const foo=function(){};
+    ```
+
 ## 0.14.9
 
 * Implement cross-module tree shaking of TypeScript enum values ([#128](https://github.com/evanw/esbuild/issues/128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
     function assertFoo(o){}const val=getFoo();assertFoo(val),console.log(val.bar);
 
     // New output (with --minify --define:window.DEBUG=false)
-    function assertFoo(o){}const val=getFoo();val,void 0,console.log(val.bar);
+    function assertFoo(o){}const val=getFoo();void 0,console.log(val.bar);
     ```
 
 ## 0.14.9

--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -2459,3 +2459,23 @@ func TestInlineFunctionCallBehaviorChanges(t *testing.T) {
 		},
 	})
 }
+
+func TestInlineFunctionCallForInitDecl(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				function empty() {}
+				function id(x) { return x }
+
+				for (var y = empty(); false; ) ;
+				for (var z = id(123); false; ) ;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MangleSyntax: true,
+		},
+	})
+}

--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -2189,13 +2189,6 @@ func TestInlineIdentityFunctionCalls(t *testing.T) {
 				keep(1)
 			`,
 
-			"/not-identity-no-args.js": `
-				function keep() { return }
-				console.log(keep(1))
-				keep(foo())
-				keep(1)
-			`,
-
 			"/not-identity-two-args.js": `
 				function keep(x, y) { return x }
 				console.log(keep(1))
@@ -2252,13 +2245,141 @@ func TestInlineIdentityFunctionCalls(t *testing.T) {
 			"/reassign-div.js",
 			"/reassign-array.js",
 			"/reassign-object.js",
-			"/not-identity-no-args.js",
 			"/not-identity-two-args.js",
 			"/not-identity-default.js",
 			"/not-identity-array.js",
 			"/not-identity-object.js",
 			"/not-identity-rest.js",
 			"/not-identity-return.js",
+		},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MangleSyntax: true,
+		},
+	})
+}
+
+func TestInlineEmptyFunctionCalls(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/empty.js": `
+				function DROP() {}
+				console.log(DROP(foo(), bar()))
+				console.log(DROP(foo(), 1))
+				console.log(DROP(1, foo()))
+				console.log(DROP(1))
+				console.log(DROP())
+				DROP(foo(), bar())
+				DROP(foo(), 1)
+				DROP(1, foo())
+				DROP(1)
+				DROP()
+			`,
+
+			"/empty-comma.js": `
+				function DROP() {}
+				console.log((DROP(), DROP(), foo()))
+				console.log((DROP(), foo(), DROP()))
+				console.log((foo(), DROP(), DROP()))
+				for (DROP(); DROP(); DROP()) DROP();
+				DROP(), DROP(), foo();
+				DROP(), foo(), DROP();
+				foo(), DROP(), DROP();
+			`,
+
+			"/empty-last.js": `
+				function DROP() { return x }
+				function DROP() { return }
+				console.log(DROP())
+				DROP()
+			`,
+
+			"/empty-cross-module.js": `
+				import { DROP } from './empty-cross-module-def'
+				console.log(DROP())
+				DROP()
+			`,
+
+			"/empty-cross-module-def.js": `
+				export function DROP() {}
+			`,
+
+			"/empty-first.js": `
+				function keep() { return }
+				function keep() { return x }
+				console.log(keep())
+				keep(foo())
+				keep(1)
+			`,
+
+			"/empty-generator.js": `
+				function* keep() {}
+				console.log(keep())
+				keep(foo())
+				keep(1)
+			`,
+
+			"/empty-async.js": `
+				async function keep() {}
+				console.log(keep())
+				keep(foo())
+				keep(1)
+			`,
+
+			"/reassign.js": `
+				function keep() {}
+				keep = reassigned
+				console.log(keep())
+				keep(foo())
+				keep(1)
+			`,
+
+			"/reassign-inc.js": `
+				function keep() {}
+				keep++
+				console.log(keep(1))
+				keep(foo())
+				keep(1)
+			`,
+
+			"/reassign-div.js": `
+				function keep() {}
+				keep /= reassigned
+				console.log(keep(1))
+				keep(foo())
+				keep(1)
+			`,
+
+			"/reassign-array.js": `
+				function keep() {}
+				[keep] = reassigned
+				console.log(keep(1))
+				keep(foo())
+				keep(1)
+			`,
+
+			"/reassign-object.js": `
+				function keep() {}
+				({keep} = reassigned)
+				console.log(keep(1))
+				keep(foo())
+				keep(1)
+			`,
+		},
+		entryPaths: []string{
+			"/empty.js",
+			"/empty-comma.js",
+			"/empty-last.js",
+			"/empty-cross-module.js",
+			"/empty-first.js",
+			"/empty-generator.js",
+			"/empty-async.js",
+			"/reassign.js",
+			"/reassign-inc.js",
+			"/reassign-div.js",
+			"/reassign-array.js",
+			"/reassign-object.js",
 		},
 		options: config.Options{
 			Mode:         config.ModeBundle,

--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -2388,3 +2388,74 @@ func TestInlineEmptyFunctionCalls(t *testing.T) {
 		},
 	})
 }
+
+func TestInlineFunctionCallBehaviorChanges(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				function empty() {}
+				function id(x) { return x }
+
+				export let shouldBeWrapped = [
+					id(foo.bar)(),
+					id(foo[bar])(),
+					id(foo?.bar)(),
+					id(foo?.[bar])(),
+
+					(empty(), foo.bar)(),
+					(empty(), foo[bar])(),
+					(empty(), foo?.bar)(),
+					(empty(), foo?.[bar])(),
+
+					id(eval)(),
+					id(eval)?.(),
+					(empty(), eval)(),
+					(empty(), eval)?.(),
+
+					id(foo.bar)` + "``" + `,
+					id(foo[bar])` + "``" + `,
+					id(foo?.bar)` + "``" + `,
+					id(foo?.[bar])` + "``" + `,
+
+					(empty(), foo.bar)` + "``" + `,
+					(empty(), foo[bar])` + "``" + `,
+					(empty(), foo?.bar)` + "``" + `,
+					(empty(), foo?.[bar])` + "``" + `,
+
+					delete id(foo),
+					delete id(foo.bar),
+					delete id(foo[bar]),
+					delete id(foo?.bar),
+					delete id(foo?.[bar]),
+
+					delete (empty(), foo),
+					delete (empty(), foo.bar),
+					delete (empty(), foo[bar]),
+					delete (empty(), foo?.bar),
+					delete (empty(), foo?.[bar]),
+
+					delete empty(),
+				]
+
+				export let shouldNotBeWrapped = [
+					id(foo)(),
+					(empty(), foo)(),
+
+					id(foo)` + "``" + `,
+					(empty(), foo)` + "``" + `,
+				]
+
+				export let shouldNotBeDoubleWrapped = [
+					delete (empty(), foo(), bar()),
+					delete id((foo(), bar())),
+				]
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModePassThrough,
+			AbsOutputDir: "/out",
+			MangleSyntax: true,
+		},
+	})
+}

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -4354,11 +4354,11 @@ func TestKeepNamesTreeShaking(t *testing.T) {
 			"/entry.js": `
 				function fnStmtRemove() {}
 				function fnStmtKeep() {}
-				fnStmtKeep()
+				x = fnStmtKeep
 
 				let fnExprRemove = function remove() {}
 				let fnExprKeep = function keep() {}
-				fnExprKeep()
+				x = fnExprKeep
 
 				class clsStmtRemove {}
 				class clsStmtKeep {}

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -266,6 +266,122 @@ var import_foo = __toESM(require_foo());
 console.log(import_foo.default);
 
 ================================================================================
+TestInlineEmptyFunctionCalls
+---------- /out/empty.js ----------
+// empty.js
+function DROP() {
+}
+console.log((foo(), bar(), void 0));
+console.log((foo(), 1, void 0));
+console.log((1, foo(), void 0));
+console.log((1, void 0));
+console.log(void 0);
+foo(), bar(), void 0;
+foo(), 1, void 0;
+1, foo(), void 0;
+1, void 0;
+void 0;
+
+---------- /out/empty-comma.js ----------
+// empty-comma.js
+function DROP() {
+}
+console.log((void 0, void 0, foo()));
+console.log((void 0, foo(), void 0));
+console.log((foo(), void 0, void 0));
+for (void 0; void 0; void 0)
+  void 0;
+void 0, void 0, foo();
+void 0, foo(), void 0;
+foo(), void 0, void 0;
+
+---------- /out/empty-last.js ----------
+// empty-last.js
+function DROP() {
+}
+console.log(void 0);
+void 0;
+
+---------- /out/empty-cross-module.js ----------
+// empty-cross-module-def.js
+function DROP() {
+}
+
+// empty-cross-module.js
+console.log(void 0);
+void 0;
+
+---------- /out/empty-first.js ----------
+// empty-first.js
+function keep() {
+  return x;
+}
+console.log(keep());
+keep(foo());
+keep(1);
+
+---------- /out/empty-generator.js ----------
+// empty-generator.js
+function* keep() {
+}
+console.log(keep());
+keep(foo());
+keep(1);
+
+---------- /out/empty-async.js ----------
+// empty-async.js
+async function keep() {
+}
+console.log(keep());
+keep(foo());
+keep(1);
+
+---------- /out/reassign.js ----------
+// reassign.js
+function keep() {
+}
+keep = reassigned;
+console.log(keep());
+keep(foo());
+keep(1);
+
+---------- /out/reassign-inc.js ----------
+// reassign-inc.js
+function keep() {
+}
+keep++;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-div.js ----------
+// reassign-div.js
+function keep() {
+}
+keep /= reassigned;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-array.js ----------
+// reassign-array.js
+function keep() {
+}
+[keep] = reassigned;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-object.js ----------
+// reassign-object.js
+function keep() {
+}
+({ keep } = reassigned);
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+================================================================================
 TestInlineIdentityFunctionCalls
 ---------- /out/identity.js ----------
 // identity.js
@@ -385,14 +501,6 @@ function keep(x) {
   return x;
 }
 ({ keep } = reassigned);
-console.log(keep(1));
-keep(foo());
-keep(1);
-
----------- /out/not-identity-no-args.js ----------
-// not-identity-no-args.js
-function keep() {
-}
 console.log(keep(1));
 keep(foo());
 keep(1);

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -284,9 +284,9 @@ foo();
 // empty-comma.js
 function DROP() {
 }
-console.log((void 0, void 0, foo()));
-console.log((void 0, foo(), void 0));
-console.log((foo(), void 0, void 0));
+console.log(foo());
+console.log((foo(), void 0));
+console.log((foo(), void 0));
 for (; void 0; )
   ;
 foo();

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -269,8 +269,6 @@ console.log(import_foo.default);
 TestInlineEmptyFunctionCalls
 ---------- /out/empty.js ----------
 // empty.js
-function DROP() {
-}
 console.log((foo(), bar(), void 0));
 console.log((foo(), void 0));
 console.log((foo(), void 0));
@@ -282,8 +280,6 @@ foo();
 
 ---------- /out/empty-comma.js ----------
 // empty-comma.js
-function DROP() {
-}
 console.log(foo());
 console.log((foo(), void 0));
 console.log((foo(), void 0));
@@ -295,15 +291,9 @@ foo();
 
 ---------- /out/empty-last.js ----------
 // empty-last.js
-function DROP() {
-}
 console.log(void 0);
 
 ---------- /out/empty-cross-module.js ----------
-// empty-cross-module-def.js
-function DROP() {
-}
-
 // empty-cross-module.js
 console.log(void 0);
 
@@ -431,17 +421,11 @@ export let shouldBeWrapped = [
 TestInlineIdentityFunctionCalls
 ---------- /out/identity.js ----------
 // identity.js
-function DROP(x) {
-  return x;
-}
 console.log(1);
 foo();
 
 ---------- /out/identity-last.js ----------
 // identity-last.js
-function DROP(x) {
-  return x;
-}
 console.log(1);
 foo();
 
@@ -473,11 +457,6 @@ keep(foo());
 keep(1);
 
 ---------- /out/identity-cross-module.js ----------
-// identity-cross-module-def.js
-function DROP(x) {
-  return x;
-}
-
 // identity-cross-module.js
 console.log(1);
 foo();

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -378,6 +378,56 @@ keep(foo());
 keep(1);
 
 ================================================================================
+TestInlineFunctionCallBehaviorChanges
+---------- /out/entry.js ----------
+function empty() {
+}
+function id(x) {
+  return x;
+}
+export let shouldBeWrapped = [
+  (0, foo.bar)(),
+  (0, foo[bar])(),
+  (0, foo?.bar)(),
+  (0, foo?.[bar])(),
+  (0, foo.bar)(),
+  (0, foo[bar])(),
+  (0, foo?.bar)(),
+  (0, foo?.[bar])(),
+  (0, eval)(),
+  (0, eval)?.(),
+  (0, eval)(),
+  (0, eval)?.(),
+  (0, foo.bar)``,
+  (0, foo[bar])``,
+  (0, foo?.bar)``,
+  (0, foo?.[bar])``,
+  (0, foo.bar)``,
+  (0, foo[bar])``,
+  (0, foo?.bar)``,
+  (0, foo?.[bar])``,
+  delete (0, foo),
+  delete (0, foo.bar),
+  delete (0, foo[bar]),
+  delete (0, foo?.bar),
+  delete (0, foo?.[bar]),
+  delete (0, foo),
+  delete (0, foo.bar),
+  delete (0, foo[bar]),
+  delete (0, foo?.bar),
+  delete (0, foo?.[bar]),
+  delete (0, void 0)
+], shouldNotBeWrapped = [
+  foo(),
+  foo(),
+  foo``,
+  foo``
+], shouldNotBeDoubleWrapped = [
+  delete (foo(), bar()),
+  delete (foo(), bar())
+];
+
+================================================================================
 TestInlineIdentityFunctionCalls
 ---------- /out/identity.js ----------
 // identity.js

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -266,6 +266,192 @@ var import_foo = __toESM(require_foo());
 console.log(import_foo.default);
 
 ================================================================================
+TestInlineIdentityFunctionCalls
+---------- /out/identity.js ----------
+// identity.js
+function DROP(x) {
+  return x;
+}
+console.log(1);
+foo();
+1;
+
+---------- /out/identity-last.js ----------
+// identity-last.js
+function DROP(x) {
+  return x;
+}
+console.log(1);
+foo();
+1;
+
+---------- /out/identity-first.js ----------
+// identity-first.js
+function keep(x) {
+  return [x];
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/identity-generator.js ----------
+// identity-generator.js
+function* keep(x) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/identity-async.js ----------
+// identity-async.js
+async function keep(x) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/identity-cross-module.js ----------
+// identity-cross-module-def.js
+function DROP(x) {
+  return x;
+}
+
+// identity-cross-module.js
+console.log(1);
+foo();
+1;
+
+---------- /out/identity-no-args.js ----------
+// identity-no-args.js
+function keep(x) {
+  return x;
+}
+console.log(keep());
+keep();
+
+---------- /out/identity-two-args.js ----------
+// identity-two-args.js
+function keep(x) {
+  return x;
+}
+console.log(keep(1, 2));
+keep(1, 2);
+
+---------- /out/reassign.js ----------
+// reassign.js
+function keep(x) {
+  return x;
+}
+keep = reassigned;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-inc.js ----------
+// reassign-inc.js
+function keep(x) {
+  return x;
+}
+keep++;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-div.js ----------
+// reassign-div.js
+function keep(x) {
+  return x;
+}
+keep /= reassigned;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-array.js ----------
+// reassign-array.js
+function keep(x) {
+  return x;
+}
+[keep] = reassigned;
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/reassign-object.js ----------
+// reassign-object.js
+function keep(x) {
+  return x;
+}
+({ keep } = reassigned);
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-no-args.js ----------
+// not-identity-no-args.js
+function keep() {
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-two-args.js ----------
+// not-identity-two-args.js
+function keep(x, y) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-default.js ----------
+// not-identity-default.js
+function keep(x = foo()) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-array.js ----------
+// not-identity-array.js
+function keep([x]) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-object.js ----------
+// not-identity-object.js
+function keep({ x }) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-rest.js ----------
+// not-identity-rest.js
+function keep(...x) {
+  return x;
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+---------- /out/not-identity-return.js ----------
+// not-identity-return.js
+function keep(x) {
+  return [x];
+}
+console.log(keep(1));
+keep(foo());
+keep(1);
+
+================================================================================
 TestJSONLoaderRemoveUnused
 ---------- /out.js ----------
 // entry.js

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -279,8 +279,6 @@ console.log(void 0);
 foo(), bar();
 foo();
 foo();
-void 0;
-void 0;
 
 ---------- /out/empty-comma.js ----------
 // empty-comma.js
@@ -289,18 +287,17 @@ function DROP() {
 console.log((void 0, void 0, foo()));
 console.log((void 0, foo(), void 0));
 console.log((foo(), void 0, void 0));
-for (void 0; void 0; void 0)
-  void 0;
-void 0, void 0, foo();
-void 0, foo(), void 0;
-foo(), void 0, void 0;
+for (; void 0; )
+  ;
+foo();
+foo();
+foo();
 
 ---------- /out/empty-last.js ----------
 // empty-last.js
 function DROP() {
 }
 console.log(void 0);
-void 0;
 
 ---------- /out/empty-cross-module.js ----------
 // empty-cross-module-def.js
@@ -309,7 +306,6 @@ function DROP() {
 
 // empty-cross-module.js
 console.log(void 0);
-void 0;
 
 ---------- /out/empty-first.js ----------
 // empty-first.js
@@ -390,7 +386,6 @@ function DROP(x) {
 }
 console.log(1);
 foo();
-1;
 
 ---------- /out/identity-last.js ----------
 // identity-last.js
@@ -399,7 +394,6 @@ function DROP(x) {
 }
 console.log(1);
 foo();
-1;
 
 ---------- /out/identity-first.js ----------
 // identity-first.js
@@ -437,7 +431,6 @@ function DROP(x) {
 // identity-cross-module.js
 console.log(1);
 foo();
-1;
 
 ---------- /out/identity-no-args.js ----------
 // identity-no-args.js

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -418,6 +418,17 @@ export let shouldBeWrapped = [
 ];
 
 ================================================================================
+TestInlineFunctionCallForInitDecl
+---------- /out/entry.js ----------
+// entry.js
+for (y = void 0; !1; )
+  ;
+var y;
+for (z = 123; !1; )
+  ;
+var z;
+
+================================================================================
 TestInlineIdentityFunctionCalls
 ---------- /out/identity.js ----------
 // identity.js

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -272,14 +272,14 @@ TestInlineEmptyFunctionCalls
 function DROP() {
 }
 console.log((foo(), bar(), void 0));
-console.log((foo(), 1, void 0));
-console.log((1, foo(), void 0));
-console.log((1, void 0));
+console.log((foo(), void 0));
+console.log((foo(), void 0));
 console.log(void 0);
-foo(), bar(), void 0;
-foo(), 1, void 0;
-1, foo(), void 0;
-1, void 0;
+console.log(void 0);
+foo(), bar();
+foo();
+foo();
+void 0;
 void 0;
 
 ---------- /out/empty-comma.js ----------

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1410,7 +1410,6 @@ TestKeepNamesTreeShaking
 function fnStmtKeep() {
 }
 __name(fnStmtKeep, "fnStmtKeep");
-void 0;
 var fnExprKeep = /* @__PURE__ */ __name(function() {
 }, "keep");
 fnExprKeep();

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1410,9 +1410,10 @@ TestKeepNamesTreeShaking
 function fnStmtKeep() {
 }
 __name(fnStmtKeep, "fnStmtKeep");
+x = fnStmtKeep;
 var fnExprKeep = /* @__PURE__ */ __name(function() {
 }, "keep");
-fnExprKeep();
+x = fnExprKeep;
 var clsStmtKeep = class {
 };
 __name(clsStmtKeep, "clsStmtKeep");

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1410,7 +1410,7 @@ TestKeepNamesTreeShaking
 function fnStmtKeep() {
 }
 __name(fnStmtKeep, "fnStmtKeep");
-fnStmtKeep();
+void 0;
 var fnExprKeep = /* @__PURE__ */ __name(function() {
 }, "keep");
 fnExprKeep();

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1577,6 +1577,10 @@ const (
 	// If this is present, the symbol could potentially be overwritten. This means
 	// it's not safe to make assumptions about this symbol from the initializer.
 	CouldPotentiallyBeMutated
+
+	// This means the symbol is a normal function that takes a single argument
+	// and returns that argument.
+	IsIdentityFunction
 )
 
 func (flags SymbolFlags) Has(flag SymbolFlags) bool {

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1573,6 +1573,10 @@ const (
 	// This flag is to avoid warning about this symbol more than once. It only
 	// applies to the "module" and "exports" unbound symbols.
 	DidWarnAboutCommonJSInESM
+
+	// If this is present, the symbol could potentially be overwritten. This means
+	// it's not safe to make assumptions about this symbol from the initializer.
+	CouldPotentiallyBeMutated
 )
 
 func (flags SymbolFlags) Has(flag SymbolFlags) bool {

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1487,7 +1487,7 @@ const (
 	ImportItemMissing
 )
 
-type SymbolFlags uint8
+type SymbolFlags uint16
 
 const (
 	// Certain symbols must not be renamed or minified. For example, the
@@ -1578,6 +1578,9 @@ const (
 	// it's not safe to make assumptions about this symbol from the initializer.
 	CouldPotentiallyBeMutated
 
+	// This means the symbol is a normal function that has no body statements.
+	IsEmptyFunction
+
 	// This means the symbol is a normal function that takes a single argument
 	// and returns that argument.
 	IsIdentityFunction
@@ -1636,6 +1639,9 @@ type Symbol struct {
 	// slot namespaces: regular symbols, label symbols, and private symbols.
 	NestedScopeSlot ast.Index32
 
+	// Boolean values should all be flags instead to save space
+	Flags SymbolFlags
+
 	Kind SymbolKind
 
 	// We automatically generate import items for property accesses off of
@@ -1656,9 +1662,6 @@ type Symbol struct {
 	// avoid this. We also need to be able to replace such import items with
 	// undefined, which this status is also used for.
 	ImportItemStatus ImportItemStatus
-
-	// Boolean values should all be flags instead to save space
-	Flags SymbolFlags
 }
 
 // You should call "MergeSymbols" instead of calling this directly

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -2218,6 +2218,10 @@ type Part struct {
 	// An estimate of the number of uses of all symbols used within this part.
 	SymbolUses map[Ref]SymbolUse
 
+	// An estimate of the number of uses of all symbols used as the target of
+	// function calls within this part.
+	SymbolCallUses map[Ref]SymbolCallUse
+
 	// This tracks property accesses off of imported symbols. We don't know
 	// during parsing if an imported symbol is going to be an inlined enum
 	// value or not. This is only known during linking. So we defer adding
@@ -2256,6 +2260,11 @@ type DeclaredSymbol struct {
 
 type SymbolUse struct {
 	CountEstimate uint32
+}
+
+type SymbolCallUse struct {
+	CallCountEstimate          uint32
+	SingleArgCallCountEstimate uint32
 }
 
 // Returns the canonical ref that represents the ref for the provided symbol.

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -13569,6 +13569,11 @@ func (p *parser) handleIdentifier(loc logger.Loc, e *js_ast.EIdentifier, opts id
 		return p.valueToSubstituteForRequire(loc)
 	}
 
+	// Mark any mutated symbols as mutable
+	if opts.assignTarget != js_ast.AssignTargetNone {
+		p.symbols[e.Ref.InnerIndex].Flags |= js_ast.CouldPotentiallyBeMutated
+	}
+
 	return js_ast.Expr{Loc: loc, Data: e}
 }
 

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -583,7 +583,7 @@ flatten:
 	if p.options.mangleSyntax {
 		if isNullOrUndefined, sideEffects, ok := toNullOrUndefinedWithSideEffects(expr.Data); ok && isNullOrUndefined {
 			if sideEffects == couldHaveSideEffects {
-				return js_ast.JoinWithComma(p.simplifyUnusedExpr(expr), valueWhenUndefined), exprOut{}
+				return js_ast.JoinWithComma(js_ast.SimplifyUnusedExpr(expr, p.isUnbound), valueWhenUndefined), exprOut{}
 			}
 			return valueWhenUndefined, exprOut{}
 		}

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -2241,7 +2241,7 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags printExprFla
 				}
 				if left.Data != e.Left.Data || right.Data != e.Right.Data {
 					// Pass a flag so we don't needlessly re-simplify the same expression
-					p.printExpr(p.guardAgainstBehaviorChangeDueToSubstitution(js_ast.JoinWithComma(left, e.Right), flags), level, flags|didAlreadySimplifyUnusedExprs)
+					p.printExpr(p.guardAgainstBehaviorChangeDueToSubstitution(js_ast.JoinWithComma(left, right), flags), level, flags|didAlreadySimplifyUnusedExprs)
 					break
 				}
 			} else {
@@ -2333,7 +2333,7 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags printExprFla
 
 		if e.Op == js_ast.BinOpComma {
 			// The result of the right operand of the comma operator is unused if the caller doesn't use it
-			p.printExpr(e.Right, rightLevel, (flags&forbidIn)|(flags&exprResultIsUnused))
+			p.printExpr(e.Right, rightLevel, flags&(forbidIn|exprResultIsUnused))
 		} else {
 			p.printExpr(e.Right, rightLevel, flags&forbidIn)
 		}

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1380,6 +1380,7 @@ func (p *printer) guardAgainstBehaviorChangeDueToSubstitution(expr js_ast.Expr, 
 		// "id(x.y)()" must not become "x.y()"
 		// "id(x.y)``" must not become "x.y``"
 		// "(empty(), x.y)()" must not become "x.y()"
+		// "(empty(), eval)()" must not become "eval()"
 		switch expr.Data.(type) {
 		case *js_ast.EDot, *js_ast.EIndex:
 			wrap = true
@@ -3160,7 +3161,7 @@ func (p *printer) printStmt(stmt js_ast.Stmt, flags printStmtFlags) {
 		p.printSpace()
 		p.print("(")
 		if init.Data != nil {
-			p.printForLoopInit(init, forbidIn|exprResultIsUnused)
+			p.printForLoopInit(init, forbidIn)
 		}
 		p.print(";")
 		p.printSpace()


### PR DESCRIPTION
This release makes esbuild inline two types of no-op functions: empty functions and identity functions. These most commonly arise when most of the function body is eliminated as dead code. In the examples below, this happens because we use `--define:window.DEBUG=false` to cause dead code elimination inside the function body of the resulting `if (false)` statement. This inlining is a small code size and performance win but, more importantly, it allows for people to use these features to add useful abstractions that improve the development experience without needing to worry about the run-time performance impact.

An identity function is a function that just returns its argument. Here's an example of inlining an identity function:

```js
// Original code
function logCalls(fn) {
  if (window.DEBUG) return function(...args) {
    console.log('calling', fn.name, 'with', args)
    return fn.apply(this, args)
  }
  return fn
}
export const foo = logCalls(function foo() {})

// Old output (with --minify --define:window.DEBUG=false --tree-shaking=true)
function o(n){return n}export const foo=o(function(){});

// New output (with --minify --define:window.DEBUG=false --tree-shaking=true)
export const foo=function(){};
```

An empty function is a function with an empty body. Here's an example of inlining an empty function:

```ts
// Original code
function assertNotNull(val: Object | null): asserts val is Object {
  if (window.DEBUG && val === null) throw new Error('null assertion failed');
}
export const val = getFoo();
assertNotNull(val);
console.log(val.bar);

// Old output (with --minify --define:window.DEBUG=false --tree-shaking=true)
function l(o){}export const val=getFoo();l(val);console.log(val.bar);

// New output (with --minify --define:window.DEBUG=false --tree-shaking=true)
export const val=getFoo();console.log(val.bar);
```

To get this behavior you'll need to use the `function` keyword to define your function since that causes the definition to be hoisted, which eliminates concerns around initialization order. These features also work across modules, so functions are still inlined even if the definition of the function is in a separate module from the call to the function. To get cross-module function inlining to work, you'll need to have bundling enabled and use the `import` and `export` keywords to access the function so that esbuild can see which functions are called. And all of this has been added without an observable impact to compile times.

I previously wasn't able to add this to esbuild easily because of esbuild's low-pass compilation approach. The compiler only does three full passes over the data for speed. The passes are roughly for parsing, binding, and printing. It's only possible to inline something after binding but it needs to be inlined before printing. Also the way module linking was done made it difficult to roll back uses of symbols that were inlined, so the symbol definitions were not tree shaken even when they became unused due to inlining.

The linking issue was somewhat resolved when I fixed #128 in the previous release. To implement cross-module inlining of TypeScript enums, I came up with a hack to defer certain symbol uses until the linking phase, which happens after binding but before printing. Another hack is that inlining of TypeScript enums is done directly in the printer to avoid needing another pass.

The possibility of these two hacks has unblocked these simple function inlining use cases that are now handled. This isn't a fully general approach because optimal inlining is recursive. Inlining something may open up further inlining opportunities, which either requires multiple iterations or a worklist algorithm, both of which don't work when doing late-stage inlining in the printer. But the function inlining that esbuild now implements is still useful even though it's one level deep, and so I believe it's still worth adding.

Fixes #290
Fixes #907
