### PR TITLE
fix #2070: ignore `export as namespace`

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -5952,7 +5952,7 @@ func (p *parser) parseStmt(opts parseStmtOpts) js_ast.Stmt {
 				return p.parseStmt(opts)
 			}
 
-			if opts.isTypeScriptDeclare && p.lexer.IsContextualKeyword("as") {
+			if p.lexer.IsContextualKeyword("as") {
 				// "export as namespace ns;"
 				p.lexer.Next()
 				p.lexer.ExpectContextualKeyword("namespace")

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -721,6 +721,11 @@ async function foo() {
 }
 
 func TestTSNamespaceExports(t *testing.T) {
+	expectPrintedTS(t, "export as namespace ns", "")
+	expectPrintedTS(t, "export as namespace ns;", "")
+	expectParseErrorTS(t, "export as namespace ns.foo", "<stdin>: ERROR: Expected \";\" but found \".\"\n")
+	expectParseErrorTS(t, "export as namespace ns function foo() {}", "<stdin>: ERROR: Expected \";\" but found \"function\"\n")
+
 	expectPrintedTS(t, `
 		namespace A {
 			export namespace B {


### PR DESCRIPTION
- fix #2070 