### PR TITLE
fix transform tsconfigRaw type

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -253,7 +253,7 @@ export interface TransformOptions extends CommonOptions {
   tsconfigRaw?: string | {
     compilerOptions?: {
       alwaysStrict?: boolean,
-      importsNotUsedAsValues?: 'remove' | 'prexserve' | 'error',
+      importsNotUsedAsValues?: 'remove' | 'preserve' | 'error',
       jsx?: 'react' | 'react-jsx' | 'react-jsxdev' | 'preserve',
       jsxFactory?: string,
       jsxFragmentFactory?: string,

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -252,11 +252,15 @@ export interface ServeResult {
 export interface TransformOptions extends CommonOptions {
   tsconfigRaw?: string | {
     compilerOptions?: {
+      alwaysStrict?: boolean,
+      importsNotUsedAsValues?: 'remove' | 'prexserve' | 'error',
+      jsx?: 'react' | 'react-jsx' | 'react-jsxdev' | 'preserve',
       jsxFactory?: string,
       jsxFragmentFactory?: string,
-      useDefineForClassFields?: boolean,
-      importsNotUsedAsValues?: 'remove' | 'preserve' | 'error',
+      jsxImportSource?: string,
       preserveValueImports?: boolean,
+      target?: string,
+      useDefineForClassFields?: boolean,
     },
   };
 


### PR DESCRIPTION
This PR updates `TransformOptions["tsconfigRaw"]["compilerOptions"]` type based on:
https://github.com/evanw/esbuild/blob/23709e2c9f15c643e6c707d9cc77a25e5d9147cf/pkg/api/api_impl.go#L1372-L1405


