### PR TITLE
fix: not throw error under `watch` mode

### DIFF
--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1199,7 +1199,7 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       };
       copyResponseToResult(response!, result);
       runOnEndCallbacks(result, logPluginError, () => {
-        if (result.errors.length > 0) {
+        if (result.errors.length > 0 && !watch) {
           return callback(failureErrorWithLog('Build failed', result.errors, result.warnings), null);
         }
 


### PR DESCRIPTION
- #2280 

In `watch` mode, if the initial content had illegal content, esbuild would throw error and exit. However if user brougt syntax error after, esbuild just notify the error, the process still going, user just change back to correct code, doesn't need to restart process.
So I propose under `watch` mode, esbuild not throw error.