### PR TITLE
Include `new URL("...", import.meta.url)` references in the import graph.

### DIFF
--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -440,7 +440,7 @@ func (*EIf) isExpr()                   {}
 func (*ERequireString) isExpr()        {}
 func (*ERequireResolveString) isExpr() {}
 func (*EImportString) isExpr()         {}
-func (*ERelativeURL) isExpr()         {}
+func (*ERelativeURL) isExpr()          {}
 func (*EImportCall) isExpr()           {}
 
 type EArray struct {

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -440,6 +440,7 @@ func (*EIf) isExpr()                   {}
 func (*ERequireString) isExpr()        {}
 func (*ERequireResolveString) isExpr() {}
 func (*EImportString) isExpr()         {}
+func (*ERelativeURL) isExpr()         {}
 func (*EImportCall) isExpr()           {}
 
 type EArray struct {
@@ -731,6 +732,10 @@ type ERequireString struct {
 }
 
 type ERequireResolveString struct {
+	ImportRecordIndex uint32
+}
+
+type ERelativeURL struct {
 	ImportRecordIndex uint32
 }
 

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -14359,35 +14359,40 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 
 	case *js_ast.ENew:
 		hasSpread := false
-		relativeJS := false
+		isImportGraphURL := false
 
 		e.Target = p.visitExpr(e.Target)
-		// new url?
+		// Test for `new URL("./relative/path.js", import.meta.url)` (https://github.com/evanw/esbuild/issues/795)
 		if id, ok := e.Target.Data.(*js_ast.EIdentifier); ok {
 			symbol := p.symbols[id.Ref.InnerIndex]
 			if symbol.OriginalName == "URL" && len(e.Args) == 2 {
-				if _, ok := e.Args[0].Data.(*js_ast.EString); ok {
-					// TODO check if url is relative and a js file
+				if s, ok := e.Args[0].Data.(*js_ast.EString); ok {
 					if eDot, ok := e.Args[1].Data.(*js_ast.EDot); ok {
 						if _, ok := eDot.Target.Data.(*js_ast.EImportMeta); ok {
 							if eDot.Name == "url" {
-								relativeJS = true
+								// TODO: This should:
+								// - Include more file types.
+								// - Understand the relative JS and TS files even if the file extension is not provided (like in TypeScript).
+								// - Check if the actual file exists in the import graph?
+								isInImportGraph := strings.HasSuffix(helpers.UTF16ToString(s.Value), ".js") || strings.HasSuffix(helpers.UTF16ToString(s.Value), ".ts")
+
+								if isInImportGraph {
+									isImportGraphURL = true
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-		if relativeJS {
-			// replace the 2 args ("../path/to.js", import.meta.url)
-			// with 1 ERelativeURL
-			s, _ := e.Args[0].Data.(*js_ast.EString);
+		if isImportGraphURL {
+			s, _ := e.Args[0].Data.(*js_ast.EString)
 			importRecordIndex := p.addImportRecord(ast.ImportDynamic, e.Args[0].Loc, helpers.UTF16ToString(s.Value), nil)
 			p.importRecordsForCurrentPart = append(p.importRecordsForCurrentPart, importRecordIndex)
-			e.Args = []js_ast.Expr{js_ast.Expr{Loc: e.Args[0].Loc, Data: &js_ast.ERelativeURL{
-				ImportRecordIndex:       importRecordIndex,
-			}}}
-	  } else {
+			e.Args[0] = js_ast.Expr{Loc: e.Args[0].Loc, Data: &js_ast.ERelativeURL{
+				ImportRecordIndex: importRecordIndex,
+			}}
+		} else {
 			p.warnAboutImportNamespaceCall(e.Target, exprKindNew)
 
 			for i, arg := range e.Args {

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -14361,22 +14361,45 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 		hasSpread := false
 
 		e.Target = p.visitExpr(e.Target)
-		p.warnAboutImportNamespaceCall(e.Target, exprKindNew)
-
-		for i, arg := range e.Args {
-			arg = p.visitExpr(arg)
-			if _, ok := arg.Data.(*js_ast.ESpread); ok {
-				hasSpread = true
+		// new url?
+		if id, ok := e.Target.Data.(*js_ast.EIdentifier); ok {
+			symbol := p.symbols[id.Ref.InnerIndex]
+			if symbol.OriginalName == "URL" {
+				if s, ok := e.Args[0].Data.(*js_ast.EString); ok {
+					// TODO check if url is relative and a js file
+					if eDot, ok := e.Args[1].Data.(*js_ast.EDot); ok {
+						if _, ok := eDot.Target.Data.(*js_ast.EImportMeta); ok {
+							if eDot.Name == "url" {
+								// replace the 2 args ("../path/to.js", import.meta.url)
+								// with 1 ERelativeURL
+								importRecordIndex := p.addImportRecord(ast.ImportDynamic, e.Args[0].Loc, helpers.UTF16ToString(s.Value), nil)
+								p.importRecordsForCurrentPart = append(p.importRecordsForCurrentPart, importRecordIndex)
+								e.Args = []js_ast.Expr{js_ast.Expr{Loc: e.Args[0].Loc, Data: &js_ast.ERelativeURL{
+									ImportRecordIndex:       importRecordIndex,
+								}}}
+							}
+						}
+					}
+				}
+			} else {
+				p.warnAboutImportNamespaceCall(e.Target, exprKindNew)
+	
+				for i, arg := range e.Args {
+					arg = p.visitExpr(arg)
+					if _, ok := arg.Data.(*js_ast.ESpread); ok {
+						hasSpread = true
+					}
+					e.Args[i] = arg
+				}
+	
+				// "new foo(1, ...[2, 3], 4)" => "new foo(1, 2, 3, 4)"
+				if p.options.minifySyntax && hasSpread && in.assignTarget == js_ast.AssignTargetNone {
+					e.Args = inlineSpreadsOfArrayLiterals(e.Args)
+				}
+	
+				p.maybeMarkKnownGlobalConstructorAsPure(e)
 			}
-			e.Args[i] = arg
 		}
-
-		// "new foo(1, ...[2, 3], 4)" => "new foo(1, 2, 3, 4)"
-		if p.options.minifySyntax && hasSpread && in.assignTarget == js_ast.AssignTargetNone {
-			e.Args = inlineSpreadsOfArrayLiterals(e.Args)
-		}
-
-		p.maybeMarkKnownGlobalConstructorAsPure(e)
 
 	case *js_ast.EArrow:
 		asyncArrowNeedsToBeLowered := e.IsAsync && p.options.unsupportedJSFeatures.Has(compat.AsyncAwait)

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1886,6 +1886,13 @@ func (p *printer) printExpr(expr js_ast.Expr, level js_ast.L, flags printExprFla
 			p.print(")")
 		}
 
+	case *js_ast.ERelativeURL:
+		record := &p.importRecords[e.ImportRecordIndex]
+		if record.Kind == ast.ImportDynamic {
+			p.addSourceMapping(record.Range.Loc)
+			p.printQuotedUTF8(record.Path.Text, true /* allowBacktick */)
+		}
+
 	case *js_ast.EImportString:
 		var leadingInteriorComments []js_ast.Comment
 		if !p.options.MinifyWhitespace {


### PR DESCRIPTION
There are important use cases when it is valuable to get the URL of an entry point, such as for web worker instantiation: https://github.com/evanw/esbuild/issues/312

This allows `esbuild` to handle the most portable way to instantiate a web worker (which works natively in browsers/`node`, and is understood by a lot of other bundlers already):

```js
const workerURL = new URL("./worker.js", import.meta.url);

// Either construct directly:
new Worker(workerURL, { type: "module" });

// Or construct using a trampoline (needed if the worker code is on a different origin than the current page, e.g. on a CDN):
const blob = new Blob([`import "${workerURL}";`], { type: "text/javascript" });
new Worker(URL.createObjectURL(blob), { type: "module" });
```

This PR implements, thanks in part to @firien [here](https://github.com/evanw/esbuild/issues/795#issuecomment-1214399891). However, it still has issues:

- It's currently hardcoded to detect `.ts` and `.js` suffixes so I can test it. But:
  - In TypeScript, it should be possible to use import paths without a file extension.
  - Other file types (e.g. `.tsx` and `.jsx`) should be included by default, possibly any file types as long as the file exists at the referenced relative path (to fully address #795).
- I haven't added tests yet.

@evanw Could I ask if you think the approach in this PR will work, and the best way to address the issues listed above?