### PR TITLE
don't leak memory on first incremental build error

### DIFF
--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1207,6 +1207,11 @@ export function createChannel(streamIn: StreamIn): StreamOut {
       copyResponseToResult(response!, result);
       runOnEndCallbacks(result, logPluginError, () => {
         if (result.errors.length > 0) {
+          if (response!.rebuild) {
+            sendRequest<protocol.RebuildDisposeRequest, null>(refs, { command: 'rebuild-dispose', key }, () => {
+              // We don't care about the result
+            });
+          }
           return callback(failureErrorWithLog('Build failed', result.errors, result.warnings), null);
         }
 


### PR DESCRIPTION
Hiya! This is kind of an aside to #1606 and #2280.

Presently, the `esbuild` server process leaks memory associated with the `activeBuild` and everything about it if a `build({ incremental: true })` fails (rather than a rebuild from it), and there's no way for a user to recover from this.

There's probably a nicer solution that involves giving the `rebuild` back to the user in the thrown error, but as you've mentioned in https://github.com/evanw/esbuild/issues/1606#issuecomment-924175385, the API gets a bit out of whack then and there's various things to ponder.

A minimally correct solution — at least, one that seems strictly more correct than what we have now, and that doesn't change the API whatsoever — is to `rebuild-dispose` before calling back with the failure.