### PR TITLE
fix: don't write pnpapi binary into own pkg

### DIFF
--- a/lib/npm/node-platform.ts
+++ b/lib/npm/node-platform.ts
@@ -2,6 +2,8 @@ import fs = require('fs');
 import os = require('os');
 import path = require('path');
 
+declare const ESBUILD_VERSION: string;
+
 // This feature was added to give external code a way to modify the binary
 // path without modifying the code itself. Do not remove this because
 // external code relies on this.
@@ -186,7 +188,12 @@ by esbuild to install the correct binary executable for your current platform.`)
   }
   if (pnpapi) {
     const root = pnpapi.getPackageInformation(pnpapi.topLevel).packageLocation;
-    const binTargetPath = path.join(root, 'node_modules/.esbuild', version, `pnpapi-${pkg}-${path.basename(subpath)}`);
+    const binTargetPath = path.join(
+      root,
+      'node_modules/.esbuild',
+      ESBUILD_VERSION,
+      `pnpapi-${pkg}-${path.basename(subpath)}`
+    );
     if (!fs.existsSync(binTargetPath)) {
       fs.mkdirSync(path.dirname(binTargetPath), { recursive: true });
       fs.copyFileSync(binPath, binTargetPath);

--- a/lib/npm/node-platform.ts
+++ b/lib/npm/node-platform.ts
@@ -179,16 +179,16 @@ by esbuild to install the correct binary executable for your current platform.`)
   // it's inside a virtual file system and the OS needs it in the real file
   // system. So we need to copy the file out of the virtual file system into
   // the real file system.
-  let isYarnPnP = false;
+  let pnpapi = false;
   try {
-    require('pnpapi');
-    isYarnPnP = true;
+    pnpapi = require('pnpapi');
   } catch (e) {
   }
-  if (isYarnPnP) {
-    const esbuildLibDir = path.dirname(require.resolve('esbuild'));
-    const binTargetPath = path.join(esbuildLibDir, `pnpapi-${pkg}-${path.basename(subpath)}`);
+  if (pnpapi) {
+    const root = pnpapi.getPackageInformation(pnpapi.topLevel).packageLocation;
+    const binTargetPath = path.join(root, 'node_modules/.esbuild', version, `pnpapi-${pkg}-${path.basename(subpath)}`);
     if (!fs.existsSync(binTargetPath)) {
+      fs.mkdirSync(path.dirname(binTargetPath), { recursive: true });
       fs.copyFileSync(binPath, binTargetPath);
       fs.chmodSync(binTargetPath, 0o755);
     }

--- a/lib/npm/node-platform.ts
+++ b/lib/npm/node-platform.ts
@@ -181,7 +181,7 @@ by esbuild to install the correct binary executable for your current platform.`)
   // it's inside a virtual file system and the OS needs it in the real file
   // system. So we need to copy the file out of the virtual file system into
   // the real file system.
-  let pnpapi = false;
+  let pnpapi: any;
   try {
     pnpapi = require('pnpapi');
   } catch (e) {
@@ -190,9 +190,10 @@ by esbuild to install the correct binary executable for your current platform.`)
     const root = pnpapi.getPackageInformation(pnpapi.topLevel).packageLocation;
     const binTargetPath = path.join(
       root,
-      'node_modules/.esbuild',
-      ESBUILD_VERSION,
-      `pnpapi-${pkg}-${path.basename(subpath)}`
+      'node_modules',
+      '.cache',
+      'esbuild',
+      `pnpapi-${pkg}-${ESBUILD_VERSION}-${path.basename(subpath)}`,
     );
     if (!fs.existsSync(binTargetPath)) {
       fs.mkdirSync(path.dirname(binTargetPath), { recursive: true });

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -49,6 +49,7 @@ const buildNeutralLib = (esbuildPath) => {
     '--outfile=' + path.join(binDir, 'esbuild'),
     '--bundle',
     '--target=' + nodeTarget,
+    '--define:ESBUILD_VERSION=' + JSON.stringify(version),
     '--external:esbuild',
     '--platform=node',
     '--log-level=warning',


### PR DESCRIPTION
583569e8f5a16b64e8e1ca23e224f9092ad4712d changed the PnP workaround so that the binary is copied into the `esbuild` package location instead of a global cache dir. However, packages should never write into their own folder as it (usually) is read-only: https://yarnpkg.com/advanced/rulebook/#packages-should-never-write-inside-their-own-folder-outside-of-postinstall

In most cases this worked because `esbuild` is automatically unplugged due to its postinstall script and therefore its folder becomes writeable. However, as soon as you disable scripts for the package or globally in `.yarnrc.yml`, `esbuild` won't be unplugged any longer, its folder becomes read-only and everything breaks. So instead, this PR writes the PnP binary to `node_modules/.esbuild/<version>/`.