### PR TITLE
feat: drop unused local variables

### DIFF
--- a/internal/bundler/bundler_dce_test.go
+++ b/internal/bundler/bundler_dce_test.go
@@ -2777,7 +2777,7 @@ func TestConstValueInliningNoBundle(t *testing.T) {
 			`,
 			"/exprs-before.js": `
 				function nested() {
-					const x = [, '', {}, 0n, /./, function() {}, () => {}]
+					const x_REMOVE = [, '', {}, 0n, /./, function() {}, () => {}]
 					const y_REMOVE = 1
 					function foo() {
 						return y_REMOVE

--- a/internal/bundler/snapshots/snapshots_dce.txt
+++ b/internal/bundler/snapshots/snapshots_dce.txt
@@ -143,9 +143,6 @@ x = [1, 1];
 
 ---------- /out/exprs-before.js ----------
 function nested() {
-  const x = [, "", {}, 0n, /./, function() {
-  }, () => {
-  }];
   function foo() {
     return 1;
   }

--- a/scripts/uglify-tests.js
+++ b/scripts/uglify-tests.js
@@ -255,6 +255,7 @@ async function test_case(esbuild, test, basename) {
       'let.js: issue_4229',
       'let.js: issue_4245',
       'let.js: use_before_init_3',
+      'let.js: issue_4276_1',
 
       // Error difference
       'dead-code.js: dead_code_2_should_warn',


### PR DESCRIPTION
This PR partially implements dropping unused local variables.
Multi-level dropping (for example: `a` is unused and `b` depends on `a`) is not implemented.

This is useful for some cases like minifying IIFE wrapped output.

### Example
**Input**
```js
(function () {
  'use strict';

  const const1 = 0;
  let let1 = 0;
  var var1 = 0;

  const const2 = 0;
  let let2 = 0;
  var var2 = 0;
  console.log(const2, let2, var2);

})();
```

**Current Output**
```js
(function() {
  "use strict";
  let let1 = 0;
  var var1 = 0;
  const const2 = 0;
  let let2 = 0;
  var var2 = 0;
  console.log(const2, let2, var2);
})();
```

**New Output**
```js
(function() {
  "use strict";
  const const2 = 0;
  let let2 = 0;
  var var2 = 0;
  console.log(const2, let2, var2);
})();
```