### PR TITLE
Fix arrow function lowering failing to emit var _this decl

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -11750,7 +11750,9 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 		// Capture "this" inside arrow functions that will be lowered into normal
 		// function expressions for older language environments
 		if p.fnOrArrowDataVisit.isArrow && p.options.unsupportedJSFeatures.Has(compat.Arrow) && p.fnOnlyDataVisit.isThisNested {
-			return js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EIdentifier{Ref: p.captureThis()}}, exprOut{}
+			ref := p.captureThis()
+			p.recordUsage(ref)
+			return js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EIdentifier{Ref: ref}}, exprOut{}
 		}
 
 	case *js_ast.EImportMeta:

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -33,6 +33,11 @@ func TestLowerFunctionArgumentScope(t *testing.T) {
 	}
 }
 
+func TestLowerArrowFunction(t *testing.T) {
+	expectPrintedTarget(t, 5, "function foo(a) { arr.forEach(e=>this.foo(e)) }",
+		"function foo(a) {\n  var _this = this;\n  arr.forEach(function(e) {\n    return _this.foo(e);\n  });\n}\n")
+}
+
 func TestLowerNullishCoalescing(t *testing.T) {
 	expectParseError(t, "a ?? b && c", "<stdin>: ERROR: Unexpected \"&&\"\n")
 	expectParseError(t, "a ?? b || c", "<stdin>: ERROR: Unexpected \"||\"\n")


### PR DESCRIPTION
Fixes issue where the synthetic _this variable was being dropped, so that:
```
function foo(a) { 
  arr.forEach(e=>this.foo(e));
}
```
was incorrectly lowered to the nonfunctional code:
```
function foo(a) {
  arr.forEach(function(e) {
    return _this.foo(e);
  });
}
```
