### PR TITLE
fix: `esm` don't need `use strict`

### DIFF
--- a/internal/bundler/bundler_tsconfig_test.go
+++ b/internal/bundler/bundler_tsconfig_test.go
@@ -1863,3 +1863,25 @@ func TestTsConfigAlwaysStrictTrueEmitDirectiveBundle(t *testing.T) {
 		},
 	})
 }
+
+func TestTsConfigAlwaysStrictDontAddDirectiveWhenOutputFormatIsESM(t *testing.T) {
+	tsconfig_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/implicit.ts": `
+				console.log('this file should not start with "use strict"')
+			`,
+			"/Users/user/project/tsconfig.json": `{
+				"compilerOptions": {
+					"alwaysStrict": true
+				}
+			}`,
+		},
+		entryPaths: []string{
+			"/Users/user/project/src/implicit.ts",
+		},
+		options: config.Options{
+			AbsOutputDir: "/Users/user/project/out",
+			OutputFormat: config.FormatESModule,
+		},
+	})
+}

--- a/internal/bundler/snapshots/snapshots_tsconfig.txt
+++ b/internal/bundler/snapshots/snapshots_tsconfig.txt
@@ -28,6 +28,11 @@ console.log('this file should start with "use strict"');
 console.log('this file should start with "use strict"');
 
 ================================================================================
+TestTsConfigAlwaysStrictDontAddDirectiveWhenOutputFormatIsESM
+---------- /Users/user/project/out/implicit.js ----------
+console.log('this file should not start with "use strict"');
+
+================================================================================
 TestTsConfigAlwaysStrictTrueEmitDirectiveFormat
 ---------- /Users/user/project/out/implicit.js ----------
 "use strict";

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -15344,7 +15344,7 @@ func Parse(log logger.Log, source logger.Source, options Options) (result js_ast
 
 	// Insert a "use strict" directive if "alwaysStrict" is active
 	directive := ""
-	if tsAlwaysStrict := p.options.tsAlwaysStrict; tsAlwaysStrict != nil && tsAlwaysStrict.Value {
+	if tsAlwaysStrict := p.options.tsAlwaysStrict; tsAlwaysStrict != nil && tsAlwaysStrict.Value && p.options.outputFormat != config.FormatESModule {
 		directive = "use strict"
 	}
 


### PR DESCRIPTION
- Close #2347