### PR TITLE
avoid var declaration overwritten

### DIFF
--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1482,10 +1482,11 @@ type Scope struct {
 	// This will be non-nil if this is a TypeScript "namespace" or "enum"
 	TSNamespace *TSNamespaceScope
 
-	Parent    *Scope
-	Children  []*Scope
-	Members   map[string]ScopeMember
-	Generated []Ref
+	Parent     *Scope
+	Children   []*Scope
+	Members    map[string]ScopeMember
+	HoistFnRef map[string]*Ref
+	Generated  []Ref
 
 	// The location of the "use strict" directive for ExplicitStrictMode
 	UseStrictLoc logger.Loc

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -1357,8 +1357,10 @@ func TestFunction(t *testing.T) {
 	expectPrintedMangle(t, "function f() {} var f", "function f() {\n}\nvar f;\n")
 	expectPrintedMangle(t, "var f; function f() { x() } function f() { y() }", "var f;\nfunction f() {\n  y();\n}\n")
 	expectPrintedMangle(t, "function f() { x() } function f() { y() } var f", "function f() {\n  y();\n}\nvar f;\n")
-	expectPrintedMangle(t, "function f() { x() } var f; function f() { y() }", "function f() {\n  x();\n}\nvar f;\nfunction f() {\n  y();\n}\n")
+	expectPrintedMangle(t, "function f() { x() } var f; function f() { y() }", "var f;\nfunction f() {\n  y();\n}\n")
 	expectPrintedMangle(t, "export function f() { x() } function f() { y() }", "export function f() {\n  x();\n}\nfunction f() {\n  y();\n}\n")
+
+	expectPrintedMangle(t, "var x = x || {}; console.log(x); var x = x || {};", "var x = x || {};\nconsole.log(x);\nvar x = x || {};\n")
 }
 
 func TestClass(t *testing.T) {


### PR DESCRIPTION
- fix #2080 regression introduced in 4fa3d7a

For the following input code

```javascript
console.log(1, f);

function f() {
  x();
}

console.log(2, f);

var f = 1;

console.log(3, f);

function f() {
  y();
}

console.log(4, f);

var f = 2;

console.log(5, f);

```

The following output will be generated

```
1 ƒ f() {
  y();
}
2 ƒ f() {
  y();
}
3 1
4 1
5 2
```

This means that input is equivalent to the following code

```javascript
var f;
function f() {
  x();
}
function f() {
  y();
}

console.log(1, f);
console.log(2, f);

f = 1;

console.log(3, f);
console.log(4, f);

f = 2;

console.log(5, f);
```


Functions can always be safely overwritten, whereas var declaration is not.

This PR tries to preserve the var declaration.