### PR TITLE
feat: inline var in function body when possible

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -7940,9 +7940,12 @@ func (p *parser) mangleStmts(stmts []js_ast.Stmt, kind stmtsKind) []js_ast.Stmt 
 								//
 								if prevS.Kind == js_ast.LocalVar {
 									// Only "var" declarations in ScopeFunctionBody are handled,
-									// so p.currentScope.Parent should be ScopeFunctionArgs.
-									if arg, ok := p.currentScope.Parent.Members[symbol.OriginalName]; ok && p.followSymbol(arg.Ref) == id.Ref {
-										break
+									// so p.currentScope should be ScopeFunctionBody,
+									// and p.currentScope.Parent should be ScopeFunctionArgs.
+									if arguments, ok := p.currentScope.Parent.Members["arguments"]; ok && p.symbols[arguments.Ref.InnerIndex].Kind == js_ast.SymbolArguments {
+										if arg, ok := p.currentScope.Parent.Members[symbol.OriginalName]; ok && p.followSymbol(arg.Ref) == id.Ref {
+											break
+										}
 									}
 								}
 

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -4437,8 +4437,12 @@ func TestMangleInlineLocals(t *testing.T) {
 	// Substitute "var" declarations only in ScopeFunctionBody.
 	check("if (console) { var x = 1; return x }", "if (console) {\n  var x = 1;\n  return x;\n}")
 	check("try {} catch (e) { var x = e; return x }", "try {\n} catch (e) {\n  var x = e;\n  return x;\n}")
+
 	// Avoid substituting a symbol merged with function arguments to protect "arguments".
 	expectPrintedMangle(t, "function fn(a){ var a = 1; return a }", "function fn(a) {\n  var a = 1;\n  return a;\n}\n")
+	expectPrintedMangle(t, "function fn(arguments){ var a = 1; return a }", "function fn(arguments) {\n  return 1;\n}\n")
+	expectPrintedMangle(t, "const fn = (a) => { var a = 1; return a }", "const fn = (a) => 1;\n")
+	expectPrintedMangle(t, "const fn = (a, arguments) => { var a = 1; return a }", "const fn = (a, arguments) => 1;\n")
 }
 
 func TestTrimCodeInDeadControlFlow(t *testing.T) {


### PR DESCRIPTION
This PR inlines `var` declarations like how `let/const`s are processed.

It's to be applied only when:
1. the `var` declaration belongs to a function body, and
2. the function is an arrow function, or
3. the `arguments` is shadowed

This PR significantly reduced the bundle size of our internal large project, because our target is es5 and there are many code structures like `prop: function() { var x = value; return x; }`

## Example
### Input
```javascript
function test() {
  var x = 1;
  return x;
}
```
### Current Output
```javascript
function test() {
  var x = 1;
  return x;
}
```
### New Output
```javascript
function test() {
  return 1;
}
```