### PR TITLE
add `wasmModule` option to `initialize` JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,33 @@
     };
     ```
 
+* Add the `wasmModule` option to the `initialize` JS API ([#1093](https://github.com/evanw/esbuild/issues/1093))
+
+    The `initialize` JS API must be called when using esbuild in the browser to provide the WebAssembly module for esbuild to use. Previously the only way to do that was using the `wasmURL` API option like this:
+
+    ```js
+    await esbuild.initialize({
+      wasmURL: '/node_modules/esbuild-wasm/esbuild.wasm',
+    })
+    console.log(await esbuild.transform('1+2'))
+    ```
+
+    With this release, you can now also initialize esbuild using a `WebAssembly.Module` instance using the `wasmModule` API option instead. The example above is equivalent to the following code:
+
+    ```js
+    await esbuild.initialize({
+      wasmModule: await fetch('/node_modules/esbuild-wasm/esbuild.wasm')
+        .then(r => {
+          if (!r.ok) throw new Error('Failed to download "/node_modules/esbuild-wasm/esbuild.wasm"')
+          return r.arrayBuffer()
+        })
+        .then(ab => new WebAssembly.Module(ab)),
+    })
+    console.log(await esbuild.transform('1+2'))
+    ```
+
+    This could be useful for environments where you want more control over how the WebAssembly download happens or where downloading the WebAssembly module is not possible.
+
 ## 0.14.31
 
 * Add support for parsing "optional variance annotations" from TypeScript 4.7 ([#2102](https://github.com/evanw/esbuild/pull/2102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,12 +116,7 @@
 
     ```js
     await esbuild.initialize({
-      wasmModule: await fetch('/node_modules/esbuild-wasm/esbuild.wasm')
-        .then(r => {
-          if (!r.ok) throw new Error('Failed to download "/node_modules/esbuild-wasm/esbuild.wasm"')
-          return r.arrayBuffer()
-        })
-        .then(ab => new WebAssembly.Module(ab)),
+      wasmModule: await WebAssembly.compileStreaming(fetch('/node_modules/esbuild-wasm/esbuild.wasm'))
     })
     console.log(await esbuild.transform('1+2'))
     ```

--- a/lib/npm/worker.ts
+++ b/lib/npm/worker.ts
@@ -1,5 +1,11 @@
 // This file is part of the web worker source code
 
+interface Go {
+  argv: string[]
+  importObject: WebAssembly.Imports
+  run(instance: WebAssembly.Instance): void
+}
+
 declare const ESBUILD_VERSION: string;
 declare function postMessage(message: any): void;
 
@@ -57,11 +63,12 @@ onmessage = ({ data: wasm }: { data: ArrayBuffer | WebAssembly.Module }) => {
     callback(null, count)
   }
 
-  let go = new (globalThis as any).Go()
+  let go: Go = new (globalThis as any).Go()
   go.argv = ['', `--service=${ESBUILD_VERSION}`]
 
   if (wasm instanceof WebAssembly.Module) {
-    go.run(new WebAssembly.Instance(wasm, go.importObject))
+    WebAssembly.instantiate(wasm, go.importObject)
+      .then(instance => go.run(instance))
   } else {
     WebAssembly.instantiate(wasm, go.importObject)
       .then(({ instance }) => go.run(instance))

--- a/lib/npm/worker.ts
+++ b/lib/npm/worker.ts
@@ -3,7 +3,7 @@
 declare const ESBUILD_VERSION: string;
 declare function postMessage(message: any): void;
 
-onmessage = ({ data: wasm }) => {
+onmessage = ({ data: wasm }: { data: ArrayBuffer | WebAssembly.Module }) => {
   let decoder = new TextDecoder()
   let fs = (globalThis as any).fs
 
@@ -60,6 +60,10 @@ onmessage = ({ data: wasm }) => {
   let go = new (globalThis as any).Go()
   go.argv = ['', `--service=${ESBUILD_VERSION}`]
 
-  WebAssembly.instantiate(wasm, go.importObject)
-    .then(({ instance }) => go.run(instance))
+  if (wasm instanceof WebAssembly.Module) {
+    go.run(new WebAssembly.Instance(wasm, go.importObject))
+  } else {
+    WebAssembly.instantiate(wasm, go.importObject)
+      .then(({ instance }) => go.run(instance))
+  }
 }

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -35,6 +35,9 @@ let mustBeArray = <T>(value: T[] | undefined): string | null =>
 let mustBeObject = (value: Object | undefined): string | null =>
   typeof value === 'object' && value !== null && !Array.isArray(value) ? null : 'an object';
 
+let mustBeWebAssemblyModule = (value: WebAssembly.Module | undefined): string | null =>
+  value instanceof WebAssembly.Module ? null : 'a WebAssembly.Module';
+
 let mustBeArrayOrRecord = <T extends string>(value: T[] | Record<T, T> | undefined): string | null =>
   typeof value === 'object' && value !== null ? null : 'an array or an object';
 
@@ -75,10 +78,12 @@ function checkForInvalidFlags(object: Object, keys: OptionKeys, where: string): 
 export function validateInitializeOptions(options: types.InitializeOptions): types.InitializeOptions {
   let keys: OptionKeys = Object.create(null);
   let wasmURL = getFlag(options, keys, 'wasmURL', mustBeString);
+  let wasmModule = getFlag(options, keys, 'wasmModule', mustBeWebAssemblyModule);
   let worker = getFlag(options, keys, 'worker', mustBeBoolean);
-  checkForInvalidFlags(options, keys, 'in startService() call');
+  checkForInvalidFlags(options, keys, 'in initialize() call');
   return {
     wasmURL,
+    wasmModule,
     worker,
   };
 }

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -572,6 +572,16 @@ export interface InitializeOptions {
   wasmURL?: string
 
   /**
+   * The result of calling "new WebAssembly.Module(buffer)" where "buffer"
+   * is a typed array or ArrayBuffer containing the binary code of the
+   * "esbuild.wasm" file.
+   *
+   * You can use this as an alternative to "wasmURL" for environments where it's
+   * not possible to download the WebAssembly module.
+   */
+  wasmModule?: WebAssembly.Module
+
+  /**
    * By default esbuild runs the WebAssembly-based browser API in a web worker
    * to avoid blocking the UI thread. This can be disabled by setting "worker"
    * to false.

--- a/scripts/browser/browser-tests.js
+++ b/scripts/browser/browser-tests.js
@@ -195,15 +195,10 @@ for (let format of ['iife', 'esm']) {
                   wasmURL: '/esbuild.wasm',
                   worker: ${worker},
                 })
-              : fetch('/esbuild.wasm')
-                  .then(r => {
-                    if (!r.ok) throw new Error('Failed to download "/esbuild.wasm"')
-                    return r.arrayBuffer()
-                  })
-                  .then(ab => esbuild.initialize({
-                    wasmModule: new WebAssembly.Module(ab),
-                    worker: ${worker},
-                  }))
+              : esbuild.initialize({
+                  wasmModule: await WebAssembly.compileStreaming(fetch('/esbuild.wasm')),
+                  worker: ${worker},
+                })
             promise.then(() => {
               return (${runAllTests})({ esbuild })
             }).then(() => {

--- a/scripts/browser/browser-tests.js
+++ b/scripts/browser/browser-tests.js
@@ -195,10 +195,10 @@ for (let format of ['iife', 'esm']) {
                   wasmURL: '/esbuild.wasm',
                   worker: ${worker},
                 })
-              : esbuild.initialize({
-                  wasmModule: await WebAssembly.compileStreaming(fetch('/esbuild.wasm')),
+              : WebAssembly.compileStreaming(fetch('/esbuild.wasm')).then(module => esbuild.initialize({
+                  wasmModule: module,
                   worker: ${worker},
-                })
+                }))
             promise.then(() => {
               return (${runAllTests})({ esbuild })
             }).then(() => {

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -144,7 +144,7 @@ exports.buildWasmLib = async (esbuildPath) => {
           for (let k of Object.getOwnPropertyNames(o))
             if (!(k in globalThis))
               Object.defineProperty(globalThis, k, { get: () => self[k] });
-        ${wasm_exec_js}
+        ${wasm_exec_js.replace(/\bfs\./g, 'globalThis.fs.')}
         ${fs.readFileSync(path.join(repoDir, 'lib', 'npm', 'worker.ts'), 'utf8')}
         return m => onmessage(m)
       `;


### PR DESCRIPTION
The `initialize` JS API must be called when using esbuild in the browser to provide the WebAssembly module for esbuild to use. Previously the only way to do that was using the `wasmURL` API option like this:

```js
await esbuild.initialize({
  wasmURL: '/node_modules/esbuild-wasm/esbuild.wasm',
})
console.log(await esbuild.transform('1+2'))
```

With this PR, you can now also initialize esbuild using a `WebAssembly.Module` instance using the `wasmModule` API option instead. The example above is equivalent to the following code:

```js
await esbuild.initialize({
  wasmModule: await WebAssembly.compileStreaming(fetch('/node_modules/esbuild-wasm/esbuild.wasm'))
})
console.log(await esbuild.transform('1+2'))
```

This could be useful for environments where you want more control over how the WebAssembly download happens or where downloading the WebAssembly module is not possible.

Fixes #1093
