### PR TITLE
Rewrite `require()` calls of Node built-ins to import statements when emitting ESM for Node

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -181,6 +181,12 @@ func parseFile(args parseArgs) {
 		}
 	}()
 
+	// When building for Node, we mark all Node built-in modules as safe to rewrite
+	// as import statements if needed.
+	if args.options.Platform == config.PlatformNode {
+		args.options.RewriteRequireForPaths = resolver.BuiltInNodeModules
+	}
+
 	switch loader {
 	case config.LoaderJS:
 		ast, ok := args.caches.JSCache.Parse(args.log, source, js_parser.OptionsFromConfig(&args.options))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,6 +287,8 @@ type Options struct {
 	NeedsMetafile           bool
 	SourceMap               SourceMap
 	ExcludeSourcesContent   bool
+
+	RewriteRequireForPaths map[string]bool
 }
 
 type TargetFromAPI uint8

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -4706,6 +4706,25 @@ ${path.relative(process.cwd(), input).replace(/\\/g, '/')}:1:2: ERROR: Unexpecte
    └ entry.js ── 25b ─── 25.0%
 `)
   },
+
+  async rewriteRequireToImport({ esbuild, testDir }) {
+    const outfile = path.join(testDir, 'out.mjs');
+    await esbuild.build({
+      stdin: {
+        contents: `const { extname } = require("path"); export { extname };`,
+      },
+      bundle: true,
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      outfile
+    })
+
+    // This needs to use relative paths to avoid breaking on Windows.
+    // Importing by absolute path doesn't work on Windows in node.
+    const result = await import('./' + path.relative(__dirname, outfile))
+    assert.strictEqual(result.extname('one.ts'), '.ts')
+  },
 }
 
 async function assertSourceMap(jsSourceMap, source) {


### PR DESCRIPTION
When outputting ESM, any `require` calls will be replaced with the `__require` shim, since `require` will not be available. However, since external paths will not be bundled, they will generate a runtime error.

This is particularly problematic when targeting Node, since any Node built-in modules are automatically marked as external and therefore requiring them will fail. This is described in https://github.com/evanw/esbuild/issues/1921.

That case is addressed in this PR. When targeting Node, any `require` calls for Node built-ins will be replaced by import statements, since we know those are available.

## Example

Take the example below:

```js
const { extname } = require("path");

console.log(extname("one.ts"));
```

And the following command to bundle it with esbuild:

```sh
esbuild --format=esm --bundle --platform=node --outfile=out.mjs
```

### Before 🔴 

Without this PR, esbuild produces the following bundle:

```js
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
}) : x)(function(x) {
  if (typeof require !== "undefined")
    return require.apply(this, arguments);
  throw new Error('Dynamic require of "' + x + '" is not supported');
});

// ../../tests/esbuild-issue/index.js
var { extname } = __require("path");
console.log(extname("example.js"));
```

Running the bundle generates a runtime error:

```sh
$ node out.mjs
file:///Users/eduardoboucas/Sites/evanw/esbuild/test-out/index.mjs:6
  throw new Error('Dynamic require of "' + x + '" is not supported');
        ^

Error: Dynamic require of "path" is not supported
    at file:///Users/eduardoboucas/Sites/evanw/esbuild/test-out/index.mjs:6:9
    at file:///Users/eduardoboucas/Sites/evanw/esbuild/test-out/index.mjs:10:19
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```

### After ✅ 

With this PR, esbuild produces the following bundle:

```js
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
}) : x)(function(x) {
  if (typeof require !== "undefined")
    return require.apply(this, arguments);
  throw new Error('Dynamic require of "' + x + '" is not supported');
});

// ../../tests/esbuild-issue/index.js
var { extname } = import_path;
console.log(extname("example.js"));
import import_path from "path";
```

And running the bundle produces the expected output:

```sh
$ node out.mjs
.js
```

## Notes

This issue impacted Netlify customers, as reported in https://github.com/netlify/zip-it-and-ship-it/issues/1036. We would love to contribute a fix back to esbuild, and we'll be happy to accommodate any feedback from @evanw and the esbuild community into our PR.

If the maintainers decide against merging this functionality, we'll probably add it to [our esbuild fork](https://github.com/netlify/esbuild) (which you can read about [here](https://github.com/netlify/esbuild/blob/netlify/NETLIFY.md)). For this reason, I've tried to reduce the surface area of the changes to the absolute minimum, which reflects in a couple of implementation details:

1. Passing the list of Node built-in modules from the bundler to the parser feels a bit awkward. This is due to the fact that importing the resolver from the parser would lead to an import cycle. To avoid moving the list of Node built-ins to its own package and include from the resolver and the parser, I'm passing the list into the parser.

2. The `__require` runtime shim is not being dead-code-eliminated when it's not used, as shown in the example above. We can address this in different ways, depending on what the maintainers decide to do with this PR.