### PR TITLE
feat: support npm_config_registry env variable

### DIFF
--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -67,7 +67,8 @@ async function installFromNPM(name: string, subpath: string): Promise<string> {
   } catch (e) {
   }
 
-  const url = `https://registry.npmjs.org/${name}/-/${name.replace('@esbuild/', '')}-${version}.tgz`
+  const npmRegistry = Deno.env.get("NPM_CONFIG_REGISTRY") || "https://registry.npmjs.org";
+  const url = `${npmRegistry}/${name}/-/${name.replace("@esbuild/", "")}-${version}.tgz`;
   const buffer = await fetch(url).then(r => r.arrayBuffer())
   const executable = extractFileFromTarGzip(new Uint8Array(buffer), subpath)
 


### PR DESCRIPTION
I have to use an alternative NPM registry in my machine because my proxy blocks the public NPM's registry https://registry.npmjs.org, so I'm basically checking whether the NPM_CONFIG_REGISTRY env variable exists before fallbacking to the public one. In case anyone else needs support, here it is.