### PR TITLE
fix #2365: Hermes does not fully support `ConstAndLet`

### DIFF
--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -392,7 +392,6 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Edge:    {{start: v{14, 0, 0}}},
 		ES:      {{start: v{2015, 0, 0}}},
 		Firefox: {{start: v{51, 0, 0}}},
-		Hermes:  {{start: v{0, 7, 0}}},
 		IE:      {{start: v{11, 0, 0}}},
 		IOS:     {{start: v{11, 0, 0}}},
 		Node:    {{start: v{6, 0, 0}}},


### PR DESCRIPTION
Remove Hermes from `ConstAndLet` as it does not fully support it.

Resolves #2365.