### PR TITLE
fix #2247: add `top-level-await` compat for opera

### DIFF
--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -497,6 +497,7 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		ES:      {{start: v{2022, 0, 0}}},
 		Firefox: {{start: v{89, 0, 0}}},
 		Node:    {{start: v{14, 8, 0}}},
+		Opera:   {{start: v{75, 0, 0}}},
 		Safari:  {{start: v{15, 0, 0}}},
 	},
 	TypeofExoticObjectIsObject: {

--- a/scripts/compat-table.js
+++ b/scripts/compat-table.js
@@ -199,6 +199,7 @@ mergeVersions('TopLevelAwait', {
   edge89: true,
   firefox89: true,
   node14_8: true,
+  opera75: true,
   safari15: true,
 })
 


### PR DESCRIPTION
close #2247, details in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility) and [caniuse.com](https://caniuse.com/mdn-javascript_operators_await_top_level)