### PR TITLE
mod: update go version in `go mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/evanw/esbuild
 
-go 1.13
+go 1.18
 
 require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8


### PR DESCRIPTION
# Main Change
For now, we use Go version 1.18.4 to build in `makefile`.
I think we can update `go version` in `go mod` to make it more clearer.