### PR TITLE
Remove extra `len(b.Properties) > 0` check

### DIFF
--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -770,7 +770,8 @@ func (p *printer) printBinding(binding js_ast.Binding) {
 				p.options.Indent--
 				p.printNewline()
 				p.printIndent()
-			} else if len(b.Properties) > 0 {
+				// This block is only reached if len(b.Properties) > 0
+			} else {
 				p.printSpace()
 			}
 		}


### PR DESCRIPTION
While debugging a printing bug in bun and using esbuild's printer as a reference, I noticed an extra `len(b.Properties) > 0` check in `js_printer.go`

https://github.com/evanw/esbuild/blob/b26003f9bc3d530bd47a9a95695a4041c58afe10/internal/js_printer/js_printer.go#L773-L776

Since `b.Properties` is not modified and the containing scope checks `len(b.Properties) > 0`:

https://github.com/evanw/esbuild/blob/b26003f9bc3d530bd47a9a95695a4041c58afe10/internal/js_printer/js_printer.go#L683-L687

It should be fine to replace the `else if` with `else`

Note: I did not run this code