### PR TITLE
implement a `copy` loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Add a `copy` loader ([#2255](https://github.com/evanw/esbuild/issues/2255))
+
+    You can configure the "loader" for a specific file extension in esbuild, which is a way of telling esbuild how it should treat that file. For example, the `text` loader means the file is imported as a string while the `binary` loader means the file is imported as a `Uint8Array`. If you want the imported file to stay a separate file, the only option was previously the `file` loader (which is intended to be similar to Webpack's [`file-loader`](https://v4.webpack.js.org/loaders/file-loader/) package). This loader copies the file to the output directory and imports the path to that output file as a string. This is useful for a web application because you can refer to resources such as `.png` images by importing them for their URL. However, it's not helpful if you need the imported file to stay a separate file but to still behave the way it normally would when the code is run without bundling.
+
+    With this release, there is now a new loader called `copy` that copies the loaded file to the output directory and then rewrites the path of the import statement or `require()` call to point to the copied file instead of the original file. This will automatically add a content hash to the output name by default (which can be configured with the `--asset-names=` setting). You can use this by specifying `copy` for a specific file extension, such as with `--loader:.png=copy`.
+
 * Fix a regression in arrow function lowering ([#2302](https://github.com/evanw/esbuild/pull/2302))
 
     This release fixes a regression with lowering arrow functions to function expressions in ES5. This feature was introduced in version 0.7.2 and regressed in version 0.14.30.

--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -42,7 +42,7 @@ var helpText = func(colors logger.Colors) string {
                         is browser and cjs when platform is node)
   --loader:X=L          Use loader L to load file extension X, where L is
                         one of: js | jsx | ts | tsx | css | json | text |
-                        base64 | file | dataurl | binary
+                        base64 | file | dataurl | binary | copy
   --minify              Minify the output (sets all --minify-* flags)
   --outdir=...          The output directory (for multiple entry points)
   --outfile=...         The output file (for one entry point)

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -126,8 +126,12 @@ type ImportRecord struct {
 	ErrorHandlerLoc logger.Loc
 
 	// The resolved source index for an internal import (within the bundle) or
-	// nil for an external import (not included in the bundle)
+	// invalid for an external import (not included in the bundle)
 	SourceIndex Index32
+
+	// Files imported via the "copy" loader use this instead of "SourceIndex"
+	// because they are sort of like external imports, and are not bundled.
+	CopySourceIndex Index32
 
 	Flags ImportRecordFlags
 	Kind  ImportKind

--- a/internal/bundler/bundler_loader_test.go
+++ b/internal/bundler/bundler_loader_test.go
@@ -959,3 +959,125 @@ func TestLoaderDataURLUnknownMIME(t *testing.T) {
 		},
 	})
 }
+
+func TestLoaderCopyWithBundleFromJS(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/entry.js": `
+				import x from "../assets/some.file"
+				console.log(x)
+			`,
+			"/Users/user/project/assets/some.file": `stuff`,
+		},
+		entryPaths: []string{"/Users/user/project/src/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputBase: "/Users/user/project",
+			AbsOutputDir:  "/out",
+			ExtensionToLoader: map[string]config.Loader{
+				".js":   config.LoaderJS,
+				".file": config.LoaderCopy,
+			},
+		},
+	})
+}
+
+func TestLoaderCopyWithBundleFromCSS(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/entry.css": `
+				body {
+					background: url(../assets/some.file);
+				}
+			`,
+			"/Users/user/project/assets/some.file": `stuff`,
+		},
+		entryPaths: []string{"/Users/user/project/src/entry.css"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputBase: "/Users/user/project",
+			AbsOutputDir:  "/out",
+			ExtensionToLoader: map[string]config.Loader{
+				".css":  config.LoaderCSS,
+				".file": config.LoaderCopy,
+			},
+		},
+	})
+}
+
+func TestLoaderCopyWithBundleEntryPoint(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/entry.js": `
+				import x from "../assets/some.file"
+				console.log(x)
+			`,
+			"/Users/user/project/src/entry.css": `
+				body {
+					background: url(../assets/some.file);
+				}
+			`,
+			"/Users/user/project/assets/some.file": `stuff`,
+		},
+		entryPaths: []string{
+			"/Users/user/project/src/entry.js",
+			"/Users/user/project/src/entry.css",
+			"/Users/user/project/assets/some.file",
+		},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputBase: "/Users/user/project",
+			AbsOutputDir:  "/out",
+			ExtensionToLoader: map[string]config.Loader{
+				".js":   config.LoaderJS,
+				".css":  config.LoaderCSS,
+				".file": config.LoaderCopy,
+			},
+		},
+	})
+}
+
+func TestLoaderCopyWithTransform(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/entry.js":     `console.log('entry')`,
+			"/Users/user/project/assets/some.file": `stuff`,
+		},
+		entryPaths: []string{
+			"/Users/user/project/src/entry.js",
+			"/Users/user/project/assets/some.file",
+		},
+		options: config.Options{
+			Mode:          config.ModePassThrough,
+			AbsOutputBase: "/Users/user/project",
+			AbsOutputDir:  "/out",
+			ExtensionToLoader: map[string]config.Loader{
+				".js":   config.LoaderJS,
+				".file": config.LoaderCopy,
+			},
+		},
+	})
+}
+
+func TestLoaderCopyWithFormat(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/entry.js":     `console.log('entry')`,
+			"/Users/user/project/assets/some.file": `stuff`,
+		},
+		entryPaths: []string{
+			"/Users/user/project/src/entry.js",
+			"/Users/user/project/assets/some.file",
+		},
+		options: config.Options{
+			Mode:          config.ModeConvertFormat,
+			OutputFormat:  config.FormatIIFE,
+			AbsOutputBase: "/Users/user/project",
+			AbsOutputDir:  "/out",
+			ExtensionToLoader: map[string]config.Loader{
+				".js":   config.LoaderJS,
+				".file": config.LoaderCopy,
+			},
+		},
+	})
+}

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -1858,6 +1858,56 @@ c {
 /* entry.css */
 
 ================================================================================
+TestLoaderCopyWithBundleEntryPoint
+---------- /out/assets/some.file ----------
+stuff
+---------- /out/src/entry.js ----------
+// Users/user/project/src/entry.js
+import x from "../assets/some.file";
+console.log(x);
+
+---------- /out/src/entry.css ----------
+/* Users/user/project/src/entry.css */
+body {
+  background: url(../assets/some.file);
+}
+
+================================================================================
+TestLoaderCopyWithBundleFromCSS
+---------- /out/some-BYATPJRB.file ----------
+stuff
+---------- /out/src/entry.css ----------
+/* Users/user/project/src/entry.css */
+body {
+  background: url(../some-BYATPJRB.file);
+}
+
+================================================================================
+TestLoaderCopyWithBundleFromJS
+---------- /out/some-BYATPJRB.file ----------
+stuff
+---------- /out/src/entry.js ----------
+// Users/user/project/src/entry.js
+import x from "../some-BYATPJRB.file";
+console.log(x);
+
+================================================================================
+TestLoaderCopyWithFormat
+---------- /out/src/entry.js ----------
+(() => {
+  console.log("entry");
+})();
+
+---------- /out/assets/some.file ----------
+stuff
+================================================================================
+TestLoaderCopyWithTransform
+---------- /out/src/entry.js ----------
+console.log("entry");
+
+---------- /out/assets/some.file ----------
+stuff
+================================================================================
 TestLoaderDataURLApplicationJSON
 ---------- /out/entry.js ----------
 // <data:application/json,"%31%32%33">

--- a/internal/cli_helpers/cli_helpers.go
+++ b/internal/cli_helpers/cli_helpers.go
@@ -47,10 +47,12 @@ func ParseLoader(text string) (api.Loader, *ErrorWithNote) {
 		return api.LoaderBinary, nil
 	case "default":
 		return api.LoaderDefault, nil
+	case "copy":
+		return api.LoaderCopy, nil
 	default:
 		return api.LoaderNone, MakeErrorWithNote(
 			fmt.Sprintf("Invalid loader value: %q", text),
-			"Valid values are \"js\", \"jsx\", \"ts\", \"tsx\", \"css\", \"json\", \"text\", \"base64\", \"dataurl\", \"file\", or \"binary\".",
+			"Valid values are \"js\", \"jsx\", \"ts\", \"tsx\", \"css\", \"json\", \"text\", \"base64\", \"dataurl\", \"file\", \"binary\", or \"copy\".",
 		)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,19 +65,20 @@ type Loader uint8
 
 const (
 	LoaderNone Loader = iota
+	LoaderBase64
+	LoaderBinary
+	LoaderCopy
+	LoaderCSS
+	LoaderDataURL
+	LoaderDefault
+	LoaderFile
 	LoaderJS
+	LoaderJSON
 	LoaderJSX
+	LoaderText
 	LoaderTS
 	LoaderTSNoAmbiguousLessThan // Used with ".mts" and ".cts"
 	LoaderTSX
-	LoaderJSON
-	LoaderText
-	LoaderBase64
-	LoaderDataURL
-	LoaderFile
-	LoaderBinary
-	LoaderCSS
-	LoaderDefault
 )
 
 func (loader Loader) IsTypeScript() bool {

--- a/internal/graph/input.go
+++ b/internal/graph/input.go
@@ -22,10 +22,10 @@ type InputFile struct {
 	InputSourceMap *sourcemap.SourceMap
 
 	// If this file ends up being used in the bundle, these are additional files
-	// that must be written to the output directory. It's used by the "file"
-	// loader.
-	AdditionalFiles        []OutputFile
-	UniqueKeyForFileLoader string
+	// that must be written to the output directory. It's used by the "file" and
+	// "copy" loaders.
+	AdditionalFiles            []OutputFile
+	UniqueKeyForAdditionalFile string
 
 	SideEffects SideEffects
 	Source      logger.Source
@@ -113,4 +113,13 @@ type CSSRepr struct {
 
 func (repr *CSSRepr) ImportRecords() *[]ast.ImportRecord {
 	return &repr.AST.ImportRecords
+}
+
+type CopyRepr struct {
+	// The URL that replaces the contents of any import record paths for this file
+	URLForCode string
+}
+
+func (repr *CopyRepr) ImportRecords() *[]ast.ImportRecord {
+	return nil
 }

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -1,6 +1,6 @@
 export type Platform = 'browser' | 'node' | 'neutral';
 export type Format = 'iife' | 'cjs' | 'esm';
-export type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'css' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'binary' | 'default';
+export type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'css' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'binary' | 'copy' | 'default';
 export type LogLevel = 'verbose' | 'debug' | 'info' | 'warning' | 'error' | 'silent';
 export type Charset = 'ascii' | 'utf8';
 export type Drop = 'console' | 'debugger';

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -132,18 +132,19 @@ type Loader uint8
 
 const (
 	LoaderNone Loader = iota
+	LoaderBase64
+	LoaderBinary
+	LoaderCopy
+	LoaderCSS
+	LoaderDataURL
+	LoaderDefault
+	LoaderFile
 	LoaderJS
+	LoaderJSON
 	LoaderJSX
+	LoaderText
 	LoaderTS
 	LoaderTSX
-	LoaderJSON
-	LoaderText
-	LoaderBase64
-	LoaderDataURL
-	LoaderFile
-	LoaderBinary
-	LoaderCSS
-	LoaderDefault
 )
 
 type Platform uint8

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -229,30 +229,32 @@ func validateTreeShaking(value TreeShaking, bundle bool, format Format) bool {
 
 func validateLoader(value Loader) config.Loader {
 	switch value {
-	case LoaderNone:
-		return config.LoaderNone
-	case LoaderJS:
-		return config.LoaderJS
-	case LoaderJSX:
-		return config.LoaderJSX
-	case LoaderTS:
-		return config.LoaderTS
-	case LoaderTSX:
-		return config.LoaderTSX
-	case LoaderJSON:
-		return config.LoaderJSON
-	case LoaderText:
-		return config.LoaderText
 	case LoaderBase64:
 		return config.LoaderBase64
+	case LoaderBinary:
+		return config.LoaderBinary
+	case LoaderCopy:
+		return config.LoaderCopy
+	case LoaderCSS:
+		return config.LoaderCSS
 	case LoaderDataURL:
 		return config.LoaderDataURL
 	case LoaderFile:
 		return config.LoaderFile
-	case LoaderBinary:
-		return config.LoaderBinary
-	case LoaderCSS:
-		return config.LoaderCSS
+	case LoaderJS:
+		return config.LoaderJS
+	case LoaderJSON:
+		return config.LoaderJSON
+	case LoaderJSX:
+		return config.LoaderJSX
+	case LoaderNone:
+		return config.LoaderNone
+	case LoaderText:
+		return config.LoaderText
+	case LoaderTS:
+		return config.LoaderTS
+	case LoaderTSX:
+		return config.LoaderTSX
 	case LoaderDefault:
 		return config.LoaderDefault
 	default:
@@ -1022,6 +1024,10 @@ func rebuildImpl(
 		for _, loader := range options.ExtensionToLoader {
 			if loader == config.LoaderFile {
 				log.AddError(nil, logger.Range{}, "Cannot use the \"file\" loader without an output path")
+				break
+			}
+			if loader == config.LoaderCopy {
+				log.AddError(nil, logger.Range{}, "Cannot use the \"copy\" loader without an output path")
 				break
 			}
 		}

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -488,11 +488,11 @@ func parseOptionsImpl(
 			if err != nil {
 				return parseOptionsExtras{}, err
 			}
-			if loader == api.LoaderFile {
+			if loader == api.LoaderFile || loader == api.LoaderCopy {
 				return parseOptionsExtras{}, cli_helpers.MakeErrorWithNote(
 					fmt.Sprintf("%q is not supported when transforming stdin", arg),
-					"Using esbuild to transform stdin only generates one output file, so you cannot use the \"file\" loader "+
-						"since that needs to generate two output files.",
+					fmt.Sprintf("Using esbuild to transform stdin only generates one output file, so you cannot use the %q loader "+
+						"since that needs to generate two output files.", value),
 				)
 			}
 			if buildOpts != nil {


### PR DESCRIPTION
You can configure the "loader" for a specific file extension in esbuild, which is a way of telling esbuild how it should treat that file. For example, the `text` loader means the file is imported as a string while the `binary` loader means the file is imported as a `Uint8Array`. If you want the imported file to stay a separate file, the only option was previously the `file` loader (which is intended to be similar to Webpack's [`file-loader`](https://v4.webpack.js.org/loaders/file-loader/) package). This loader copies the file to the output directory and imports the path to that output file as a string. This is useful for a web application because you can refer to resources such as `.png` images by importing them for their URL. However, it's not helpful if you need the imported file to stay a separate file but to still behave the way it normally would when the code is run without bundling.

With this PR, there is now a new loader called `copy` that copies the loaded file to the output directory and then rewrites the path of the import statement or `require()` call to point to the copied file instead of the original file. This will automatically add a content hash to the output name by default (which can be configured with the `--asset-names=` setting). You can use this by specifying `copy` for a specific file extension, such as with `--loader:.png=copy`.

Fixes: #2255
