### PR TITLE
feat(wasm): use instantiateStreaming as much as possible

### DIFF
--- a/lib/npm/browser.ts
+++ b/lib/npm/browser.ts
@@ -104,7 +104,13 @@ const startRunningService = async (wasmURL: string, useWorker: boolean): Promise
     }
   }
 
-  worker.onmessage = ({ data }) => readFromStdout(data)
+  worker.onmessage = ({ data }) => {
+    if (data.type === 'done') {
+      worker.onmessage = ({ data }) => readFromStdout(data)
+      return
+    }
+    throw new Error(data?.error ?? 'Failed to compile wasm code')
+  }
 
   let { readFromStdout, service } = common.createChannel({
     writeToStdin(bytes) {

--- a/lib/npm/worker.ts
+++ b/lib/npm/worker.ts
@@ -1,65 +1,81 @@
 // This file is part of the web worker source code
 
 declare const ESBUILD_VERSION: string;
-declare function postMessage(message: any): void;
 
-onmessage = ({ data: wasm }) => {
-  let decoder = new TextDecoder()
-  let fs = (global as any).fs
+async function loadWasm(
+  url: string,
+  importObject?: WebAssembly.Imports
+): Promise<WebAssembly.WebAssemblyInstantiatedSource> {
+  const response = await fetch(url)
+  if (!response.ok)
+    throw new Error(`Failed to download ${JSON.stringify(url)}`)
 
-  let stderr = ''
-  fs.writeSync = (fd: number, buffer: Uint8Array) => {
-    if (fd === 1) {
-      postMessage(buffer)
-    } else if (fd === 2) {
-      stderr += decoder.decode(buffer)
-      let parts = stderr.split('\n')
-      if (parts.length > 1) console.log(parts.slice(0, -1).join('\n'))
-      stderr = parts[parts.length - 1]
-    } else {
-      throw new Error('Bad write')
-    }
-    return buffer.length
+  const mimeType = response.headers.get("Content-Type") ?? ""; // case-insensitive
+  // wasm mime type header is required for instantiateStreaming api
+  // https://www.w3.org/TR/wasm-web-api-1/#streaming-modules
+  const isWasmMime = mimeType.includes("application/wasm")
+  if (typeof WebAssembly.instantiateStreaming === "function" && isWasmMime) {
+    return WebAssembly.instantiateStreaming(response, importObject)
+  } else {
+    return WebAssembly.instantiate(await response.arrayBuffer(), importObject)
   }
-
-  let stdin: Uint8Array[] = []
-  let resumeStdin: () => void
-  let stdinPos = 0
-
-  onmessage = ({ data }) => {
-    if (data.length > 0) {
-      stdin.push(data)
-      if (resumeStdin) resumeStdin()
-    }
-  }
-
-  fs.read = (
-    fd: number, buffer: Uint8Array, offset: number, length: number,
-    position: null, callback: (err: Error | null, count?: number) => void,
-  ) => {
-    if (fd !== 0 || offset !== 0 || length !== buffer.length || position !== null) {
-      throw new Error('Bad read')
-    }
-
-    if (stdin.length === 0) {
-      resumeStdin = () => fs.read(fd, buffer, offset, length, position, callback)
-      return
-    }
-
-    let first = stdin[0]
-    let count = Math.max(0, Math.min(length, first.length - stdinPos))
-    buffer.set(first.subarray(stdinPos, stdinPos + count), offset)
-    stdinPos += count
-    if (stdinPos === first.length) {
-      stdin.shift()
-      stdinPos = 0
-    }
-    callback(null, count)
-  }
-
-  let go = new (global as any).Go()
-  go.argv = ['', `--service=${ESBUILD_VERSION}`]
-
-  WebAssembly.instantiate(wasm, go.importObject)
-    .then(({ instance }) => go.run(instance))
 }
+
+let decoder = new TextDecoder()
+let fs = (global as any).fs
+
+let stderr = ''
+fs.writeSync = (fd: number, buffer: Uint8Array) => {
+  if (fd === 1) {
+    postMessage(buffer)
+  } else if (fd === 2) {
+    stderr += decoder.decode(buffer)
+    let parts = stderr.split('\n')
+    if (parts.length > 1) console.log(parts.slice(0, -1).join('\n'))
+    stderr = parts[parts.length - 1]
+  } else {
+    throw new Error('Bad write')
+  }
+  return buffer.length
+}
+
+let stdin: Uint8Array[] = []
+let resumeStdin: () => void
+let stdinPos = 0
+
+onmessage = ({ data }) => {
+  if (data.length > 0) {
+    stdin.push(data)
+    if (resumeStdin) resumeStdin()
+  }
+}
+
+fs.read = (
+  fd: number, buffer: Uint8Array, offset: number, length: number,
+  position: null, callback: (err: Error | null, count?: number) => void,
+) => {
+  if (fd !== 0 || offset !== 0 || length !== buffer.length || position !== null) {
+    throw new Error('Bad read')
+  }
+
+  if (stdin.length === 0) {
+    resumeStdin = () => fs.read(fd, buffer, offset, length, position, callback)
+    return
+  }
+
+  let first = stdin[0]
+  let count = Math.max(0, Math.min(length, first.length - stdinPos))
+  buffer.set(first.subarray(stdinPos, stdinPos + count), offset)
+  stdinPos += count
+  if (stdinPos === first.length) {
+    stdin.shift()
+    stdinPos = 0
+  }
+  callback(null, count)
+}
+
+let go = new (global as any).Go()
+go.argv = ['', `--service=${ESBUILD_VERSION}`]
+
+loadWasm((global as any).WASM_URL, go.importObject)
+  .then(({ instance }) => go.run(instance))

--- a/lib/npm/worker.ts
+++ b/lib/npm/worker.ts
@@ -78,4 +78,8 @@ let go = new (global as any).Go()
 go.argv = ['', `--service=${ESBUILD_VERSION}`]
 
 loadWasm((global as any).WASM_URL, go.importObject)
-  .then(({ instance }) => go.run(instance))
+  .then(async ({ instance }) => {
+    postMessage({ type: 'done' })
+    return go.run(instance)
+  })
+  .catch(err => postMessage({ type: 'error', error: err?.message ?? err }))

--- a/scripts/browser/browser-tests.js
+++ b/scripts/browser/browser-tests.js
@@ -284,6 +284,10 @@ async function main() {
   async function runPage(key) {
     try {
       const page = await browser.newPage()
+      page.on('pageerror', error => {
+        console.error(`❌ page error: ${error?.message ?? error}`)
+        allTestsPassed = false
+      })
       page.on('console', obj => console.log(`[console.${obj.type()}] ${obj.text()}`))
       page.exposeFunction('testFail', error => {
         console.log(`❌ ${error}`)


### PR DESCRIPTION
This PR aims to optimize `esbuild-wasm` loading process.

## Changes
  1. load wasm file in ~~main~~ worker thread
      - absolute path is required for resource fetching in worker thread. PR has covered scenario that wasmURL is a related path.
      - correct mime header is required. Otherwise, fallback to `instantiate` API.
  1. handle wasm loading errors and push them back to the main thread.
  1. ~~only use `WebAssembly.instantiate` to instantiate wasm code.~~ use `WebAssembly.instantiateStreaming` API by default. It will use `WebAssembly.instantiate` again if current browser doesn't support `instantiateStreaming`.
