### PR TITLE
feat: @keyframes now support <string> type AND will convert it into ident if possible...

### DIFF
--- a/internal/css_ast/css_ast.go
+++ b/internal/css_ast/css_ast.go
@@ -319,9 +319,10 @@ func (r *RAtImport) Hash() (uint32, bool) {
 }
 
 type RAtKeyframes struct {
-	AtToken string
-	Name    string
-	Blocks  []KeyframeBlock
+	AtToken      string
+	Name         string
+	IsStringName bool
+	Blocks       []KeyframeBlock
 }
 
 type KeyframeBlock struct {

--- a/internal/css_parser/css_decls.go
+++ b/internal/css_parser/css_decls.go
@@ -237,6 +237,15 @@ func (p *parser) processDeclarations(rules []css_ast.Rule) []css_ast.Rule {
 			if p.options.MinifySyntax {
 				borderRadius.mangleCorner(rules, decl, i, p.options.MinifyWhitespace, borderRadiusBottomLeft)
 			}
+
+		case css_ast.DAnimation,
+			css_ast.DAnimationName:
+			mustBeString := cssWideAndReservedKeywords[decl.Value[0].Text] || decl.Value[0].Text == "none"
+			if p.options.MinifySyntax {
+				if decl.Value[0].Kind == css_lexer.TString && !mustBeString {
+					decl.Value[0].Kind = css_lexer.TIdent
+				}
+			}
 		}
 	}
 

