### PR TITLE
generate `"names"` in source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Emit `names` in source maps ([#1296](https://github.com/evanw/esbuild/issues/1296))
+
+    The [source map specification](https://sourcemaps.info/spec.html) includes an optional `names` field that can associate an identifier with a mapping entry. This can be used to record the original name for an identifier, which is useful if the identifier was renamed to something else in the generated code. When esbuild was originally written, this field wasn't widely used, but now there are some debuggers that make use of it to provide better debugging of minified code. With this release, esbuild now includes a `names` field in the source maps that it generates. To save space, the original name is only recorded when it's different from the final name.
+
 * Update parser for arrow functions with initial default type parameters in `.tsx` files ([#2410](https://github.com/evanw/esbuild/issues/2410))
 
     TypeScript 4.6 introduced a [change to the parsing of JSX syntax in `.tsx` files](https://github.com/microsoft/TypeScript/issues/47062). Now a `<` token followed by an identifier and then a `=` token is parsed as an arrow function with a default type parameter instead of as a JSX element. This release updates esbuild's parser to match TypeScript's parser.

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -5950,6 +5950,7 @@ func (c *linkerContext) generateSourceMapForChunk(
 	mappingsStart := j.Length()
 	prevEndState := sourcemap.SourceMapState{}
 	prevColumnOffset := 0
+	totalQuotedNameLen := 0
 	for _, result := range results {
 		chunk := result.sourceMapChunk
 		offset := result.generatedOffset
@@ -5971,6 +5972,7 @@ func (c *linkerContext) generateSourceMapForChunk(
 			SourceIndex:     sourcesIndex,
 			GeneratedLine:   offset.Lines,
 			GeneratedColumn: offset.Columns,
+			OriginalName:    totalQuotedNameLen,
 		}
 		if offset.Lines == 0 {
 			startState.GeneratedColumn += prevColumnOffset
@@ -5980,9 +5982,24 @@ func (c *linkerContext) generateSourceMapForChunk(
 		sourcemap.AppendSourceMapChunk(&j, prevEndState, startState, chunk.Buffer)
 
 		// Generate the relative offset to start from next time
+		prevOriginalName := prevEndState.OriginalName
 		prevEndState = chunk.EndState
 		prevEndState.SourceIndex += sourcesIndex
+		if chunk.Buffer.FirstNameOffset.IsValid() {
+			prevEndState.OriginalName += totalQuotedNameLen
+		} else {
+			// It's possible for a chunk to have mappings but for none of those
+			// mappings to have an associated name. The name is optional and is
+			// omitted when the mapping is for a non-name token or if the final
+			// and original names are the same. In that case we need to restore
+			// the previous original name end state since it wasn't modified after
+			// all. If we don't do this, then files after this will adjust their
+			// name offsets assuming that the previous generated mapping has this
+			// file's offset, which is wrong.
+			prevEndState.OriginalName = prevOriginalName
+		}
 		prevColumnOffset = chunk.FinalGeneratedColumn
+		totalQuotedNameLen += len(chunk.QuotedNames)
 
 		// If this was all one line, include the column offset from the start
 		if prevEndState.GeneratedLine == 0 {
@@ -5992,8 +6009,23 @@ func (c *linkerContext) generateSourceMapForChunk(
 	}
 	mappingsEnd := j.Length()
 
+	// Write the names
+	isFirstName := true
+	j.AddString("\",\n  \"names\": [")
+	for _, result := range results {
+		for _, quotedName := range result.sourceMapChunk.QuotedNames {
+			if isFirstName {
+				isFirstName = false
+			} else {
+				j.AddString(", ")
+			}
+			j.AddBytes(quotedName)
+		}
+	}
+	j.AddString("]")
+
 	// Finish the source map
-	j.AddString("\",\n  \"names\": []\n}\n")
+	j.AddString("\n}\n")
 	bytes := j.Done()
 
 	if !canHaveShifts {

--- a/internal/css_printer/css_printer.go
+++ b/internal/css_printer/css_printer.go
@@ -48,7 +48,7 @@ func Print(tree css_ast.AST, options Options) PrintResult {
 	p := printer{
 		options:       options,
 		importRecords: tree.ImportRecords,
-		builder:       sourcemap.MakeChunkBuilder(options.InputSourceMap, options.LineOffsetTables),
+		builder:       sourcemap.MakeChunkBuilder(options.InputSourceMap, options.LineOffsetTables, options.ASCIIOnly),
 	}
 	for _, rule := range tree.Rules {
 		p.printRule(rule, 0, false)
@@ -78,7 +78,7 @@ func (p *printer) printRule(rule css_ast.Rule, indent int32, omitTrailingSemicol
 	}
 
 	if p.options.AddSourceMappings {
-		p.builder.AddSourceMapping(rule.Loc, p.css)
+		p.builder.AddSourceMapping(rule.Loc, "", p.css)
 	}
 
 	if !p.options.MinifyWhitespace {

--- a/internal/sourcemap/sourcemap.go
+++ b/internal/sourcemap/sourcemap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"unicode/utf8"
 
+	"github.com/evanw/esbuild/internal/ast"
 	"github.com/evanw/esbuild/internal/helpers"
 	"github.com/evanw/esbuild/internal/logger"
 )
@@ -12,15 +13,17 @@ type Mapping struct {
 	GeneratedLine   int32 // 0-based
 	GeneratedColumn int32 // 0-based count of UTF-16 code units
 
-	SourceIndex    int32 // 0-based
-	OriginalLine   int32 // 0-based
-	OriginalColumn int32 // 0-based count of UTF-16 code units
+	SourceIndex    int32       // 0-based
+	OriginalLine   int32       // 0-based
+	OriginalColumn int32       // 0-based count of UTF-16 code units
+	OriginalName   ast.Index32 // 0-based, optional
 }
 
 type SourceMap struct {
 	Sources        []string
 	SourcesContent []SourceContent
 	Mappings       []Mapping
+	Names          []string
 }
 
 type SourceContent struct {
@@ -318,6 +321,13 @@ func (pieces SourceMapPieces) Finalize(shifts []SourceMapShift) []byte {
 		_, current = DecodeVLQ(pieces.Mappings, current) // The original line
 		_, current = DecodeVLQ(pieces.Mappings, current) // The original column
 
+		// Skip over the original name
+		if current < len(pieces.Mappings) {
+			if c := pieces.Mappings[current]; c != ',' && c != ';' {
+				_, current = DecodeVLQ(pieces.Mappings, current)
+			}
+		}
+
 		// Skip a trailing comma
 		if current < len(pieces.Mappings) && pieces.Mappings[current] == ',' {
 			current++
@@ -378,6 +388,8 @@ type SourceMapState struct {
 	SourceIndex     int
 	OriginalLine    int
 	OriginalColumn  int
+	OriginalName    int
+	HasOriginalName bool
 }
 
 // Source map chunks are computed in parallel for speed. Each chunk is relative
@@ -388,7 +400,7 @@ type SourceMapState struct {
 // After all chunks are computed, they are joined together in a second pass.
 // This rewrites the first mapping in each chunk to be relative to the end
 // state of the previous chunk.
-func AppendSourceMapChunk(j *helpers.Joiner, prevEndState SourceMapState, startState SourceMapState, sourceMap []byte) {
+func AppendSourceMapChunk(j *helpers.Joiner, prevEndState SourceMapState, startState SourceMapState, buffer MappingsBuffer) {
 	// Handle line breaks in between this mapping and the previous one
 	if startState.GeneratedLine != 0 {
 		j.AddBytes(bytes.Repeat([]byte{';'}, startState.GeneratedLine))
@@ -397,12 +409,11 @@ func AppendSourceMapChunk(j *helpers.Joiner, prevEndState SourceMapState, startS
 
 	// Skip past any leading semicolons, which indicate line breaks
 	semicolons := 0
-	for sourceMap[semicolons] == ';' {
+	for buffer.Data[semicolons] == ';' {
 		semicolons++
 	}
 	if semicolons > 0 {
-		j.AddBytes(sourceMap[:semicolons])
-		sourceMap = sourceMap[semicolons:]
+		j.AddBytes(buffer.Data[:semicolons])
 		prevEndState.GeneratedColumn = 0
 		startState.GeneratedColumn = 0
 	}
@@ -410,11 +421,16 @@ func AppendSourceMapChunk(j *helpers.Joiner, prevEndState SourceMapState, startS
 	// Strip off the first mapping from the buffer. The first mapping should be
 	// for the start of the original file (the printer always generates one for
 	// the start of the file).
-	generatedColumn, i := DecodeVLQ(sourceMap, 0)
-	sourceIndex, i := DecodeVLQ(sourceMap, i)
-	originalLine, i := DecodeVLQ(sourceMap, i)
-	originalColumn, i := DecodeVLQ(sourceMap, i)
-	sourceMap = sourceMap[i:]
+	//
+	// Note that we do not want to strip off the original name, even though it
+	// could be a part of the first mapping. This will be handled using a special
+	// case below instead. Original names are optional and are often omitted, so
+	// we handle it uniformly by saving an index to the first original name,
+	// which may or may not be a part of the first mapping.
+	generatedColumn, i := DecodeVLQ(buffer.Data, semicolons)
+	sourceIndex, i := DecodeVLQ(buffer.Data, i)
+	originalLine, i := DecodeVLQ(buffer.Data, i)
+	originalColumn, i := DecodeVLQ(buffer.Data, i)
 
 	// Rewrite the first mapping to be relative to the end state of the previous
 	// chunk. We now know what the end state is because we're in the second pass
@@ -423,35 +439,46 @@ func AppendSourceMapChunk(j *helpers.Joiner, prevEndState SourceMapState, startS
 	startState.GeneratedColumn += generatedColumn
 	startState.OriginalLine += originalLine
 	startState.OriginalColumn += originalColumn
-	j.AddBytes(appendMappingToBuffer(nil, j.LastByte(), prevEndState, startState))
+	prevEndState.HasOriginalName = false // This is handled separately below
+	rewritten, _ := appendMappingToBuffer(nil, j.LastByte(), prevEndState, startState)
+	j.AddBytes(rewritten)
 
-	// Then append everything after that without modification.
-	j.AddBytes(sourceMap)
+	// Next, if there's an original name, we need to rewrite that as well to be
+	// relative to that of the previous chunk.
+	if buffer.FirstNameOffset.IsValid() {
+		before := int(buffer.FirstNameOffset.GetIndex())
+		originalName, after := DecodeVLQ(buffer.Data, before)
+		originalName += startState.OriginalName - prevEndState.OriginalName
+		j.AddBytes(buffer.Data[i:before])
+		j.AddBytes(encodeVLQ(nil, originalName))
+		j.AddBytes(buffer.Data[after:])
+		return
+	}
+
+	// Otherwise, just append everything after that without modification
+	j.AddBytes(buffer.Data[i:])
 }
 
-func appendMappingToBuffer(buffer []byte, lastByte byte, prevState SourceMapState, currentState SourceMapState) []byte {
+func appendMappingToBuffer(buffer []byte, lastByte byte, prevState SourceMapState, currentState SourceMapState) ([]byte, ast.Index32) {
 	// Put commas in between mappings
 	if lastByte != 0 && lastByte != ';' && lastByte != '"' {
 		buffer = append(buffer, ',')
 	}
 
-	// Record the generated column (the line is recorded using ';' elsewhere)
+	// Record the mapping (note that the generated line is recorded using ';' elsewhere)
 	buffer = encodeVLQ(buffer, currentState.GeneratedColumn-prevState.GeneratedColumn)
-	prevState.GeneratedColumn = currentState.GeneratedColumn
-
-	// Record the generated source
 	buffer = encodeVLQ(buffer, currentState.SourceIndex-prevState.SourceIndex)
-	prevState.SourceIndex = currentState.SourceIndex
-
-	// Record the original line
 	buffer = encodeVLQ(buffer, currentState.OriginalLine-prevState.OriginalLine)
-	prevState.OriginalLine = currentState.OriginalLine
-
-	// Record the original column
 	buffer = encodeVLQ(buffer, currentState.OriginalColumn-prevState.OriginalColumn)
-	prevState.OriginalColumn = currentState.OriginalColumn
 
-	return buffer
+	// Record the optional original name
+	var nameOffset ast.Index32
+	if currentState.HasOriginalName {
+		nameOffset = ast.MakeIndex32(uint32(len(buffer)))
+		buffer = encodeVLQ(buffer, currentState.OriginalName-prevState.OriginalName)
+	}
+
+	return buffer, nameOffset
 }
 
 type LineOffsetTable struct {
@@ -549,8 +576,14 @@ func GenerateLineOffsetTables(contents string, approximateLineCount int32) []Lin
 	return lineOffsetTables
 }
 
+type MappingsBuffer struct {
+	Data            []byte
+	FirstNameOffset ast.Index32
+}
+
 type Chunk struct {
-	Buffer []byte
+	Buffer      MappingsBuffer
+	QuotedNames [][]byte
 
 	// This end state will be used to rewrite the start of the following source
 	// map chunk so that the delta-encoded VLQ numbers are preserved.
@@ -567,12 +600,18 @@ type Chunk struct {
 type ChunkBuilder struct {
 	inputSourceMap      *SourceMap
 	sourceMap           []byte
+	quotedNames         [][]byte
+	namesMap            map[string]uint32
 	lineOffsetTables    []LineOffsetTable
+	prevOriginalName    string
 	prevState           SourceMapState
 	lastGeneratedUpdate int
 	generatedColumn     int
-	prevLoc             logger.Loc
+	prevGeneratedLen    int
+	prevOriginalLoc     logger.Loc
+	firstNameOffset     ast.Index32
 	hasPrevState        bool
+	asciiOnly           bool
 
 	// This is a workaround for a bug in the popular "source-map" library:
 	// https://github.com/mozilla/source-map/issues/261. The library will
@@ -586,11 +625,13 @@ type ChunkBuilder struct {
 	coverLinesWithoutMappings bool
 }
 
-func MakeChunkBuilder(inputSourceMap *SourceMap, lineOffsetTables []LineOffsetTable) ChunkBuilder {
+func MakeChunkBuilder(inputSourceMap *SourceMap, lineOffsetTables []LineOffsetTable, asciiOnly bool) ChunkBuilder {
 	return ChunkBuilder{
 		inputSourceMap:   inputSourceMap,
-		prevLoc:          logger.Loc{Start: -1},
+		prevOriginalLoc:  logger.Loc{Start: -1},
 		lineOffsetTables: lineOffsetTables,
+		asciiOnly:        asciiOnly,
+		namesMap:         make(map[string]uint32),
 
 		// We automatically repeat the previous source mapping if we ever generate
 		// a line that doesn't start with a mapping. This helps give files more
@@ -607,11 +648,15 @@ func MakeChunkBuilder(inputSourceMap *SourceMap, lineOffsetTables []LineOffsetTa
 	}
 }
 
-func (b *ChunkBuilder) AddSourceMapping(loc logger.Loc, output []byte) {
-	if loc == b.prevLoc {
+func (b *ChunkBuilder) AddSourceMapping(originalLoc logger.Loc, originalName string, output []byte) {
+	// Avoid generating duplicate mappings
+	if originalLoc == b.prevOriginalLoc && (b.prevGeneratedLen == len(output) || b.prevOriginalName == originalName) {
 		return
 	}
-	b.prevLoc = loc
+
+	b.prevOriginalLoc = originalLoc
+	b.prevGeneratedLen = len(output)
+	b.prevOriginalName = originalName
 
 	// Binary search to find the line
 	lineOffsetTables := b.lineOffsetTables
@@ -620,7 +665,7 @@ func (b *ChunkBuilder) AddSourceMapping(loc logger.Loc, output []byte) {
 	for count > 0 {
 		step := count / 2
 		i := originalLine + step
-		if lineOffsetTables[i].byteOffsetToStartOfLine <= loc.Start {
+		if lineOffsetTables[i].byteOffsetToStartOfLine <= originalLoc.Start {
 			originalLine = i + 1
 			count = count - step - 1
 		} else {
@@ -631,7 +676,7 @@ func (b *ChunkBuilder) AddSourceMapping(loc logger.Loc, output []byte) {
 
 	// Use the line to compute the column
 	line := &lineOffsetTables[originalLine]
-	originalColumn := int(loc.Start - line.byteOffsetToStartOfLine)
+	originalColumn := int(originalLoc.Start - line.byteOffsetToStartOfLine)
 	if line.columnsForNonASCII != nil && originalColumn >= int(line.byteOffsetToFirstNonASCII) {
 		originalColumn = int(line.columnsForNonASCII[originalColumn-int(line.byteOffsetToFirstNonASCII)])
 	}
@@ -650,7 +695,7 @@ func (b *ChunkBuilder) AddSourceMapping(loc logger.Loc, output []byte) {
 		})
 	}
 
-	b.appendMapping(SourceMapState{
+	b.appendMapping(originalName, SourceMapState{
 		GeneratedLine:   b.prevState.GeneratedLine,
 		GeneratedColumn: b.generatedColumn,
 		OriginalLine:    originalLine,
@@ -671,7 +716,11 @@ func (b *ChunkBuilder) GenerateChunk(output []byte) Chunk {
 		}
 	}
 	return Chunk{
-		Buffer:               b.sourceMap,
+		Buffer: MappingsBuffer{
+			Data:            b.sourceMap,
+			FirstNameOffset: b.firstNameOffset,
+		},
+		QuotedNames:          b.quotedNames,
 		EndState:             b.prevState,
 		FinalGeneratedColumn: b.generatedColumn,
 		ShouldIgnore:         shouldIgnore,
@@ -725,7 +774,7 @@ func (b *ChunkBuilder) updateGeneratedLineAndColumn(output []byte) {
 	b.lastGeneratedUpdate = len(output)
 }
 
-func (b *ChunkBuilder) appendMapping(currentState SourceMapState) {
+func (b *ChunkBuilder) appendMapping(originalName string, currentState SourceMapState) {
 	// If the input file had a source map, map all the way back to the original
 	if b.inputSourceMap != nil {
 		mapping := b.inputSourceMap.Find(
@@ -740,6 +789,26 @@ func (b *ChunkBuilder) appendMapping(currentState SourceMapState) {
 		currentState.SourceIndex = int(mapping.SourceIndex)
 		currentState.OriginalLine = int(mapping.OriginalLine)
 		currentState.OriginalColumn = int(mapping.OriginalColumn)
+
+		// Map all the way back to the original name if present. Otherwise, keep
+		// the original name from esbuild, which corresponds to the name in the
+		// intermediate source code. This is important for tools that only emit
+		// a name mapping when the name is different than the original name.
+		if mapping.OriginalName.IsValid() {
+			originalName = b.inputSourceMap.Names[mapping.OriginalName.GetIndex()]
+		}
+	}
+
+	// Optionally reference the original name
+	if originalName != "" {
+		i, ok := b.namesMap[originalName]
+		if !ok {
+			i = uint32(len(b.quotedNames))
+			b.quotedNames = append(b.quotedNames, helpers.QuoteForJSON(originalName, b.asciiOnly))
+			b.namesMap[originalName] = i
+		}
+		currentState.OriginalName = int(i)
+		currentState.HasOriginalName = true
 	}
 
 	b.appendMappingWithoutRemapping(currentState)
@@ -751,7 +820,16 @@ func (b *ChunkBuilder) appendMappingWithoutRemapping(currentState SourceMapState
 		lastByte = b.sourceMap[len(b.sourceMap)-1]
 	}
 
-	b.sourceMap = appendMappingToBuffer(b.sourceMap, lastByte, b.prevState, currentState)
+	var nameOffset ast.Index32
+	b.sourceMap, nameOffset = appendMappingToBuffer(b.sourceMap, lastByte, b.prevState, currentState)
+	prevOriginalName := b.prevState.OriginalName
 	b.prevState = currentState
+	if !currentState.HasOriginalName {
+		// Revert the original name change if it's invalid
+		b.prevState.OriginalName = prevOriginalName
+	} else if !b.firstNameOffset.IsValid() {
+		// Keep track of the first name offset so we can jump right to it later
+		b.firstNameOffset = nameOffset
+	}
 	b.hasPrevState = true
 }

--- a/scripts/verify-source-map.js
+++ b/scripts/verify-source-map.js
@@ -320,6 +320,36 @@ const testCaseBundleCSS = {
   `,
 }
 
+const testCaseNames = {
+  'entry.js': `
+    import "./nested1"
+
+    // Test regular name positions
+    var /**/foo = /**/foo || 0
+    function /**/fn(/**/bar) {}
+    class /**/cls {}
+    keep(fn, cls) // Make sure these aren't removed
+
+    // Test property mangling name positions
+    var { /**/mangle_: bar } = foo
+    var { /**/'mangle_': bar } = foo
+    foo./**/mangle_ = 1
+    foo[/**/'mangle_']
+    foo = { /**/mangle_: 0 }
+    foo = { /**/'mangle_': 0 }
+    foo = class { /**/mangle_ = 0 }
+    foo = class { /**/'mangle_' = 0 }
+    foo = /**/'mangle_' in bar
+  `,
+  'nested1.js': `
+    import { foo } from './nested2'
+    foo(bar)
+  `,
+  'nested2.jsx': `
+    export let /**/foo = /**/bar => /**/bar()
+  `
+}
+
 async function check(kind, testCase, toSearch, { ext, flags, entryPoints, crlf, followUpFlags = [] }) {
   let failed = 0
 
@@ -489,6 +519,135 @@ async function check(kind, testCase, toSearch, { ext, flags, entryPoints, crlf, 
   return failed
 }
 
+async function checkNames(kind, testCase, { ext, flags, entryPoints, crlf }) {
+  let failed = 0
+
+  try {
+    const recordCheck = (success, message) => {
+      if (!success) {
+        failed++
+        console.error(`❌ [${kind}] ${message}`)
+      }
+    }
+
+    const tempDir = path.join(testDir, `${kind}-${tempDirCount++}`)
+    await fs.mkdir(tempDir, { recursive: true })
+
+    for (const name in testCase) {
+      const tempPath = path.join(tempDir, name)
+      let code = testCase[name]
+      await fs.mkdir(path.dirname(tempPath), { recursive: true })
+      if (crlf) code = code.replace(/\n/g, '\r\n')
+      await fs.writeFile(tempPath, code)
+    }
+
+    const args = ['--sourcemap', '--log-level=warning'].concat(flags)
+    let stdout = ''
+
+    await new Promise((resolve, reject) => {
+      args.unshift(...entryPoints)
+      const child = childProcess.spawn(esbuildPath, args, { cwd: tempDir, stdio: ['pipe', 'pipe', 'inherit'] })
+      child.stdin.end()
+      child.stdout.on('data', chunk => stdout += chunk.toString())
+      child.stdout.on('end', resolve)
+      child.on('error', reject)
+    })
+
+    const outCode = await fs.readFile(path.join(tempDir, `out.${ext}`), 'utf8')
+    recordCheck(outCode.includes(`# sourceMappingURL=out.${ext}.map`), `.${ext} file must link to .${ext}.map`)
+    const outCodeMap = await fs.readFile(path.join(tempDir, `out.${ext}.map`), 'utf8')
+
+    // Check the mapping of various key locations back to the original source
+    const checkMap = (out, map) => {
+      const undoQuotes = x => `'"`.includes(x[0]) ? (0, eval)(x) : x.startsWith('(') ? x.slice(1, -1) : x
+      const generatedLines = out.split(/\r\n|\r|\n/g)
+
+      for (let i = 0; i < map.sources.length; i++) {
+        const source = map.sources[i]
+        const content = map.sourcesContent[i];
+        let index = 0
+
+        // The names for us to check are prefixed by "/**/" right before to mark them
+        const parts = content.split(/(\/\*\*\/(?:\w+|'\w+'|"\w+"))/g)
+
+        for (let j = 1; j < parts.length; j += 2) {
+          const expectedName = undoQuotes(parts[j].slice(4))
+          index += parts[j - 1].length
+
+          const prefixLines = content.slice(0, index + 4).split(/\r\n|\r|\n/g)
+          const line = prefixLines.length
+          const column = prefixLines[prefixLines.length - 1].length
+          index += parts[j].length
+
+          const generated = map.generatedPositionFor({ source, line, column })
+          const original = map.originalPositionFor(generated)
+          const generatedContentAfter = generatedLines[generated.line - 1].slice(generated.column)
+          recordCheck(original.source === source && original.line === line && original.column === column,
+            `\n` +
+            `\n  original position:               ${JSON.stringify({ source, line, column })}` +
+            `\n  maps to generated position:      ${JSON.stringify(generated)}` +
+            `\n  which maps to original position: ${JSON.stringify(original)}` +
+            `\n`)
+
+          if (original.source === source && original.line === line && original.column === column) {
+            const matchAfter = /^(?:\w+|'\w+'|"\w+"|\(\w+\))/.exec(generatedContentAfter)
+            recordCheck(matchAfter !== null, `expected identifier starting here: ${generatedContentAfter.slice(0, 100)}`)
+
+            if (matchAfter !== null) {
+              const observedName = undoQuotes(matchAfter[0])
+              recordCheck(expectedName === (original.name || observedName),
+                `\n` +
+                `\n  generated position: ${JSON.stringify(generated)}` +
+                `\n  original position:  ${JSON.stringify(original)}` +
+                `\n` +
+                `\n  original name:  ${JSON.stringify(expectedName)}` +
+                `\n  generated name: ${JSON.stringify(observedName)}` +
+                `\n  mapping name:   ${JSON.stringify(original.name)}` +
+                `\n`)
+            }
+          }
+        }
+      }
+    }
+
+    const outMap = await new SourceMapConsumer(outCodeMap)
+    checkMap(outCode, outMap)
+
+    // Bundle again to test nested source map chaining
+    for (let order of [0, 1, 2]) {
+      const fileToTest = `out.${ext}`
+      const nestedEntry = path.join(tempDir, `nested-entry.${ext}`)
+      await fs.writeFile(path.join(tempDir, `extra.${ext}`), `console.log('extra')`)
+      await fs.writeFile(nestedEntry,
+        order === 1 ? `import './${fileToTest}'; import './extra.${ext}'` :
+          order === 2 ? `import './extra.${ext}'; import './${fileToTest}'` :
+            `import './${fileToTest}'`)
+      await execFileAsync(esbuildPath, [
+        nestedEntry,
+        '--bundle',
+        '--outfile=' + path.join(tempDir, `out2.${ext}`),
+        '--sourcemap',
+      ], { cwd: testDir })
+
+      const out2Code = await fs.readFile(path.join(tempDir, `out2.${ext}`), 'utf8')
+      recordCheck(out2Code.includes(`# sourceMappingURL=out2.${ext}.map`), `.${ext} file must link to .${ext}.map`)
+      const out2CodeMap = await fs.readFile(path.join(tempDir, `out2.${ext}.map`), 'utf8')
+
+      const out2Map = await new SourceMapConsumer(out2CodeMap)
+      checkMap(out2Code, out2Map)
+    }
+
+    if (!failed) removeRecursiveSync(tempDir)
+  }
+
+  catch (e) {
+    console.error(`❌ [${kind}] ${e && e.message || e}`)
+    failed++
+  }
+
+  return failed
+}
+
 async function main() {
   const promises = []
   for (const crlf of [false, true]) {
@@ -598,6 +757,26 @@ async function main() {
           ext: 'css',
           flags: flags.concat('--outfile=out.css', '--bundle'),
           entryPoints: ['entry.css'],
+          crlf,
+        }),
+
+        // Checks for the "names" field
+        checkNames('names' + suffix, testCaseNames, {
+          ext: 'js',
+          flags: flags.concat('--outfile=out.js', '--bundle'),
+          entryPoints: ['entry.js'],
+          crlf,
+        }),
+        checkNames('names-mangle' + suffix, testCaseNames, {
+          ext: 'js',
+          flags: flags.concat('--outfile=out.js', '--bundle', '--mangle-props=^mangle_$'),
+          entryPoints: ['entry.js'],
+          crlf,
+        }),
+        checkNames('names-mangle-quoted' + suffix, testCaseNames, {
+          ext: 'js',
+          flags: flags.concat('--outfile=out.js', '--bundle', '--mangle-props=^mangle_$', '--mangle-quoted'),
+          entryPoints: ['entry.js'],
           crlf,
         }),
       )


### PR DESCRIPTION
The [source map specification](https://sourcemaps.info/spec.html) includes an optional `names` field that can associate an identifier with a mapping entry. This can be used to record the original name for an identifier, which is useful if the identifier was renamed to something else in the generated code. When esbuild was originally written, this field wasn't widely used, but now there are some debuggers that make use of it to provide better debugging of minified code. With this release, esbuild now includes a `names` field in the source maps that it generates. To save space, the original name is only recorded when it's different from the final name.

Fixes #1296
