### PR TITLE
feat: reuse slots when minifying identifiers

### DIFF
--- a/internal/bundler_tests/bundler_default_test.go
+++ b/internal/bundler_tests/bundler_default_test.go
@@ -8168,3 +8168,32 @@ NOTE: You can mark the path "node_modules/fflate" as external to exclude it from
 `,
 	})
 }
+
+func TestMinifyHoistedVar(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				;(function() {
+					var pl = 1, ac = 2
+					{	var opt = {} }
+					{
+						var opt = { a: 1 }
+						;(function() {
+							var a = opt.a
+							var s = {}
+							fn(a, s)
+							fn(s)
+						})()
+					}
+				})()
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:              config.ModeBundle,
+			MinifyIdentifiers: true,
+			AbsOutputFile:     "/out.js",
+			OutputFormat:      config.FormatIIFE,
+		},
+	})
+}

--- a/internal/bundler_tests/snapshots/snapshots_default.txt
+++ b/internal/bundler_tests/snapshots/snapshots_default.txt
@@ -22,9 +22,9 @@ export function a(o = foo) {
   return o;
 }
 export class b {
-  fn(r = foo) {
-    var f;
-    return r;
+  fn(o = foo) {
+    var r;
+    return o;
   }
 }
 export let c = [
@@ -53,34 +53,34 @@ TestArgumentsSpecialCaseNoBundle
 ---------- /out.js ----------
 (() => {
   var r;
-  function t(n = arguments) {
+  function t(r = arguments) {
     return arguments;
   }
-  (function(n = arguments) {
+  (function(r = arguments) {
     return arguments;
   });
-  ({ foo(n = arguments) {
+  ({ foo(r = arguments) {
     return arguments;
   } });
-  class u {
-    foo(e = arguments) {
+  class n {
+    foo(r = arguments) {
       return arguments;
     }
   }
   (class {
-    foo(n = arguments) {
+    foo(r = arguments) {
       return arguments;
     }
   });
-  function t(n = arguments) {
+  function t(r = arguments) {
     var arguments;
     return arguments;
   }
-  (function(n = arguments) {
+  (function(r = arguments) {
     var arguments;
     return arguments;
   });
-  ({ foo(n = arguments) {
+  ({ foo(r = arguments) {
     var arguments;
     return arguments;
   } });
@@ -131,14 +131,14 @@ TestArrowFnScope
 ---------- /out.js ----------
 // entry.js
 tests = {
-  0: (s = (e) => s + e, t) => s + t,
-  1: (s, t = (e) => t + e) => t + s,
-  2: (s = (a = (c) => s + a + c, b) => s + a + b, t, e) => s + t + e,
-  3: (s, t, e = (a, b = (c) => e + b + c) => e + b + a) => e + s + t,
+  0: (s = (t) => s + t, t) => s + t,
+  1: (s, t = (s) => t + s) => t + s,
+  2: (s = (t = (e) => s + t + e, e) => s + t + e, t, e) => s + t + e,
+  3: (s, t, e = (s, t = (s) => e + t + s) => e + t + s) => e + s + t,
   4: (x = (s) => x + s, y, x + y),
   5: (y, x = (s) => x + s, x + y),
-  6: (x = (s = (e) => x + s + e, t) => x + s + t, y, z, x + y + z),
-  7: (y, z, x = (s, t = (e) => x + t + e) => x + t + s, x + y + z)
+  6: (x = (s = (t) => x + s + t, t) => x + s + t, y, z, x + y + z),
+  7: (y, z, x = (s, t = (s) => x + t + s) => x + t + s, x + y + z)
 };
 
 ================================================================================
@@ -1048,25 +1048,25 @@ ok(
 TestDirectEvalTaintingNoBundle
 ---------- /out.js ----------
 function test1() {
-  function add(n, t) {
-    return n + t;
+  function add(t, n) {
+    return t + n;
   }
   eval("add(1, 2)");
 }
 function test2() {
-  function n(t, e) {
-    return t + e;
+  function t(t, n) {
+    return t + n;
   }
   (0, eval)("add(1, 2)");
 }
 function test3() {
-  function n(t, e) {
-    return t + e;
+  function t(t, n) {
+    return t + n;
   }
 }
 function test4(eval) {
-  function add(n, t) {
-    return n + t;
+  function add(t, n) {
+    return t + n;
   }
   eval("add(1, 2)");
 }
@@ -1472,11 +1472,11 @@ export default 123;
 export var varName = 234;
 export let letName = 234;
 export const constName = 234;
-function s() {
+function o() {
 }
-class t {
+class s {
 }
-export { Class as Cls, s as Fn2, t as Cls2 };
+export { Class as Cls, o as Fn2, s as Cls2 };
 export function Func() {
 }
 export class Class {
@@ -4372,6 +4372,28 @@ TestMinifyArguments
 })();
 
 ================================================================================
+TestMinifyHoistedVar
+---------- /out.js ----------
+(() => {
+  // entry.js
+  (function() {
+    var n = 1, a = 2;
+    {
+      var r = {};
+    }
+    {
+      var r = { a: 1 };
+      (function() {
+        var n = r.a;
+        var a = {};
+        fn(n, a);
+        fn(a);
+      })();
+    }
+  })();
+})();
+
+================================================================================
 TestMinifyIdentifiersImportPathFrequencyAnalysis
 ---------- /out/import.js ----------
 var o=123;console.log(o,"no identifier in this file should be named W, X, Y, or Z");
@@ -4414,25 +4436,25 @@ TestMinifyPrivateIdentifiersNoBundle
 class Foo {
   #a;
   foo = class {
+    #a;
+    #o;
     #s;
-    #f;
-    #r;
   };
   get #o() {
   }
-  set #o(a) {
+  set #o(o) {
   }
 }
 class Bar {
   #a;
   foo = class {
+    #a;
+    #o;
     #s;
-    #f;
-    #r;
   };
   get #o() {
   }
-  set #o(a) {
+  set #o(o) {
   }
 }
 
@@ -4596,21 +4618,21 @@ console.log((0, import_demo_pkg.default)());
 TestNonDeterminismIssue2537
 ---------- /out.js ----------
 // entry.ts
-function b(o, e) {
+function o(n, e) {
   let r = "teun";
-  if (o) {
+  if (n) {
     let u = function(n) {
       return n * 2;
     }, t = function(n) {
       return n / 2;
     };
-    var i = u, a = t;
+    var f = u, i = t;
     r = u(e) + t(e);
   }
   return r;
 }
 export {
-  b as aap
+  o as aap
 };
 
 ================================================================================
@@ -6294,9 +6316,9 @@ TestWithStatementTaintingNoBundle
   let outerDead = 3;
   with ({}) {
     var hoisted = 4;
-    let t = 5;
+    let e = 5;
     hoisted++;
-    t++;
+    e++;
     if (1)
       outer++;
     if (0)

--- a/internal/bundler_tests/snapshots/snapshots_ts.txt
+++ b/internal/bundler_tests/snapshots/snapshots_ts.txt
@@ -857,26 +857,26 @@ export var Foo=(e=>(e[e.X=0]="X",e[e.Y=1]="Y",e[e.Z=e]="Z",e))(Foo||{});
 ================================================================================
 TestTSMinifyNamespace
 ---------- /a.js ----------
-var Foo;(e=>{let a;(p=>foo(e,p))(a=e.Bar||={})})(Foo||={});
+var Foo;(a=>{let e;(e=>foo(a,e))(e=a.Bar||={})})(Foo||={});
 
 ---------- /b.js ----------
-export var Foo;(e=>{let a;(p=>foo(e,p))(a=e.Bar||={})})(Foo||={});
+export var Foo;(a=>{let e;(e=>foo(a,e))(e=a.Bar||={})})(Foo||={});
 
 ================================================================================
 TestTSMinifyNamespaceNoArrow
 ---------- /a.js ----------
-var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||={})})(Foo||={});
+var Foo;(function(a){let e;(function(e){foo(a,e)})(e=a.Bar||={})})(Foo||={});
 
 ---------- /b.js ----------
-export var Foo;(function(e){let a;(function(p){foo(e,p)})(a=e.Bar||={})})(Foo||={});
+export var Foo;(function(a){let e;(function(e){foo(a,e)})(e=a.Bar||={})})(Foo||={});
 
 ================================================================================
 TestTSMinifyNamespaceNoLogicalAssignment
 ---------- /a.js ----------
-var Foo;(e=>{let a;(p=>foo(e,p))(a=e.Bar||(e.Bar={}))})(Foo||(Foo={}));
+var Foo;(a=>{let e;(e=>foo(a,e))(e=a.Bar||(a.Bar={}))})(Foo||(Foo={}));
 
 ---------- /b.js ----------
-export var Foo;(e=>{let a;(p=>foo(e,p))(a=e.Bar||(e.Bar={}))})(Foo||(Foo={}));
+export var Foo;(a=>{let e;(e=>foo(a,e))(e=a.Bar||(a.Bar={}))})(Foo||(Foo={}));
 
 ================================================================================
 TestTSMinifyNestedEnum

--- a/internal/js_ast/js_ast.go
+++ b/internal/js_ast/js_ast.go
@@ -1466,6 +1466,9 @@ type Symbol struct {
 	// avoid this. We also need to be able to replace such import items with
 	// undefined, which this status is also used for.
 	ImportItemStatus ImportItemStatus
+
+	// Record the scope where this symbol is declared or hoisted up to.
+	DeclareScope *Scope
 }
 
 // You should call "MergeSymbols" instead of calling this directly
@@ -1558,6 +1561,11 @@ type Scope struct {
 	Members   map[string]ScopeMember
 	Replaced  []ScopeMember
 	Generated []Ref
+
+	// Symbols used in the scope, for computing Enclosed.
+	UsedSymbols map[Ref]uint32
+	// Enclosed symbols in the scope.
+	Enclosed []Ref
 
 	// The location of the "use strict" directive for ExplicitStrictMode
 	UseStrictLoc logger.Loc


### PR DESCRIPTION
Currently, esbuild cannot reuse slots from those symbols from the outer scope that are not used in the current scope.

This PR implements slots reusing and helps reduce the final size of our large project.

## case 1

use smaller char set for better gzip compression

```javascript
((y, z, x = (z, y = z => x + y + z) => x + y + z) => x + y + z)
```

### before
```javascript
(s, t, e = (a, b = (c) => e + b + c) => e + b + a) => e + s + t
```

### after
```javascript
(s, t, e = (s, t = (s) => e + t + s) => e + t + s) => e + s + t
```

## case 2

use shorter variable name, which is useful for large bundles

```javascript
{
  let a = fn(), b = fn(), c = fn(), 
      d = fn(), e = fn(), f = fn(),
      g = fn(), h = fn(), i = fn(),
      j = fn(), k = fn(), l = fn(),
      m = fn(), n = fn(), o = fn(),
      p = fn(), q = fn(), r = fn(),
      s = fn(), t = fn(), u = fn(),
      v = fn(), w = fn(), x = fn(),
      y = fn(), z = fn()
  {
      let a = fn(), b = fn(), c = fn(), 
          d = fn(), e = fn(), f = fn(),
          g = fn(), h = fn(), i = fn(),
          j = fn(), k = fn(), l = fn(),
          m = fn(), n = fn(), o = fn(),
          p = fn(), q = fn(), r = fn(),
          s = fn(), t = fn(), u = fn(),
          v = fn(), w = fn(), x = fn(),
          y = fn(), z = fn()
      {
      	let a = fn()
        let b = fn()
        let c = fn()
      }
  }
}
```

### before
```javascript
{let f=fn(),n=fn(),e=fn(),l=fn(),t=fn(),a=fn(),b=fn(),c=fn(),d=fn(),g=fn(),h=fn(),i=fn(),j=fn(),k=fn(),m=fn(),o=fn(),p=fn(),q=fn(),r=fn(),s=fn(),u=fn(),v=fn(),w=fn(),x=fn(),y=fn(),z=fn();{let A=fn(),B=fn(),C=fn(),D=fn(),E=fn(),F=fn(),G=fn(),H=fn(),I=fn(),J=fn(),K=fn(),L=fn(),M=fn(),N=fn(),O=fn(),P=fn(),Q=fn(),R=fn(),S=fn(),T=fn(),U=fn(),V=fn(),W=fn(),X=fn(),Y=fn(),Z=fn();{let _=fn(),$=fn(),ff=fn()}}}
```

### after
```javascript
{let f=fn(),n=fn(),e=fn(),l=fn(),t=fn(),a=fn(),b=fn(),c=fn(),d=fn(),g=fn(),h=fn(),i=fn(),j=fn(),k=fn(),m=fn(),o=fn(),p=fn(),q=fn(),r=fn(),s=fn(),u=fn(),v=fn(),w=fn(),x=fn(),y=fn(),z=fn();{let f=fn(),n=fn(),e=fn(),l=fn(),t=fn(),a=fn(),b=fn(),c=fn(),d=fn(),g=fn(),h=fn(),i=fn(),j=fn(),k=fn(),m=fn(),o=fn(),p=fn(),q=fn(),r=fn(),s=fn(),u=fn(),v=fn(),w=fn(),x=fn(),y=fn(),z=fn();{let f=fn(),n=fn(),e=fn()}}}
```


<details>
<summary>comparison on large bundle</summary>

  | index.js w/o gzip | index.js w/ gzip
-- | -- | --
terser | 10598460 | 2047103
esbuild | 10980927 (+3.61%) | 2421417 （+18.29%）
esbuild + optimization | 10601433 (+0.03%) | 2147534 （+4.91%）


  | index.worker.js w/o gzip | index.worker.js w/ gzip
-- | -- | --
terser | 7001335 | 1751726
esbuild | 8027227 (+14.65%) | 1956705 (+11.70%)
esbuild + optimization | 7832245 (+11.87%) | 1825999 (+4.24%)

  | Final Package (Gzipped)
-- | --
terser | 3856785
esbuild | 4435832 (+15.01%)
esbuild + optimization | 4032394 (+4.55%)


</details>