--- a/internal/css_parser/css_decls.go
+++ b/internal/css_parser/css_decls.go
@@ -4,6 +4,7 @@ import (
 	"github.com/evanw/esbuild/internal/compat"
 	"github.com/evanw/esbuild/internal/css_ast"
 	"github.com/evanw/esbuild/internal/css_lexer"
+	"strings"
 )
 
 func (p *parser) commaToken() css_ast.Token {
@@ -240,7 +241,8 @@ func (p *parser) processDeclarations(rules []css_ast.Rule) []css_ast.Rule {
 
 		case css_ast.DAnimation,
 			css_ast.DAnimationName:
-			mustBeString := cssWideAndReservedKeywords[decl.Value[0].Text] || decl.Value[0].Text == "none"
+			text := strings.ToLower(decl.Value[0].Text)
+			mustBeString := cssWideAndReservedKeywords[text] || text == "none"
 			if p.options.MinifySyntax {
 				if decl.Value[0].Kind == css_lexer.TString && !mustBeString {
 					decl.Value[0].Kind = css_lexer.TIdent

--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -832,11 +832,15 @@ abortRuleParser:
 
 		if p.peek(css_lexer.TIdent) {
 			name = p.decoded()
+			if name == "none" {
+				p.log.AddID(logger.MsgID_CSS_CSSSyntaxError, logger.Warning, &p.tracker, atRange, "Expected identifier but found `none` which is invalid in this context")
+				p.prevError = p.current().Range.Loc
+			}
 			p.advance()
 			isStringName = false
 		} else if p.peek(css_lexer.TString) {
 			name = p.decoded()
-			isStringName = !p.options.MinifySyntax || cssWideAndReservedKeywords[name]
+			isStringName = !p.options.MinifySyntax || cssWideAndReservedKeywords[name] || name == "none"
 			p.advance()
 		} else if !(p.expect(css_lexer.TIdent) && p.expect(css_lexer.TString)) && !p.peek(css_lexer.TOpenBrace) {
 			// Consider string names a syntax error even though they are allowed by

--- a/internal/css_parser/css_parser.go
+++ b/internal/css_parser/css_parser.go
@@ -831,7 +831,7 @@ abortRuleParser:
 		var isStringName bool
 
 		if p.peek(css_lexer.TIdent) {
-			name = p.decoded()
+			name = strings.ToLower(p.decoded())
 			if name == "none" {
 				p.log.AddID(logger.MsgID_CSS_CSSSyntaxError, logger.Warning, &p.tracker, atRange, "Expected identifier but found `none` which is invalid in this context")
 				p.prevError = p.current().Range.Loc
@@ -839,7 +839,7 @@ abortRuleParser:
 			p.advance()
 			isStringName = false
 		} else if p.peek(css_lexer.TString) {
-			name = p.decoded()
+			name = strings.ToLower(p.decoded())
 			isStringName = !p.options.MinifySyntax || cssWideAndReservedKeywords[name] || name == "none"
 			p.advance()
 		} else if !(p.expect(css_lexer.TIdent) && p.expect(css_lexer.TString)) && !p.peek(css_lexer.TOpenBrace) {

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1913,5 +1913,6 @@ func TestAnimationName(t *testing.T) {
 			expectPrintedMangleMinify(t, "a { "+key+": \""+cssWideKeyword+"\" }", "a{"+key+":\""+cssWideKeyword+"\"}")
 		}
 		expectPrintedMangleMinify(t, "a { "+key+": \"none\" }", "a{"+key+":\"none\"}")
+		expectPrintedMangleMinify(t, "a { "+key+": \"None\" }", "a{"+key+":\"None\"}")
 	}
 }

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1013,10 +1013,15 @@ func TestLegalComment(t *testing.T) {
 func TestAtKeyframes(t *testing.T) {
 	expectPrinted(t, "@keyframes {}", "@keyframes \"\" {\n}\n")
 	expectPrinted(t, "@keyframes name{}", "@keyframes name {\n}\n")
-	// string name valid
+	// string name valid to convert into ident
 	expectPrinted(t, `@keyframes "name"{}`, "@keyframes \"name\" {\n}\n")
 	expectPrintedMinify(t, `@keyframes "name"{}`, "@keyframes \"name\"{}")
 	expectPrintedMangleMinify(t, `@keyframes "name"{}`, "@keyframes name{}")
+
+	// string name valid to convert into ident but need escape
+	expectPrinted(t, `@keyframes "foo bar"{}`, "@keyframes \"foo bar\" {\n}\n")
+	expectPrintedMinify(t, `@keyframes "foo bar"{}`, "@keyframes \"foo bar\"{}")
+	expectPrintedMangleMinify(t, `@keyframes "foo bar"{}`, "@keyframes foo\\ bar{}")
 
 	// string name that doesn't allow to convert to ident
 	for cssWideKeywords := range cssWideAndReservedKeywords {

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1898,3 +1898,20 @@ func TestPropertyTypoWarning(t *testing.T) {
 	// Short names should not be corrected ("alt" is actually valid in WebKit, and should not become "all")
 	expectParseError(t, "a { alt: \"\" }", "")
 }
+
+func TestAnimationName(t *testing.T) {
+	tests := []string{"animation", "animation-name"}
+
+	for _, key := range tests {
+		expectPrinted(t, "a { "+key+": name }", "a {\n  "+key+": name;\n}\n")
+		expectPrinted(t, "a { "+key+": \"name\" }", "a {\n  "+key+": \"name\";\n}\n")
+		expectPrinted(t, "a { "+key+": \"foo bar\" }", "a {\n  "+key+": \"foo bar\";\n}\n")
+
+		expectPrintedMangleMinify(t, "a { "+key+": \"name\" }", "a{"+key+":name}")
+		expectPrintedMangleMinify(t, "a { "+key+": \"foo bar\" }", "a{"+key+":foo\\ bar}")
+		for cssWideKeyword := range cssWideAndReservedKeywords {
+			expectPrintedMangleMinify(t, "a { "+key+": \""+cssWideKeyword+"\" }", "a{"+key+":\""+cssWideKeyword+"\"}")
+		}
+		expectPrintedMangleMinify(t, "a { "+key+": \"none\" }", "a{"+key+":\"none\"}")
+	}
+}

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1029,6 +1029,9 @@ func TestAtKeyframes(t *testing.T) {
 		expectPrintedMinify(t, `@keyframes "`+cssWideKeywords+`"{}`, "@keyframes \""+cssWideKeywords+"\"{}")
 		expectPrintedMangleMinify(t, `@keyframes "`+cssWideKeywords+`"{}`, "@keyframes \""+cssWideKeywords+"\"{}")
 	}
+	expectPrinted(t, `@keyframes "none"{}`, "@keyframes \"none\" {\n}\n")
+	expectPrintedMinify(t, `@keyframes "none"{}`, "@keyframes \"none\"{}")
+	expectPrintedMangleMinify(t, `@keyframes "none"{}`, "@keyframes \"none\"{}")
 
 	expectPrinted(t, "@keyframes name {}", "@keyframes name {\n}\n")
 	expectPrinted(t, "@keyframes name{0%,50%{color:red}25%,75%{color:blue}}",
@@ -1050,6 +1053,7 @@ func TestAtKeyframes(t *testing.T) {
 	expectPrinted(t, "@-ms-keyframes name {}", "@-ms-keyframes name {\n}\n")
 	expectPrinted(t, "@-o-keyframes name {}", "@-o-keyframes name {\n}\n")
 
+	expectParseError(t, "@keyframes none{}", "<stdin>: WARNING: Expected identifier but found `none` which is invalid in this context\n")
 	expectParseError(t, "@keyframes {}", "<stdin>: WARNING: Expected identifier but found \"{\"\n")
 	expectParseError(t, "@keyframes name { 0% 100% {} }", "<stdin>: WARNING: Expected \",\" but found \"100%\"\n")
 	expectParseError(t, "@keyframes name { {} 0% {} }", "<stdin>: WARNING: Expected percentage but found \"{\"\n")

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1013,6 +1013,18 @@ func TestLegalComment(t *testing.T) {
 func TestAtKeyframes(t *testing.T) {
 	expectPrinted(t, "@keyframes {}", "@keyframes \"\" {\n}\n")
 	expectPrinted(t, "@keyframes name{}", "@keyframes name {\n}\n")
+	// string name valid
+	expectPrinted(t, `@keyframes "name"{}`, "@keyframes \"name\" {\n}\n")
+	expectPrintedMinify(t, `@keyframes "name"{}`, "@keyframes \"name\"{}")
+	expectPrintedMangleMinify(t, `@keyframes "name"{}`, "@keyframes name{}")
+
+	// string name that doesn't allow to convert to ident
+	for cssWideKeywords := range cssWideAndReservedKeywords {
+		expectPrinted(t, `@keyframes "`+cssWideKeywords+`"{}`, "@keyframes \""+cssWideKeywords+"\" {\n}\n")
+		expectPrintedMinify(t, `@keyframes "`+cssWideKeywords+`"{}`, "@keyframes \""+cssWideKeywords+"\"{}")
+		expectPrintedMangleMinify(t, `@keyframes "`+cssWideKeywords+`"{}`, "@keyframes \""+cssWideKeywords+"\"{}")
+	}
+
 	expectPrinted(t, "@keyframes name {}", "@keyframes name {\n}\n")
 	expectPrinted(t, "@keyframes name{0%,50%{color:red}25%,75%{color:blue}}",
 		"@keyframes name {\n  0%, 50% {\n    color: red;\n  }\n  25%, 75% {\n    color: blue;\n  }\n}\n")
@@ -1034,7 +1046,6 @@ func TestAtKeyframes(t *testing.T) {
 	expectPrinted(t, "@-o-keyframes name {}", "@-o-keyframes name {\n}\n")
 
 	expectParseError(t, "@keyframes {}", "<stdin>: WARNING: Expected identifier but found \"{\"\n")
-	expectParseError(t, "@keyframes 'name' {}", "<stdin>: WARNING: Expected identifier but found \"'name'\"\n")
 	expectParseError(t, "@keyframes name { 0% 100% {} }", "<stdin>: WARNING: Expected \",\" but found \"100%\"\n")
 	expectParseError(t, "@keyframes name { {} 0% {} }", "<stdin>: WARNING: Expected percentage but found \"{\"\n")
 	expectParseError(t, "@keyframes name { 100 {} }", "<stdin>: WARNING: Expected percentage but found \"100\"\n")

--- a/internal/css_printer/css_printer.go
+++ b/internal/css_printer/css_printer.go
@@ -111,7 +111,13 @@ func (p *printer) printRule(rule css_ast.Rule, indent int32, omitTrailingSemicol
 		if r.Name == "" {
 			p.print("\"\"")
 		} else {
-			p.printIdent(r.Name, identNormal, canDiscardWhitespaceAfter)
+			if r.IsStringName {
+				p.print("\"")
+				p.print(r.Name)
+				p.print("\"")
+			} else {
+				p.printIdent(r.Name, identNormal, canDiscardWhitespaceAfter)
+			}
 		}
 		if !p.options.MinifyWhitespace {
 			p.print(" ")


### PR DESCRIPTION
... Plus `animation` and `animation-name` mangling as well

fixes: #2555