### PR TITLE
fix: missing ios15 in top-level await

### DIFF
--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -690,6 +690,7 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Edge:    {{start: v{89, 0, 0}}},
 		ES:      {{start: v{2022, 0, 0}}},
 		Firefox: {{start: v{89, 0, 0}}},
+		IOS:     {{start: v{15, 0, 0}}},
 		Node:    {{start: v{14, 8, 0}}},
 		Opera:   {{start: v{75, 0, 0}}},
 		Safari:  {{start: v{15, 0, 0}}},

--- a/scripts/compat-table.js
+++ b/scripts/compat-table.js
@@ -234,6 +234,7 @@ mergeVersions('TopLevelAwait', {
   chrome89: true,
   edge89: true,
   firefox89: true,
+  ios15: true,
   node14_8: true,
   opera75: true,
   safari15: true,


### PR DESCRIPTION
fix #2504