### PR TITLE
types: more `build` overload definitions

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -449,7 +449,9 @@ export interface AnalyzeMetafileOptions {
  * Documentation: https://esbuild.github.io/api/#build-api
  */
 export declare function build(options: BuildOptions & { write: false }): Promise<BuildResult & { outputFiles: OutputFile[] }>;
+export declare function build(options: BuildOptions & { incremental: true, metafile: true }): Promise<BuildIncremental & { metafile: Metafile }>;
 export declare function build(options: BuildOptions & { incremental: true }): Promise<BuildIncremental>;
+export declare function build(options: BuildOptions & { metafile: true }): Promise<BuildResult & { metafile: Metafile }>;
 export declare function build(options: BuildOptions): Promise<BuildResult>;
 
 /**

--- a/scripts/ts-type-tests.js
+++ b/scripts/ts-type-tests.js
@@ -60,6 +60,21 @@ const tests = {
       result.rebuild.dispose()
     }
   `,
+  metafileTrue: `
+    import {build, analyzeMetafile} from 'esbuild';
+    build({ metafile: true }).then(result => {
+      analyzeMetafile(result.metafile)
+    })
+  `,
+  incrementalAndMetafileTrue: `
+    import {build, analyzeMetafile} from 'esbuild';
+    build({
+      incremental: true,
+      metafile: true,
+    }).then(result => {
+      analyzeMetafile(result.metafile)
+    })
+  `,
   ifRebuild: `
     import * as esbuild from 'esbuild'
     let options: any


### PR DESCRIPTION
Add overloads for `build` so when `metafile: true` is passed, resulting `.metafile` property is not optional anymore.

Similar to #561.