### PR TITLE
Change hint for unresolved dependency.

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -563,7 +563,7 @@ func ResolveFailureErrorTextSuggestionNotes(
 	hint := ""
 
 	if resolver.IsPackagePath(path) && !fs.IsAbs(path) {
-		hint = fmt.Sprintf("You can mark the path %q as external to exclude it from the bundle, which will remove this error.", path)
+		hint = fmt.Sprintf("If you expect this dependency to be provided by your environment, ie. your browser or Node.JS, you can mark the path %q as external to exclude it from the bundle.", path)
 		if kind == ast.ImportRequire {
 			hint += " You can also surround this \"require\" call with a try/catch block to handle this failure at run-time instead of bundle-time."
 		} else if kind == ast.ImportDynamic {


### PR DESCRIPTION
I had a case where a dev hit a run-of-the-mill resolution failure and blindly followed the hint's instructions, which does read a bit like a "just do this and your problems will be solved!" notice.
Specifying *when* you may want to exclude a module from a bundle, and what the implications are, hopefully will be a bit easier on the uninitiated and prevent some unintended footguns.