### PR TITLE
Fix a mention of "EImportString" from "EImportCall"

### DIFF
--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -711,7 +711,7 @@ type EImportCall struct {
 	Expr         Expr
 	OptionsOrNil Expr
 
-	// See the comment for this same field on "EImportCall" for more information
+	// See the comment for this same field on "EImportString" for more information
 	LeadingInteriorComments []Comment
 }
 


### PR DESCRIPTION
Before, the comment on `LeadingInteriorComments` from "EImportCall" was referring to itself.