### PR TITLE
disable Go compiler optimization for riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ GO_FLAGS += "-ldflags=-s -w"
 # Avoid embedding the build path in the executable for more reproducible builds
 GO_FLAGS += -trimpath
 
+# Temporary workaround for golang/go#51101 before Go 1.18/1.17.8 is released
+ifeq ($(GOARCH), riscv64)
+	GO_FLAGS += "-gcflags=all=-N -l"
+endif
+
 esbuild: cmd/esbuild/version.go cmd/esbuild/*.go pkg/*/*.go internal/*/*.go go.mod
 	CGO_ENABLED=0 go build $(GO_FLAGS) ./cmd/esbuild
 


### PR DESCRIPTION
This PR adds a temporary workaround for golang/go#51101 and can be reverted as soon as Go 1.18 or 1.17.8 is released.