### PR TITLE
Consider TypeScript's target in `parseRuntime()`

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -2487,6 +2487,9 @@ type runtimeCacheKey struct {
 	unsupportedJSFeatures compat.JSFeature
 	minifySyntax          bool
 	minifyIdentifiers     bool
+	// TODO: Safe to use a pointer here? Is the target itself easier/safer?
+	// tsTargetValue	  *config.TSTarget.value?
+	tsTarget			  *config.TSTarget
 }
 
 type runtimeCache struct {
@@ -2502,6 +2505,7 @@ func (cache *runtimeCache) parseRuntime(options *config.Options) (source logger.
 		unsupportedJSFeatures: options.UnsupportedJSFeatures,
 		minifySyntax:          options.MinifySyntax,
 		minifyIdentifiers:     options.MinifyIdentifiers,
+		tsTarget:              options.TSTarget,
 	}
 
 	// Determine which source to use
@@ -2526,6 +2530,9 @@ func (cache *runtimeCache) parseRuntime(options *config.Options) (source logger.
 		UnsupportedJSFeatures: key.unsupportedJSFeatures,
 		MinifySyntax:          key.minifySyntax,
 		MinifyIdentifiers:     key.minifyIdentifiers,
+		// If there is no top-level esbuild "target" setting, the parser will
+		// use TypeScript's "target" for lowering the runtime source. 
+		TSTarget:              key.tsTarget,
 
 		// Always do tree shaking for the runtime because we never want to
 		// include unnecessary runtime code

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -15905,8 +15905,8 @@ func Parse(log logger.Log, source logger.Source, options Options) (result js_ast
 	}
 
 	// If there is no top-level esbuild "target" setting, include unsupported
-	// JavaScript features from the TypeScript "target" setting. Otherwise the
-	// TypeScript "target" setting is ignored.
+	// JavaScript features based on TypeScript's "target" setting. If there is
+	// an esbuild "target" setting, the TypeScript "target" setting is ignored.
 	if options.targetFromAPI == config.TargetWasUnconfigured && options.tsTarget != nil {
 		options.unsupportedJSFeatures |= options.tsTarget.UnsupportedJSFeatures
 


### PR DESCRIPTION
Closes https://github.com/evanw/esbuild/issues/2628

Currently esbuild emits `||=` even when TS target is set to ES6:

```
$ echo 'var a = { a:1 }; window.xyz ||= a; export default { b:2, ...a }' | ./esbuild --loader=ts --tsconfig-raw='{"compilerOptions": { "target": "es6" }}'
[...]
var __spreadValues = (a2, b) => {
  for (var prop in b ||= {})
    [...]
  return a2;
};
var a = { a: 1 };
window.xyz || (window.xyz = a);
export default __spreadValues({ b: 2 }, a);
```

This PR fixes the output to lower `||=` into `b || (b = {})`:

```
$ echo 'var a = { a:1 }; window.xyz ||= a; export default { b:2, ...a }' | ./esbuild --loader=ts --tsconfig-raw='{"compilerOptions": { "target": "es6" }}'
[...]
var __spreadValues = (a2, b) => {
  for (var prop in b || (b = {}))
   [...]
  return a2;
};
var a = { a: 1 };
window.xyz || (window.xyz = a);
export default __spreadValues({ b: 2 }, a);
```

Disclaimer: I've never written Go and I debugged this with a dozen `fmt.Println()` calls. Sorry I'm not up for writing tests. Also see PR comment about the cache key.