### PR TITLE
Suggest using `Number.isNaN` instead of `isNaN` in `equals-nan` warning

### DIFF
--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -4019,7 +4019,7 @@ delete-super.js: WARNING: Attempting to delete a property of "super" will throw 
 dup-case.js: WARNING: This case clause will never be evaluated because it duplicates an earlier case clause
 dup-case.js: NOTE: The earlier case clause is here:
 equals-nan.js: WARNING: Comparison with NaN using the "===" operator here is always false
-NOTE: Floating-point equality is defined such that NaN is never equal to anything, so "x === NaN" always returns false. You need to use "isNaN(x)" instead to test for NaN.
+NOTE: Floating-point equality is defined such that NaN is never equal to anything, so "x === NaN" always returns false. You need to use "Number.isNaN(x)" instead to test for NaN.
 equals-neg-zero.js: WARNING: Comparison with -0 using the "===" operator will also match 0
 NOTE: Floating-point equality is defined such that 0 and -0 are equal, so "x === -0" returns true for both 0 and -0. You need to use "Object.is(x, -0)" instead to test for -0.
 equals-object.js: WARNING: Comparison using the "===" operator here is always false

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -11135,7 +11135,7 @@ func (p *parser) warnAboutEqualityCheck(op string, value js_ast.Expr, afterOpLoc
 			}
 			p.log.AddIDWithNotes(logger.MsgID_JS_EqualsNaN, kind, &p.tracker, r, text,
 				[]logger.MsgData{{Text: "Floating-point equality is defined such that NaN is never equal to anything, so \"x === NaN\" always returns false. " +
-					"You need to use \"isNaN(x)\" instead to test for NaN."}})
+					"You need to use \"Number.isNaN(x)\" instead to test for NaN."}})
 			return true
 		}
 

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2769,7 +2769,7 @@ func TestWarningEqualsNewObject(t *testing.T) {
 
 func TestWarningEqualsNaN(t *testing.T) {
 	note := "NOTE: Floating-point equality is defined such that NaN is never equal to anything, so \"x === NaN\" always returns false. " +
-		"You need to use \"isNaN(x)\" instead to test for NaN.\n"
+		"You need to use \"Number.isNaN(x)\" instead to test for NaN.\n"
 
 	expectParseError(t, "x === NaN", "<stdin>: WARNING: Comparison with NaN using the \"===\" operator here is always false\n"+note)
 	expectParseError(t, "x !== NaN", "<stdin>: WARNING: Comparison with NaN using the \"!==\" operator here is always true\n"+note)


### PR DESCRIPTION
Since the `equals-nan` warning is about equality comparison, it should suggest the stricter [`Number.isNaN`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN) instead of type coercing [`isNaN`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isNaN).