### PR TITLE
Add fast-path for ASCII characters

### DIFF
--- a/internal/css_lexer/css_lexer.go
+++ b/internal/css_lexer/css_lexer.go
@@ -232,7 +232,17 @@ func Tokenize(log logger.Log, source logger.Source) TokenizeResult {
 }
 
 func (lexer *lexer) step() {
-	codePoint, width := utf8.DecodeRuneInString(lexer.source.Contents[lexer.current:])
+	if lexer.current >= len(lexer.source.Contents) {
+		lexer.codePoint = eof
+		lexer.Token.Range.Len = int32(lexer.current) - lexer.Token.Range.Loc.Start
+		return
+	}
+	// Add fast-path for ASCII runes.
+	codePoint, width := rune(lexer.source.Contents[lexer.current]), 1
+
+	if codePoint >= utf8.RuneSelf {
+		codePoint, width = utf8.DecodeRuneInString(lexer.source.Contents[lexer.current:])
+	}
 
 	// Use -1 to indicate the end of the file
 	if width == 0 {

--- a/internal/js_lexer/js_lexer.go
+++ b/internal/js_lexer/js_lexer.go
@@ -2598,7 +2598,17 @@ func (lexer *Lexer) RescanCloseBraceAsTemplateToken() {
 }
 
 func (lexer *Lexer) step() {
-	codePoint, width := utf8.DecodeRuneInString(lexer.source.Contents[lexer.current:])
+	if lexer.current >= len(lexer.source.Contents) {
+		lexer.codePoint = -1
+		lexer.end = lexer.current
+		return
+	}
+	// Fast-path for ASCII-runes.
+	codePoint, width := rune(lexer.source.Contents[lexer.current]), 1
+
+	if codePoint >= utf8.RuneSelf {
+		codePoint, width = utf8.DecodeRuneInString(lexer.source.Contents[lexer.current:])
+	}
 
 	// Use -1 to indicate the end of the file
 	if width == 0 {


### PR DESCRIPTION
- Don't always rely on the `utf8` package to decode the next codepoint. First try to use normal `rune` conversion to see if it's a ASCII codepoint(they don't need `utf8` decoding). Otherwise fallback to the "slower" decoding of `utf8`.
- I'm not sure where the benchmarks of ESBuild can be run, but on my personal projects I've see good performance improvements in the lexing process.