### PR TITLE
feat:  buildBinary according to node_env with gops arg

### DIFF
--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -294,7 +294,11 @@ exports.writeFileAtomic = (where, contents) => {
 }
 
 exports.buildBinary = () => {
-  childProcess.execFileSync('go', ['build', '-ldflags=-s -w', './cmd/esbuild'], { cwd: repoDir, stdio: 'ignore' })
+  let args = '-ldflags=-s -w';
+  if (String(process.env.NODE_ENV).toLocaleLowerCase() == "development") {
+    args = '-gcflags="all=-N -l"';
+  }
+  childProcess.execFileSync('go', ['build', args, './cmd/esbuild'], { cwd: repoDir, stdio: 'ignore' })
   return path.join(repoDir, process.platform === 'win32' ? 'esbuild.exe' : 'esbuild')
 }
 


### PR DESCRIPTION
When I wanted to develop esbuild, I found that the byte file did not carry args to debugging. There was no way to debug on an IDE such as vscode or goland. All the args to 'go build' were modified according to the NodeJs environment variables.