### PR TITLE
Update Yarn PnP to match the latest specification

### DIFF
--- a/internal/fs/fs_zip.go
+++ b/internal/fs/fs_zip.go
@@ -324,8 +324,13 @@ func parseYarnPnPVirtualPath(path string) (string, string, bool) {
 		}
 		i += slash + 1
 
-		// Replace the segments "__virtual__/<segment>/<n>" with N times the ".." operation
-		if path[start:i-1] == "__virtual__" {
+		// Replace the segments "__virtual__/<segment>/<n>" with N times the ".."
+		// operation. Note: The "__virtual__" folder name appeared with Yarn 3.0.
+		// Earlier releases used "$$virtual", but it was changed after discovering
+		// that this pattern triggered bugs in software where paths were used as
+		// either regexps or replacement. For example, "$$" found in the second
+		// parameter of "String.prototype.replace" silently turned into "$".
+		if segment := path[start : i-1]; segment == "__virtual__" || segment == "$$virtual" {
 			if slash := strings.IndexAny(path[i:], "/\\"); slash != -1 {
 				var count string
 				var suffix string

--- a/internal/fs/fs_zip.go
+++ b/internal/fs/fs_zip.go
@@ -279,7 +279,7 @@ func (fs *zipFS) Abs(path string) (string, bool) {
 }
 
 func (fs *zipFS) Dir(path string) string {
-	if prefix, suffix, ok := parseYarnPnPVirtualPath(path); ok && suffix == "" {
+	if prefix, suffix, ok := ParseYarnPnPVirtualPath(path); ok && suffix == "" {
 		return prefix
 	}
 	return fs.inner.Dir(path)
@@ -313,7 +313,7 @@ func (fs *zipFS) WatchData() WatchData {
 	return fs.inner.WatchData()
 }
 
-func parseYarnPnPVirtualPath(path string) (string, string, bool) {
+func ParseYarnPnPVirtualPath(path string) (string, string, bool) {
 	i := 0
 
 	for {
@@ -377,7 +377,7 @@ func parseYarnPnPVirtualPath(path string) (string, string, bool) {
 }
 
 func mangleYarnPnPVirtualPath(path string) string {
-	if prefix, suffix, ok := parseYarnPnPVirtualPath(path); ok {
+	if prefix, suffix, ok := ParseYarnPnPVirtualPath(path); ok {
 		return prefix + suffix
 	}
 	return path

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1189,21 +1189,45 @@ func (r resolverQuery) dirInfoUncached(path string) *dirInfo {
 		}
 	}
 
-	// Record if this directory has a Yarn PnP data file
-	if pnp, _ := entries.Get(".pnp.data.json"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
-		absPath := r.fs.Join(path, ".pnp.data.json")
-		if json := r.extractYarnPnPDataFromJSON(absPath, &r.caches.JSONCache); json.Data != nil {
-			info.pnpData = compileYarnPnPData(absPath, path, json)
-		}
-	} else if pnp, _ := entries.Get(".pnp.cjs"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
-		absPath := r.fs.Join(path, ".pnp.cjs")
-		if json := r.tryToExtractYarnPnPDataFromJS(absPath, &r.caches.JSONCache); json.Data != nil {
-			info.pnpData = compileYarnPnPData(absPath, path, json)
-		}
-	} else if pnp, _ := entries.Get(".pnp.js"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
-		absPath := r.fs.Join(path, ".pnp.js")
-		if json := r.tryToExtractYarnPnPDataFromJS(absPath, &r.caches.JSONCache); json.Data != nil {
-			info.pnpData = compileYarnPnPData(absPath, path, json)
+	// Record if this directory has a Yarn PnP manifest. This must not be done
+	// for Yarn virtual paths because that will result in duplicate copies of
+	// the same manifest which will result in multiple copies of the same virtual
+	// directory in the same path, which we don't handle (and which also doesn't
+	// match Yarn's behavior).
+	//
+	// For example, imagine a project with a manifest here:
+	//
+	//   /project/.pnp.cjs
+	//
+	// and a source file with an import of "bar" here:
+	//
+	//   /project/.yarn/__virtual__/pkg/1/foo.js
+	//
+	// If we didn't ignore Yarn PnP manifests in virtual folders, then we would
+	// pick up on the one here:
+	//
+	//   /project/.yarn/__virtual__/pkg/1/.pnp.cjs
+	//
+	// which means we would potentially resolve the import to something like this:
+	//
+	//   /project/.yarn/__virtual__/pkg/1/.yarn/__virtual__/pkg/1/bar
+	//
+	if _, _, ok := fs.ParseYarnPnPVirtualPath(path); !ok {
+		if pnp, _ := entries.Get(".pnp.data.json"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
+			absPath := r.fs.Join(path, ".pnp.data.json")
+			if json := r.extractYarnPnPDataFromJSON(absPath, &r.caches.JSONCache); json.Data != nil {
+				info.pnpData = compileYarnPnPData(absPath, path, json)
+			}
+		} else if pnp, _ := entries.Get(".pnp.cjs"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
+			absPath := r.fs.Join(path, ".pnp.cjs")
+			if json := r.tryToExtractYarnPnPDataFromJS(absPath, &r.caches.JSONCache); json.Data != nil {
+				info.pnpData = compileYarnPnPData(absPath, path, json)
+			}
+		} else if pnp, _ := entries.Get(".pnp.js"); pnp != nil && pnp.Kind(r.fs) == fs.FileEntry {
+			absPath := r.fs.Join(path, ".pnp.js")
+			if json := r.tryToExtractYarnPnPDataFromJS(absPath, &r.caches.JSONCache); json.Data != nil {
+				info.pnpData = compileYarnPnPData(absPath, path, json)
+			}
 		}
 	}
 

--- a/internal/resolver/testExpectations.json
+++ b/internal/resolver/testExpectations.json
@@ -13,7 +13,7 @@
       [null, [
         [null, {
           "packageLocation": "./",
-          "packageDependencies": [],
+          "packageDependencies": [["test", "npm:1.0.0"]],
           "linkType": "SOFT"
         }]
       ]],

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -2653,17 +2653,25 @@ require("/assets/file.png");
       import foo from './test.zip/foo.js'
       import bar from './test.zip/bar/bar.js'
 
-      import virtual1 from './test.zip/__virtual__/ignored/0/foo.js'
-      import virtual2 from './test.zip/ignored/__virtual__/ignored/1/foo.js'
-      import virtual3 from './test.zip/__virtual__/ignored/1/test.zip/foo.js'
+      import __virtual__1 from './test.zip/__virtual__/ignored/0/foo.js'
+      import __virtual__2 from './test.zip/ignored/__virtual__/ignored/1/foo.js'
+      import __virtual__3 from './test.zip/__virtual__/ignored/1/test.zip/foo.js'
+
+      import $$virtual1 from './test.zip/$$virtual/ignored/0/foo.js'
+      import $$virtual2 from './test.zip/ignored/$$virtual/ignored/1/foo.js'
+      import $$virtual3 from './test.zip/$$virtual/ignored/1/test.zip/foo.js'
 
       console.log({
         foo,
         bar,
 
-        virtual1,
-        virtual2,
-        virtual3,
+        __virtual__1,
+        __virtual__2,
+        __virtual__3,
+
+        $$virtual1,
+        $$virtual2,
+        $$virtual3,
       })
     `)
 
@@ -2702,13 +2710,25 @@ require("/assets/file.png");
   // scripts/.js-api-tests/zipFile/test.zip/__virtual__/ignored/1/test.zip/foo.js
   var foo_default4 = "foo";
 
+  // scripts/.js-api-tests/zipFile/test.zip/$$virtual/ignored/0/foo.js
+  var foo_default5 = "foo";
+
+  // scripts/.js-api-tests/zipFile/test.zip/ignored/$$virtual/ignored/1/foo.js
+  var foo_default6 = "foo";
+
+  // scripts/.js-api-tests/zipFile/test.zip/$$virtual/ignored/1/test.zip/foo.js
+  var foo_default7 = "foo";
+
   // scripts/.js-api-tests/zipFile/entry.js
   console.log({
     foo: foo_default,
     bar: bar_default,
-    virtual1: foo_default2,
-    virtual2: foo_default3,
-    virtual3: foo_default4
+    __virtual__1: foo_default2,
+    __virtual__2: foo_default3,
+    __virtual__3: foo_default4,
+    $$virtual1: foo_default5,
+    $$virtual2: foo_default6,
+    $$virtual3: foo_default7
   });
 })();
 `)


### PR DESCRIPTION
Changes:

* Make `$$virtual` an alias for `__virtual__`
* Update `testExpectations.json` to the latest value
* Check for platform-specific absolute paths instead of always for the `/` prefix
* Ignore PnP manifests in virtual folders

With these changes, Yarn now builds with these instructions:

```
yarn up esbuild@0.15.0
sed -i.bak -e "s/, pnpPlugin()//" packages/yarnpkg-builder/sources/commands/build/bundle.ts
sed -i.bak -e "s/silent/debug/" packages/yarnpkg-builder/sources/commands/build/bundle.ts
ESBUILD_BINARY_PATH=<path-to-esbuild> yarn build:cli
```

Fixes #2452
