### PR TITLE
Version 0.17.0: rewrite the incremental build apis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test-wasm-browser: platform-wasm | scripts/browser/node_modules
 
 test-deno: esbuild platform-deno
 	ESBUILD_BINARY_PATH="$(shell pwd)/esbuild" deno test --allow-run --allow-env --allow-net --allow-read --allow-write --no-check scripts/deno-tests.js
+	@echo '✅ deno tests passed' # I couldn't find a Deno API for telling when tests have failed, so I'm doing this here instead
 	deno eval 'import { transform, stop } from "file://$(shell pwd)/deno/mod.js"; console.log((await transform("1+2")).code); stop()' | grep "1 + 2;"
 	deno eval 'import { transform, stop } from "file://$(shell pwd)/deno/wasm.js"; console.log((await transform("1+2")).code); stop()' | grep "1 + 2;"
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@ The main goal of the esbuild bundler project is to bring about a new era of buil
 
 Major features:
 
-* Extreme speed without needing a cache
-* ES6 and CommonJS modules
-* Tree shaking of ES6 modules
-* An [API](https://esbuild.github.io/api/) for JavaScript and Go
-* [TypeScript](https://esbuild.github.io/content-types/#typescript) and [JSX](https://esbuild.github.io/content-types/#jsx) syntax
-* [Source maps](https://esbuild.github.io/api/#sourcemap)
-* [Minification](https://esbuild.github.io/api/#minify)
-* [Plugins](https://esbuild.github.io/plugins/)
+- Extreme speed without needing a cache
+- [JavaScript](https://esbuild.github.io/content-types/#javascript), [CSS](https://esbuild.github.io/content-types/#css), [TypeScript](https://esbuild.github.io/content-types/#typescript), and [JSX](https://esbuild.github.io/content-types/#jsx) built-in
+- A straightforward [API](https://esbuild.github.io/api/) for CLI, JS, and Go
+- Bundles ESM and CommonJS modules
+- Tree shaking, [minification](https://esbuild.github.io/api/#minify), and [source maps](https://esbuild.github.io/api/#sourcemap)
+- [Local server](https://esbuild.github.io/api/#serve), [watch mode](https://esbuild.github.io/api/#watch), and [plugins](https://esbuild.github.io/plugins/)
 
 Check out the [getting started](https://esbuild.github.io/getting-started/) instructions if you want to give esbuild a try.

--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -61,6 +61,7 @@ var helpText = func(colors logger.Colors) string {
                             (default "[name]-[hash]")
   --banner:T=...            Text to be prepended to each output file of type T
                             where T is one of: css | js
+  --certfile=...            Certificate for serving HTTPS (see also "--keyfile")
   --charset=utf8            Do not escape UTF-8 code points
   --chunk-names=...         Path template to use for code splitting chunks
                             (default "[name]-[hash]")
@@ -84,6 +85,7 @@ var helpText = func(colors logger.Colors) string {
   --jsx=...                 Set to "automatic" to use React's automatic runtime
                             or to "preserve" to disable transforming JSX to JS
   --keep-names              Preserve "name" on functions and classes
+  --keyfile=...             Key for serving HTTPS (see also "--certfile")
   --legal-comments=...      Where to place legal comments (none | inline |
                             eof | linked | external, default eof when bundling
                             and inline otherwise)

--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -25,24 +25,20 @@ import (
 )
 
 type responseCallback func(interface{})
-type rebuildCallback func(uint32) []byte
-type watchStopCallback func()
-type serveStopCallback func()
 type pluginResolveCallback func(uint32, map[string]interface{}) []byte
 
 type activeBuild struct {
-	rebuild       rebuildCallback
-	watchStop     watchStopCallback
-	serveStop     serveStopCallback
+	ctx           api.BuildContext
 	pluginResolve pluginResolveCallback
 	mutex         sync.Mutex
-	refCount      int
+	didGetRebuild bool
+	waitGroup     sync.WaitGroup
 }
 
 type serviceType struct {
 	callbacks          map[uint32]responseCallback
 	activeBuilds       map[int]*activeBuild
-	outgoingPackets    chan outgoingPacket
+	outgoingPackets    chan []byte // Always use "sendPacket" instead of sending on this channel
 	keepAliveWaitGroup *helpers.ThreadSafeWaitGroup
 	mutex              sync.Mutex
 	nextRequestID      uint32
@@ -55,13 +51,13 @@ func (service *serviceType) getActiveBuild(key int) *activeBuild {
 	return activeBuild
 }
 
-func (service *serviceType) trackActiveBuild(key int) *activeBuild {
+func (service *serviceType) createActiveBuild(key int) *activeBuild {
 	service.mutex.Lock()
 	defer service.mutex.Unlock()
 	if service.activeBuilds[key] != nil {
 		panic("Internal error")
 	}
-	activeBuild := &activeBuild{refCount: 1}
+	activeBuild := &activeBuild{}
 	service.activeBuilds[key] = activeBuild
 
 	// This pairs with "Done()" in "decRefCount"
@@ -69,28 +65,16 @@ func (service *serviceType) trackActiveBuild(key int) *activeBuild {
 	return activeBuild
 }
 
-func (service *serviceType) decRefCount(key int, activeBuild *activeBuild) {
-	activeBuild.mutex.Lock()
-	activeBuild.refCount--
-	remaining := activeBuild.refCount
-	activeBuild.mutex.Unlock()
-
-	if remaining < 0 {
+func (service *serviceType) destroyActiveBuild(key int) {
+	service.mutex.Lock()
+	if service.activeBuilds[key] == nil {
 		panic("Internal error")
 	}
+	delete(service.activeBuilds, key)
+	service.mutex.Unlock()
 
-	if remaining == 0 {
-		service.mutex.Lock()
-		delete(service.activeBuilds, key)
-		service.mutex.Unlock()
-
-		// This pairs with "Add()" in "trackActiveBuild"
-		service.keepAliveWaitGroup.Done()
-	}
-}
-
-type outgoingPacket struct {
-	bytes []byte
+	// This pairs with "Add()" in "trackActiveBuild"
+	service.keepAliveWaitGroup.Done()
 }
 
 func runService(sendPings bool) {
@@ -99,7 +83,7 @@ func runService(sendPings bool) {
 	service := serviceType{
 		callbacks:          make(map[uint32]responseCallback),
 		activeBuilds:       make(map[int]*activeBuild),
-		outgoingPackets:    make(chan outgoingPacket),
+		outgoingPackets:    make(chan []byte),
 		keepAliveWaitGroup: helpers.MakeThreadSafeWaitGroup(),
 	}
 	buffer := make([]byte, 16*1024)
@@ -107,9 +91,8 @@ func runService(sendPings bool) {
 
 	// Write packets on a single goroutine so they aren't interleaved
 	go func() {
-		for {
-			packet := <-service.outgoingPackets
-			if _, err := os.Stdout.Write(packet.bytes); err != nil {
+		for packet := range service.outgoingPackets {
+			if _, err := os.Stdout.Write(packet); err != nil {
 				os.Exit(1) // I/O error
 			}
 			service.keepAliveWaitGroup.Done() // This pairs with the "Add()" when putting stuff into "outgoingPackets"
@@ -162,22 +145,20 @@ func runService(sendPings bool) {
 			}
 			bytes = afterPacket
 
-			// Clone the input and run it on another goroutine
+			// Clone the input since slices into it may be used on another goroutine
 			clone := append([]byte{}, packet...)
-			service.keepAliveWaitGroup.Add(1)
-			go func() {
-				out := service.handleIncomingPacket(clone)
-				if out.bytes != nil {
-					service.keepAliveWaitGroup.Add(1) // The writer thread will call "Done()"
-					service.outgoingPackets <- out
-				}
-				service.keepAliveWaitGroup.Done() // This pairs with the "Add()" in the stdin thread
-			}()
+			service.handleIncomingPacket(clone)
 		}
 
 		// Move the remaining partial packet to the end to avoid reallocating
 		stream = append(stream[:0], bytes...)
 	}
+}
+
+// Each packet added to "outgoingPackets" must also add to the wait group
+func (service *serviceType) sendPacket(packet []byte) {
+	service.keepAliveWaitGroup.Add(1) // The writer thread will call "Done()"
+	service.outgoingPackets <- packet
 }
 
 // This will either block until the request has been sent and a response has
@@ -199,203 +180,325 @@ func (service *serviceType) sendRequest(request interface{}) interface{} {
 		return id
 	}()
 
-	service.keepAliveWaitGroup.Add(1) // The writer thread will call "Done()"
-	service.outgoingPackets <- outgoingPacket{
-		bytes: encodePacket(packet{
-			id:        id,
-			isRequest: true,
-			value:     request,
-		}),
-	}
+	service.sendPacket(encodePacket(packet{
+		id:        id,
+		isRequest: true,
+		value:     request,
+	}))
 	return <-result
 }
 
-func (service *serviceType) handleIncomingPacket(bytes []byte) (result outgoingPacket) {
+// This function deliberately processes incoming packets sequentially on the
+// same goroutine as the caller. We want calling "dispose" on a context to take
+// effect immediately and to fail all future calls on that context. We don't
+// want "dispose" to accidentally be reordered after any future calls on that
+// context, since those future calls are supposed to fail.
+//
+// If processing a packet could potentially take a while, then the remainder of
+// the work should be run on another goroutine after decoding the command.
+func (service *serviceType) handleIncomingPacket(bytes []byte) {
 	p, ok := decodePacket(bytes)
 	if !ok {
-		return outgoingPacket{}
+		return
 	}
 
-	if p.isRequest {
-		// Catch panics in the code below so they get passed to the caller
-		defer func() {
-			if r := recover(); r != nil {
-				result = outgoingPacket{
-					bytes: encodePacket(packet{
-						id: p.id,
-						value: map[string]interface{}{
-							"error": fmt.Sprintf("panic: %v\n\n%s", r, helpers.PrettyPrintedStack()),
-						},
-					}),
-				}
-			}
+	if !p.isRequest {
+		service.mutex.Lock()
+		callback := service.callbacks[p.id]
+		delete(service.callbacks, p.id)
+		service.mutex.Unlock()
+
+		if callback == nil {
+			panic(fmt.Sprintf("callback nil for id %d, value %v", p.id, p.value))
+		}
+
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
+			callback(p.value)
+		}()
+		return
+	}
+
+	// Handle the request
+	request := p.value.(map[string]interface{})
+	command := request["command"].(string)
+	switch command {
+	case "build":
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
+			service.sendPacket(service.handleBuildRequest(p.id, request))
 		}()
 
-		// Handle the request
-		request := p.value.(map[string]interface{})
-		command := request["command"].(string)
-		switch command {
-		case "build":
-			return service.handleBuildRequest(p.id, request)
+	case "transform":
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
+			service.sendPacket(service.handleTransformRequest(p.id, request))
+		}()
 
-		case "transform":
-			return outgoingPacket{
-				bytes: service.handleTransformRequest(p.id, request),
+	case "resolve":
+		key := request["key"].(int)
+		if build := service.getActiveBuild(key); build != nil {
+			build.mutex.Lock()
+			ctx := build.ctx
+			pluginResolve := build.pluginResolve
+			if ctx != nil && pluginResolve != nil {
+				build.waitGroup.Add(1)
 			}
-
-		case "resolve":
-			key := request["key"].(int)
-			if build := service.getActiveBuild(key); build != nil {
-				build.mutex.Lock()
-				pluginResolve := build.pluginResolve
-				build.mutex.Unlock()
-				if pluginResolve != nil {
-					return outgoingPacket{
-						bytes: pluginResolve(p.id, request),
+			build.mutex.Unlock()
+			if pluginResolve != nil {
+				service.keepAliveWaitGroup.Add(1)
+				go func() {
+					defer service.keepAliveWaitGroup.Done()
+					if ctx != nil {
+						defer build.waitGroup.Done()
 					}
-				}
+					service.sendPacket(pluginResolve(p.id, request))
+				}()
+				return
 			}
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id: p.id,
-					value: map[string]interface{}{
-						"error": "Cannot call \"resolve\" on an inactive build",
-					},
-				}),
-			}
+		}
+		service.sendPacket(encodePacket(packet{
+			id: p.id,
+			value: map[string]interface{}{
+				"error": "Cannot call \"resolve\" on an inactive build",
+			},
+		}))
 
-		case "rebuild":
-			key := request["key"].(int)
-			if build := service.getActiveBuild(key); build != nil {
-				build.mutex.Lock()
-				rebuild := build.rebuild
-				build.mutex.Unlock()
-				if rebuild != nil {
-					return outgoingPacket{
-						bytes: rebuild(p.id),
+	case "rebuild":
+		key := request["key"].(int)
+		if build := service.getActiveBuild(key); build != nil {
+			build.mutex.Lock()
+			ctx := build.ctx
+			if ctx != nil {
+				build.didGetRebuild = true
+				build.waitGroup.Add(1)
+			}
+			build.mutex.Unlock()
+			if ctx != nil {
+				service.keepAliveWaitGroup.Add(1)
+				go func() {
+					defer service.keepAliveWaitGroup.Done()
+					defer build.waitGroup.Done()
+					result := ctx.Rebuild()
+					service.sendPacket(encodePacket(packet{
+						id: p.id,
+						value: map[string]interface{}{
+							"errors":   encodeMessages(result.Errors),
+							"warnings": encodeMessages(result.Warnings),
+						},
+					}))
+				}()
+				return
+			}
+		}
+		service.sendPacket(encodePacket(packet{
+			id: p.id,
+			value: map[string]interface{}{
+				"error": "Cannot rebuild",
+			},
+		}))
+
+	case "watch":
+		key := request["key"].(int)
+		if build := service.getActiveBuild(key); build != nil {
+			build.mutex.Lock()
+			ctx := build.ctx
+			if ctx != nil {
+				build.waitGroup.Add(1)
+			}
+			build.mutex.Unlock()
+			if ctx != nil {
+				service.keepAliveWaitGroup.Add(1)
+				go func() {
+					defer service.keepAliveWaitGroup.Done()
+					defer build.waitGroup.Done()
+					if err := ctx.Watch(api.WatchOptions{}); err != nil {
+						service.sendPacket(encodeErrorPacket(p.id, err))
+					} else {
+						service.sendPacket(encodePacket(packet{
+							id:    p.id,
+							value: make(map[string]interface{}),
+						}))
 					}
-				}
+				}()
+				return
 			}
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id: p.id,
-					value: map[string]interface{}{
-						"error": "Cannot rebuild",
-					},
-				}),
-			}
+		}
+		service.sendPacket(encodePacket(packet{
+			id: p.id,
+			value: map[string]interface{}{
+				"error": "Cannot watch",
+			},
+		}))
 
-		case "watch-stop":
-			key := request["key"].(int)
-			if build := service.getActiveBuild(key); build != nil {
-				build.mutex.Lock()
-				watchStop := build.watchStop
-				build.watchStop = nil
-				build.mutex.Unlock()
-
-				// Stop watch mode and release this ref count if it was held
-				if watchStop != nil {
-					watchStop()
-					service.decRefCount(key, build)
-				}
+	case "serve":
+		key := request["key"].(int)
+		if build := service.getActiveBuild(key); build != nil {
+			build.mutex.Lock()
+			ctx := build.ctx
+			if ctx != nil {
+				build.waitGroup.Add(1)
 			}
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id:    p.id,
-					value: make(map[string]interface{}),
-				}),
+			build.mutex.Unlock()
+			if ctx != nil {
+				service.keepAliveWaitGroup.Add(1)
+				go func() {
+					defer service.keepAliveWaitGroup.Done()
+					defer build.waitGroup.Done()
+					var options api.ServeOptions
+					if value, ok := request["host"]; ok {
+						options.Host = value.(string)
+					}
+					if value, ok := request["port"]; ok {
+						options.Port = uint16(value.(int))
+					}
+					if value, ok := request["servedir"]; ok {
+						options.Servedir = value.(string)
+					}
+					if value, ok := request["keyfile"]; ok {
+						options.Keyfile = value.(string)
+					}
+					if value, ok := request["certfile"]; ok {
+						options.Certfile = value.(string)
+					}
+					if request["onRequest"].(bool) {
+						options.OnRequest = func(args api.ServeOnRequestArgs) {
+							// This could potentially be called after we return from
+							// "Dispose()". If it does, then make sure we don't call into
+							// JavaScript because we'll get an error. Also make sure that
+							// if we do call into JavaScript, we wait to call "Dispose()"
+							// until JavaScript has returned back to us.
+							build.mutex.Lock()
+							ctx := build.ctx
+							if ctx != nil {
+								build.waitGroup.Add(1)
+							}
+							build.mutex.Unlock()
+							if ctx != nil {
+								service.sendRequest(map[string]interface{}{
+									"command": "serve-request",
+									"key":     key,
+									"args": map[string]interface{}{
+										"remoteAddress": args.RemoteAddress,
+										"method":        args.Method,
+										"path":          args.Path,
+										"status":        args.Status,
+										"timeInMS":      args.TimeInMS,
+									},
+								})
+								build.waitGroup.Done()
+							}
+						}
+					}
+					if result, err := ctx.Serve(options); err != nil {
+						service.sendPacket(encodeErrorPacket(p.id, err))
+					} else {
+						service.sendPacket(encodePacket(packet{
+							id: p.id,
+							value: map[string]interface{}{
+								"port": int(result.Port),
+								"host": result.Host,
+							},
+						}))
+					}
+				}()
+				return
 			}
+		}
+		service.sendPacket(encodePacket(packet{
+			id: p.id,
+			value: map[string]interface{}{
+				"error": "Cannot serve",
+			},
+		}))
 
-		case "serve-stop":
-			key := request["key"].(int)
-			if build := service.getActiveBuild(key); build != nil {
-				build.mutex.Lock()
-				serveStop := build.serveStop
-				build.serveStop = nil
-				build.mutex.Unlock()
+	case "dispose":
+		key := request["key"].(int)
+		if build := service.getActiveBuild(key); build != nil {
+			build.mutex.Lock()
+			ctx := build.ctx
+			build.ctx = nil
+			build.mutex.Unlock()
 
-				// Stop serving but do not release the ref count (that's done elsewhere)
-				if serveStop != nil {
-					serveStop()
-				}
+			// Release this ref count if it was held
+			if ctx != nil {
+				service.keepAliveWaitGroup.Add(1)
+				go func() {
+					defer service.keepAliveWaitGroup.Done()
+
+					// While "Dispose()" will wait for any existing operations on the
+					// context to finish, we also don't want to start any new operations.
+					// That can happen because operations (e.g. "Rebuild()") are started
+					// from a separate goroutine without locking the build mutex. This
+					// uses a WaitGroup to handle this case. If that happened, then we'll
+					// wait for it here before disposing. Once the wait is over, no more
+					// operations can happen on the context because we have already
+					// zeroed out the shared context pointer above.
+					build.waitGroup.Done()
+					build.waitGroup.Wait()
+
+					ctx.Dispose()
+					service.destroyActiveBuild(key)
+
+					// Only return control to JavaScript once everything relating to this
+					// build has gracefully ended. Otherwise JavaScript will unregister
+					// everything related to this build and any calls an ongoing build
+					// makes into JavaScript will cause errors, which may be observable.
+					service.sendPacket(encodePacket(packet{
+						id:    p.id,
+						value: make(map[string]interface{}),
+					}))
+				}()
+				return
 			}
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id:    p.id,
-					value: make(map[string]interface{}),
-				}),
-			}
+		}
+		service.sendPacket(encodePacket(packet{
+			id:    p.id,
+			value: make(map[string]interface{}),
+		}))
 
-		case "rebuild-dispose":
-			key := request["key"].(int)
-			if build := service.getActiveBuild(key); build != nil {
-				build.mutex.Lock()
-				rebuild := build.rebuild
-				build.rebuild = nil
-				build.mutex.Unlock()
+	case "error":
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
 
-				// Release this ref count if it was held
-				if rebuild != nil {
-					service.decRefCount(key, build)
-				}
-			}
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id:    p.id,
-					value: make(map[string]interface{}),
-				}),
-			}
-
-		case "error":
 			// This just exists so that errors during JavaScript API setup get printed
 			// nicely to the console. This matters if the JavaScript API setup code
 			// swallows thrown errors. We still want to be able to see the error.
 			flags := decodeStringArray(request["flags"].([]interface{}))
 			msg := decodeMessageToPrivate(request["error"].(map[string]interface{}))
 			logger.PrintMessageToStderr(flags, msg)
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id:    p.id,
-					value: make(map[string]interface{}),
-				}),
-			}
+			service.sendPacket(encodePacket(packet{
+				id:    p.id,
+				value: make(map[string]interface{}),
+			}))
+		}()
 
-		case "format-msgs":
-			return outgoingPacket{
-				bytes: service.handleFormatMessagesRequest(p.id, request),
-			}
+	case "format-msgs":
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
+			service.sendPacket(service.handleFormatMessagesRequest(p.id, request))
+		}()
 
-		case "analyze-metafile":
-			return outgoingPacket{
-				bytes: service.handleAnalyzeMetafileRequest(p.id, request),
-			}
+	case "analyze-metafile":
+		service.keepAliveWaitGroup.Add(1)
+		go func() {
+			defer service.keepAliveWaitGroup.Done()
+			service.sendPacket(service.handleAnalyzeMetafileRequest(p.id, request))
+		}()
 
-		default:
-			return outgoingPacket{
-				bytes: encodePacket(packet{
-					id: p.id,
-					value: map[string]interface{}{
-						"error": fmt.Sprintf("Invalid command: %s", command),
-					},
-				}),
-			}
-		}
+	default:
+		service.sendPacket(encodePacket(packet{
+			id: p.id,
+			value: map[string]interface{}{
+				"error": fmt.Sprintf("Invalid command: %s", command),
+			},
+		}))
 	}
-
-	callback := func() responseCallback {
-		service.mutex.Lock()
-		defer service.mutex.Unlock()
-		callback := service.callbacks[p.id]
-		delete(service.callbacks, p.id)
-		return callback
-	}()
-
-	if callback == nil {
-		panic(fmt.Sprintf("callback nil for id %d, value %v", p.id, p.value))
-	}
-
-	callback(p.value)
-	return outgoingPacket{}
 }
 
 func encodeErrorPacket(id uint32, err error) []byte {
@@ -407,11 +510,10 @@ func encodeErrorPacket(id uint32, err error) []byte {
 	})
 }
 
-func (service *serviceType) handleBuildRequest(id uint32, request map[string]interface{}) outgoingPacket {
+func (service *serviceType) handleBuildRequest(id uint32, request map[string]interface{}) []byte {
+	isContext := request["context"].(bool)
 	key := request["key"].(int)
 	write := request["write"].(bool)
-	incremental := request["incremental"].(bool)
-	serveObj, isServe := request["serve"].(interface{})
 	entries := request["entries"].([]interface{})
 	flags := decodeStringArray(request["flags"].([]interface{}))
 
@@ -435,10 +537,10 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 	// stdout as a communication channel and writing the build output to stdout
 	// would corrupt our protocol. Special-case this to channel this back to the
 	// host process and write it to stdout there.
-	writeToStdout := err == nil && !isServe && write && options.Outfile == "" && options.Outdir == ""
+	writeToStdout := err == nil && write && options.Outfile == "" && options.Outdir == ""
 
 	if err != nil {
-		return outgoingPacket{bytes: encodeErrorPacket(id, err)}
+		return encodeErrorPacket(id, err)
 	}
 
 	// Optionally allow input from the stdin channel
@@ -452,27 +554,22 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		}
 	}
 
-	activeBuild := service.trackActiveBuild(key)
-	defer service.decRefCount(key, activeBuild)
+	activeBuild := service.createActiveBuild(key)
 
+	hasOnEndCallbacks := false
 	if plugins, ok := request["plugins"]; ok {
-		if plugins, err := service.convertPlugins(key, plugins, activeBuild); err != nil {
-			return outgoingPacket{bytes: encodeErrorPacket(id, err)}
+		if plugins, hasOnEnd, err := service.convertPlugins(key, plugins, activeBuild); err != nil {
+			return encodeErrorPacket(id, err)
 		} else {
 			options.Plugins = plugins
+			hasOnEndCallbacks = hasOnEnd
 		}
-	}
-
-	if isServe {
-		return service.handleServeRequest(id, options, serveObj, key, activeBuild)
 	}
 
 	resultToResponse := func(result api.BuildResult) map[string]interface{} {
 		response := map[string]interface{}{
 			"errors":   encodeMessages(result.Errors),
 			"warnings": encodeMessages(result.Warnings),
-			"rebuild":  incremental,
-			"watch":    options.Watch != nil,
 		}
 		if !write {
 			// Pass the output files back to the caller
@@ -490,114 +587,97 @@ func (service *serviceType) handleBuildRequest(id uint32, request map[string]int
 		return response
 	}
 
-	if options.Watch != nil {
-		options.Watch.OnRebuild = func(result api.BuildResult) {
-			service.sendRequest(map[string]interface{}{
-				"command": "watch-rebuild",
-				"key":     key,
-				"args":    resultToResponse(result),
-			})
-		}
-	}
-
 	if !writeToStdout {
 		options.Write = write
 	}
-	options.Incremental = incremental
-	result := api.Build(options)
-	response := resultToResponse(result)
 
-	if incremental {
-		activeBuild.rebuild = func(id uint32) []byte {
-			result := result.Rebuild()
-			response := resultToResponse(result)
+	if isContext {
+		options.Plugins = append(options.Plugins, api.Plugin{
+			Name: "onEnd",
+			Setup: func(build api.PluginBuild) {
+				build.OnStart(func() (api.OnStartResult, error) {
+					activeBuild.mutex.Lock()
+					activeBuild.didGetRebuild = true
+					activeBuild.mutex.Unlock()
+					return api.OnStartResult{}, nil
+				})
+
+				build.OnEnd(func(result *api.BuildResult) (api.OnEndResult, error) {
+					// For performance, we only send JavaScript an "onEnd" message if
+					// it's needed. It's only needed if there are any "onEnd" callbacks
+					// registered or if JavaScript has called our "rebuild()" function
+					// (since the result for "rebuild" is passed via the same mechanism).
+					// This is especially important if "write" is false since otherwise
+					// we'd unnecessarily send the entire contents of all output files!
+					//
+					//          "If a tree falls in a forest and no one is
+					//           around to hear it, does it make a sound?"
+					//
+					if !hasOnEndCallbacks {
+						activeBuild.mutex.Lock()
+						didGetRebuild := activeBuild.didGetRebuild
+						activeBuild.didGetRebuild = false
+						activeBuild.mutex.Unlock()
+						if !didGetRebuild {
+							return api.OnEndResult{}, nil
+						}
+					}
+					request := resultToResponse(*result)
+					request["command"] = "on-end"
+					request["key"] = key
+					response, ok := service.sendRequest(request).(map[string]interface{})
+					if !ok {
+						return api.OnEndResult{}, errors.New("The service was stopped")
+					}
+					var errors []api.Message
+					var warnings []api.Message
+					if value, ok := response["errors"].([]interface{}); ok {
+						errors = decodeMessages(value)
+					}
+					if value, ok := response["warnings"].([]interface{}); ok {
+						warnings = decodeMessages(value)
+					}
+					return api.OnEndResult{
+						Errors:   errors,
+						Warnings: warnings,
+					}, nil
+				})
+			},
+		})
+
+		ctx, err := api.Context(options)
+		if err != nil {
 			return encodePacket(packet{
-				id:    id,
-				value: response,
+				id: id,
+				value: map[string]interface{}{
+					"errors":   encodeMessages(err.Errors),
+					"warnings": []interface{}{},
+				},
 			})
 		}
 
-		// Make sure the build doesn't finish until "dispose" has been called
-		activeBuild.refCount++
-	}
+		// Keep the build alive until "dispose" has been called
+		activeBuild.waitGroup.Add(1)
+		activeBuild.ctx = ctx
 
-	if options.Watch != nil {
-		activeBuild.watchStop = func() {
-			result.Stop()
-		}
-
-		// Make sure the build doesn't finish until "stop" has been called
-		activeBuild.refCount++
-	}
-
-	return outgoingPacket{
-		bytes: encodePacket(packet{
-			id:    id,
-			value: response,
-		}),
-	}
-}
-
-func (service *serviceType) handleServeRequest(id uint32, options api.BuildOptions, serveObj interface{}, key int, activeBuild *activeBuild) outgoingPacket {
-	var serveOptions api.ServeOptions
-	serve := serveObj.(map[string]interface{})
-	if port, ok := serve["port"]; ok {
-		serveOptions.Port = uint16(port.(int))
-	}
-	if host, ok := serve["host"]; ok {
-		serveOptions.Host = host.(string)
-	}
-	if servedir, ok := serve["servedir"]; ok {
-		serveOptions.Servedir = servedir.(string)
-	}
-	serveOptions.OnRequest = func(args api.ServeOnRequestArgs) {
-		service.sendRequest(map[string]interface{}{
-			"command": "serve-request",
-			"key":     key,
-			"args": map[string]interface{}{
-				"remoteAddress": args.RemoteAddress,
-				"method":        args.Method,
-				"path":          args.Path,
-				"status":        args.Status,
-				"timeInMS":      args.TimeInMS,
+		return encodePacket(packet{
+			id: id,
+			value: map[string]interface{}{
+				"errors":   []interface{}{},
+				"warnings": []interface{}{},
 			},
 		})
 	}
-	result, err := api.Serve(serveOptions, options)
-	if err != nil {
-		return outgoingPacket{bytes: encodeErrorPacket(id, err)}
-	}
-	response := map[string]interface{}{
-		"port": int(result.Port),
-		"host": result.Host,
-	}
 
-	activeBuild.refCount++ // Make sure the serve doesn't finish until "Wait" finishes
-	activeBuild.serveStop = result.Stop
+	result := api.Build(options)
+	response := resultToResponse(result)
 
-	// Asynchronously wait for the server to stop, then fulfill the "wait" promise
-	go func() {
-		request := map[string]interface{}{
-			"command": "serve-wait",
-			"key":     key,
-		}
-		if err := result.Wait(); err != nil {
-			request["error"] = err.Error()
-		} else {
-			request["error"] = nil
-		}
-		service.sendRequest(request)
+	service.destroyActiveBuild(key)
 
-		// Release the ref count now that the server has shut down
-		service.decRefCount(key, activeBuild)
-	}()
-
-	return outgoingPacket{
-		bytes: encodePacket(packet{
-			id:    id,
-			value: response,
-		}),
-	}
+	return encodePacket(packet{
+		id:    id,
+		value: response,
+	})
 }
 
 func resolveKindToString(kind api.ResolveKind) string {
@@ -651,7 +731,7 @@ func stringToResolveKind(kind string) (api.ResolveKind, bool) {
 	return api.ResolveNone, false
 }
 
-func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activeBuild *activeBuild) ([]api.Plugin, error) {
+func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activeBuild *activeBuild) ([]api.Plugin, bool, error) {
 	type filteredCallback struct {
 		filter     *regexp.Regexp
 		pluginName string
@@ -662,6 +742,7 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 	var onResolveCallbacks []filteredCallback
 	var onLoadCallbacks []filteredCallback
 	hasOnStart := false
+	hasOnEnd := false
 
 	filteredCallbacks := func(pluginName string, kind string, items []interface{}) (result []filteredCallback, err error) {
 		for _, item := range items {
@@ -688,14 +769,18 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 			hasOnStart = true
 		}
 
+		if p["onEnd"].(bool) {
+			hasOnEnd = true
+		}
+
 		if callbacks, err := filteredCallbacks(pluginName, "onResolve", p["onResolve"].([]interface{})); err != nil {
-			return nil, err
+			return nil, false, err
 		} else {
 			onResolveCallbacks = append(onResolveCallbacks, callbacks...)
 		}
 
 		if callbacks, err := filteredCallbacks(pluginName, "onLoad", p["onLoad"].([]interface{})); err != nil {
-			return nil, err
+			return nil, false, err
 		} else {
 			onLoadCallbacks = append(onLoadCallbacks, callbacks...)
 		}
@@ -760,24 +845,17 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 			// Only register "OnStart" if needed
 			if hasOnStart {
 				build.OnStart(func() (api.OnStartResult, error) {
-					result := api.OnStartResult{}
-
 					response, ok := service.sendRequest(map[string]interface{}{
 						"command": "on-start",
 						"key":     key,
 					}).(map[string]interface{})
 					if !ok {
-						return result, errors.New("The service was stopped")
+						return api.OnStartResult{}, errors.New("The service was stopped")
 					}
-
-					if value, ok := response["errors"]; ok {
-						result.Errors = decodeMessages(value.([]interface{}))
-					}
-					if value, ok := response["warnings"]; ok {
-						result.Warnings = decodeMessages(value.([]interface{}))
-					}
-
-					return result, nil
+					return api.OnStartResult{
+						Errors:   decodeMessages(response["errors"].([]interface{})),
+						Warnings: decodeMessages(response["warnings"].([]interface{})),
+					}, nil
 				})
 			}
 
@@ -944,7 +1022,7 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 				})
 			}
 		},
-	}}, nil
+	}}, hasOnEnd, nil
 }
 
 func (service *serviceType) handleTransformRequest(id uint32, request map[string]interface{}) []byte {

--- a/images/wordmark-dark.svg
+++ b/images/wordmark-dark.svg
@@ -2,5 +2,5 @@
   <circle cx="125" cy="125" r="75" fill="#FFCF00"/>
   <path d="M85.625 89.375L121.25 125L85.625 160.625M130.625 89.375L166.25 125L130.625 160.625" fill="none" stroke="#191919" stroke-width="18"/>
   <text x="241" y="152" font-size="100" font-weight="bold" fill="#C9D1D9">esbuild</text>
-  <text x="241" y="184" font-size="21" font-style="italic" fill="#C9D1D9">An extremely fast JavaScript bundler</text>
+  <text x="241" y="184" font-size="21" font-style="italic" fill="#C9D1D9">An extremely fast bundler for the web</text>
 </svg>

--- a/images/wordmark-light.svg
+++ b/images/wordmark-light.svg
@@ -2,5 +2,5 @@
   <circle cx="125" cy="125" r="75" fill="#FFCF00"/>
   <path d="M85.625 89.375L121.25 125L85.625 160.625M130.625 89.375L166.25 125L130.625 160.625" fill="none" stroke="#191919" stroke-width="18"/>
   <text x="241" y="152" font-size="100" font-weight="bold">esbuild</text>
-  <text x="241" y="184" font-size="21" font-style="italic">An extremely fast JavaScript bundler</text>
+  <text x="241" y="184" font-size="21" font-style="italic">An extremely fast bundler for the web</text>
 </svg>

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1111,6 +1111,7 @@ func ScanBundle(
 	applyOptionDefaults(&options)
 
 	// Run "onStart" plugins in parallel
+	timer.Begin("On-start callbacks")
 	onStartWaitGroup := sync.WaitGroup{}
 	for _, plugin := range options.Plugins {
 		for _, onStart := range plugin.OnStart {
@@ -1194,6 +1195,7 @@ func ScanBundle(
 	//   }
 	//
 	onStartWaitGroup.Wait()
+	timer.End("On-start callbacks")
 
 	s.preprocessInjectedFiles()
 	entryPointMeta := s.addEntryPoints(entryPoints)

--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -1,4 +1,4 @@
-import * as types from "../shared/types"
+import type * as types from "../shared/types"
 import * as common from "../shared/common"
 import * as ourselves from "./mod"
 import * as denoflate from "https://deno.land/x/denoflate@1.2.1/mod.ts"
@@ -11,9 +11,9 @@ export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().then(service =>
     service.build(options))
 
-export const serve: typeof types.serve = (serveOptions, buildOptions) =>
+export const context: typeof types.context = (options: types.BuildOptions) =>
   ensureServiceIsRunning().then(service =>
-    service.serve(serveOptions, buildOptions))
+    service.context(options))
 
 export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().then(service =>
@@ -169,7 +169,7 @@ async function install(): Promise<string> {
 
 interface Service {
   build: typeof types.build
-  serve: typeof types.serve
+  context: typeof types.context
   transform: typeof types.transform
   formatMessages: typeof types.formatMessages
   analyzeMetafile: typeof types.analyzeMetafile
@@ -224,7 +224,7 @@ let ensureServiceIsRunning = (): Promise<Service> => {
           startWriteFromQueueWorker()
         },
         isSync: false,
-        isWriteUnavailable: false,
+        hasFS: true,
         esbuild: ourselves,
       })
 
@@ -247,36 +247,31 @@ let ensureServiceIsRunning = (): Promise<Service> => {
       readMoreStdout()
 
       return {
-        build: (options: types.BuildOptions): Promise<any> => {
-          return new Promise<types.BuildResult>((resolve, reject) => {
-            service.buildOrServe({
+        build: (options: types.BuildOptions) =>
+          new Promise<types.BuildResult>((resolve, reject) => {
+            service.buildOrContext({
               callName: 'build',
               refs: null,
-              serveOptions: null,
               options,
               isTTY,
               defaultWD,
               callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
             })
-          })
-        },
+          }),
 
-        serve: (serveOptions, buildOptions) => {
-          if (serveOptions === null || typeof serveOptions !== 'object')
-            throw new Error('The first argument must be an object')
-          return new Promise((resolve, reject) =>
-            service.buildOrServe({
-              callName: 'serve',
+        context: (options: types.BuildOptions) =>
+          new Promise<types.BuildContext>((resolve, reject) =>
+            service.buildOrContext({
+              callName: 'context',
               refs: null,
-              serveOptions,
-              options: buildOptions,
+              options,
               isTTY,
-              defaultWD, callback: (err, res) => err ? reject(err) : resolve(res as types.ServeResult),
-            }))
-        },
+              defaultWD,
+              callback: (err, res) => err ? reject(err) : resolve(res as types.BuildContext),
+            })),
 
-        transform: (input: string | Uint8Array, options?: types.TransformOptions) => {
-          return new Promise<types.TransformResult>((resolve, reject) =>
+        transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
+          new Promise<types.TransformResult>((resolve, reject) =>
             service.transform({
               callName: 'transform',
               refs: null,
@@ -306,30 +301,27 @@ let ensureServiceIsRunning = (): Promise<Service> => {
                 },
               },
               callback: (err, res) => err ? reject(err) : resolve(res!),
-            }))
-        },
+            })),
 
-        formatMessages: (messages, options) => {
-          return new Promise((resolve, reject) =>
+        formatMessages: (messages, options) =>
+          new Promise((resolve, reject) =>
             service.formatMessages({
               callName: 'formatMessages',
               refs: null,
               messages,
               options,
               callback: (err, res) => err ? reject(err) : resolve(res!),
-            }))
-        },
+            })),
 
-        analyzeMetafile: (metafile, options) => {
-          return new Promise((resolve, reject) =>
+        analyzeMetafile: (metafile, options) =>
+          new Promise((resolve, reject) =>
             service.analyzeMetafile({
               callName: 'analyzeMetafile',
               refs: null,
               metafile: typeof metafile === 'string' ? metafile : JSON.stringify(metafile),
               options,
               callback: (err, res) => err ? reject(err) : resolve(res!),
-            }))
-        },
+            })),
       }
     })()
   }

--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -7,7 +7,7 @@ declare const ESBUILD_VERSION: string
 
 export let version = ESBUILD_VERSION
 
-export let build: typeof types.build = (options: types.BuildOptions): Promise<any> =>
+export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().then(service =>
     service.build(options))
 
@@ -15,7 +15,7 @@ export const serve: typeof types.serve = (serveOptions, buildOptions) =>
   ensureServiceIsRunning().then(service =>
     service.serve(serveOptions, buildOptions))
 
-export const transform: typeof types.transform = (input, options) =>
+export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().then(service =>
     service.transform(input, options))
 
@@ -275,8 +275,8 @@ let ensureServiceIsRunning = (): Promise<Service> => {
             }))
         },
 
-        transform: (input, options) => {
-          return new Promise((resolve, reject) =>
+        transform: (input: string | Uint8Array, options?: types.TransformOptions) => {
+          return new Promise<types.TransformResult>((resolve, reject) =>
             service.transform({
               callName: 'transform',
               refs: null,

--- a/lib/deno/wasm.ts
+++ b/lib/deno/wasm.ts
@@ -8,7 +8,7 @@ declare let WEB_WORKER_FUNCTION: (postMessage: (data: Uint8Array) => void) => (e
 
 export let version = ESBUILD_VERSION
 
-export let build: typeof types.build = (options: types.BuildOptions): Promise<any> =>
+export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().then(service =>
     service.build(options))
 
@@ -16,7 +16,7 @@ export const serve: typeof types.serve = () => {
   throw new Error(`The "serve" API does not work in Deno via WebAssembly`)
 }
 
-export const transform: typeof types.transform = (input, options) =>
+export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().then(service =>
     service.transform(input, options))
 
@@ -144,8 +144,8 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           defaultWD: '/',
           callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
         })),
-    transform: (input, options) =>
-      new Promise((resolve, reject) =>
+    transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
+      new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
           callName: 'transform',
           refs: null,

--- a/lib/deno/wasm.ts
+++ b/lib/deno/wasm.ts
@@ -1,4 +1,4 @@
-import * as types from "../shared/types"
+import type * as types from "../shared/types"
 import * as common from "../shared/common"
 import * as ourselves from "./wasm"
 
@@ -12,9 +12,9 @@ export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().then(service =>
     service.build(options))
 
-export const serve: typeof types.serve = () => {
-  throw new Error(`The "serve" API does not work in Deno via WebAssembly`)
-}
+export const context: typeof types.context = (options: types.BuildOptions) =>
+  ensureServiceIsRunning().then(service =>
+    service.context(options))
 
 export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().then(service =>
@@ -50,6 +50,7 @@ export const stop = () => {
 
 interface Service {
   build: typeof types.build
+  context: typeof types.context
   transform: typeof types.transform
   formatMessages: typeof types.formatMessages
   analyzeMetafile: typeof types.analyzeMetafile
@@ -119,7 +120,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
       worker.postMessage(bytes)
     },
     isSync: false,
-    isWriteUnavailable: true,
+    hasFS: false,
     esbuild: ourselves,
   })
 
@@ -133,17 +134,28 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
   }
 
   return {
-    build: (options: types.BuildOptions): Promise<any> =>
+    build: (options: types.BuildOptions) =>
       new Promise<types.BuildResult>((resolve, reject) =>
-        service.buildOrServe({
+        service.buildOrContext({
           callName: 'build',
           refs: null,
-          serveOptions: null,
           options,
           isTTY: false,
           defaultWD: '/',
           callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
         })),
+
+    context: (options: types.BuildOptions) =>
+      new Promise<types.BuildContext>((resolve, reject) =>
+        service.buildOrContext({
+          callName: 'context',
+          refs: null,
+          options,
+          isTTY: false,
+          defaultWD: '/',
+          callback: (err, res) => err ? reject(err) : resolve(res as types.BuildContext),
+        })),
+
     transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
       new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
@@ -158,6 +170,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           },
           callback: (err, res) => err ? reject(err) : resolve(res!),
         })),
+
     formatMessages: (messages, options) =>
       new Promise((resolve, reject) =>
         service.formatMessages({
@@ -167,6 +180,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           options,
           callback: (err, res) => err ? reject(err) : resolve(res!),
         })),
+
     analyzeMetafile: (metafile, options) =>
       new Promise((resolve, reject) =>
         service.analyzeMetafile({

--- a/lib/npm/browser.ts
+++ b/lib/npm/browser.ts
@@ -8,14 +8,14 @@ declare let WEB_WORKER_FUNCTION: (postMessage: (data: Uint8Array) => void) => (e
 
 export let version = ESBUILD_VERSION;
 
-export let build: typeof types.build = (options: types.BuildOptions): Promise<any> =>
+export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().build(options);
 
 export const serve: typeof types.serve = () => {
   throw new Error(`The "serve" API only works in node`);
 };
 
-export const transform: typeof types.transform = (input, options) =>
+export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().transform(input, options);
 
 export const formatMessages: typeof types.formatMessages = (messages, options) =>
@@ -122,7 +122,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
   await firstMessagePromise
 
   longLivedService = {
-    build: (options: types.BuildOptions): Promise<any> =>
+    build: (options: types.BuildOptions) =>
       new Promise<types.BuildResult>((resolve, reject) =>
         service.buildOrServe({
           callName: 'build',
@@ -133,8 +133,8 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           defaultWD: '/',
           callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
         })),
-    transform: (input, options) =>
-      new Promise((resolve, reject) =>
+    transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
+      new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
           callName: 'transform',
           refs: null,

--- a/lib/npm/browser.ts
+++ b/lib/npm/browser.ts
@@ -1,4 +1,4 @@
-import * as types from "../shared/types"
+import type * as types from "../shared/types"
 import * as common from "../shared/common"
 import * as ourselves from "./browser"
 
@@ -11,9 +11,8 @@ export let version = ESBUILD_VERSION;
 export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().build(options);
 
-export const serve: typeof types.serve = () => {
-  throw new Error(`The "serve" API only works in node`);
-};
+export let context: typeof types.context = (options: types.BuildOptions) =>
+  ensureServiceIsRunning().context(options);
 
 export const transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().transform(input, options);
@@ -42,6 +41,7 @@ export const analyzeMetafileSync: typeof types.analyzeMetafileSync = () => {
 
 interface Service {
   build: typeof types.build;
+  context: typeof types.context;
   transform: typeof types.transform;
   formatMessages: typeof types.formatMessages;
   analyzeMetafile: typeof types.analyzeMetafile;
@@ -114,7 +114,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
       worker.postMessage(bytes)
     },
     isSync: false,
-    isWriteUnavailable: true,
+    hasFS: false,
     esbuild: ourselves,
   })
 
@@ -124,15 +124,26 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
   longLivedService = {
     build: (options: types.BuildOptions) =>
       new Promise<types.BuildResult>((resolve, reject) =>
-        service.buildOrServe({
+        service.buildOrContext({
           callName: 'build',
           refs: null,
-          serveOptions: null,
           options,
           isTTY: false,
           defaultWD: '/',
           callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
         })),
+
+    context: (options: types.BuildOptions) =>
+      new Promise<types.BuildContext>((resolve, reject) =>
+        service.buildOrContext({
+          callName: 'context',
+          refs: null,
+          options,
+          isTTY: false,
+          defaultWD: '/',
+          callback: (err, res) => err ? reject(err) : resolve(res as types.BuildContext),
+        })),
+
     transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
       new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
@@ -147,6 +158,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           },
           callback: (err, res) => err ? reject(err) : resolve(res!),
         })),
+
     formatMessages: (messages, options) =>
       new Promise((resolve, reject) =>
         service.formatMessages({
@@ -156,6 +168,7 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
           options,
           callback: (err, res) => err ? reject(err) : resolve(res!),
         })),
+
     analyzeMetafile: (metafile, options) =>
       new Promise((resolve, reject) =>
         service.analyzeMetafile({

--- a/lib/npm/node.ts
+++ b/lib/npm/node.ts
@@ -1,4 +1,4 @@
-import * as types from "../shared/types";
+import type * as types from "../shared/types";
 import * as common from "../shared/common";
 import * as ourselves from "./node"
 import { ESBUILD_BINARY_PATH, generateBinPath } from "./node-platform";
@@ -133,8 +133,8 @@ export let version = ESBUILD_VERSION;
 export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().build(options);
 
-export let serve: typeof types.serve = (serveOptions, buildOptions) =>
-  ensureServiceIsRunning().serve(serveOptions, buildOptions);
+export let context: typeof types.context = (buildOptions: types.BuildOptions) =>
+  ensureServiceIsRunning().context(buildOptions);
 
 export let transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().transform(input, options);
@@ -153,10 +153,9 @@ export let buildSync: typeof types.buildSync = (options: types.BuildOptions) => 
   }
 
   let result: types.BuildResult;
-  runServiceSync(service => service.buildOrServe({
+  runServiceSync(service => service.buildOrContext({
     callName: 'buildSync',
     refs: null,
-    serveOptions: null,
     options,
     isTTY: isTTY(),
     defaultWD,
@@ -236,7 +235,7 @@ export let initialize: typeof types.initialize = options => {
 
 interface Service {
   build: typeof types.build;
-  serve: typeof types.serve;
+  context: typeof types.context;
   transform: typeof types.transform;
   formatMessages: typeof types.formatMessages;
   analyzeMetafile: typeof types.analyzeMetafile;
@@ -263,7 +262,7 @@ let ensureServiceIsRunning = (): Service => {
     },
     readFileSync: fs.readFileSync,
     isSync: false,
-    isWriteUnavailable: false,
+    hasFS: true,
     esbuild: ourselves,
   });
 
@@ -294,34 +293,31 @@ let ensureServiceIsRunning = (): Service => {
   }
 
   longLivedService = {
-    build: (options: types.BuildOptions): Promise<any> => {
-      return new Promise<types.BuildResult>((resolve, reject) => {
-        service.buildOrServe({
+    build: (options: types.BuildOptions) =>
+      new Promise<types.BuildResult>((resolve, reject) => {
+        service.buildOrContext({
           callName: 'build',
           refs,
-          serveOptions: null,
           options,
           isTTY: isTTY(),
           defaultWD,
           callback: (err, res) => err ? reject(err) : resolve(res as types.BuildResult),
         })
-      })
-    },
-    serve: (serveOptions, buildOptions) => {
-      if (serveOptions === null || typeof serveOptions !== 'object')
-        throw new Error('The first argument must be an object')
-      return new Promise((resolve, reject) =>
-        service.buildOrServe({
-          callName: 'serve',
+      }),
+
+    context: (options: types.BuildOptions) =>
+      new Promise<types.BuildContext>((resolve, reject) =>
+        service.buildOrContext({
+          callName: 'context',
           refs,
-          serveOptions,
-          options: buildOptions,
+          options,
           isTTY: isTTY(),
-          defaultWD, callback: (err, res) => err ? reject(err) : resolve(res as types.ServeResult),
-        }))
-    },
-    transform: (input: string | Uint8Array, options?: types.TransformOptions) => {
-      return new Promise<types.TransformResult>((resolve, reject) =>
+          defaultWD,
+          callback: (err, res) => err ? reject(err) : resolve(res as types.BuildContext),
+        })),
+
+    transform: (input: string | Uint8Array, options?: types.TransformOptions) =>
+      new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
           callName: 'transform',
           refs,
@@ -330,28 +326,27 @@ let ensureServiceIsRunning = (): Service => {
           isTTY: isTTY(),
           fs: fsAsync,
           callback: (err, res) => err ? reject(err) : resolve(res!),
-        }));
-    },
-    formatMessages: (messages, options) => {
-      return new Promise((resolve, reject) =>
+        })),
+
+    formatMessages: (messages, options) =>
+      new Promise((resolve, reject) =>
         service.formatMessages({
           callName: 'formatMessages',
           refs,
           messages,
           options,
           callback: (err, res) => err ? reject(err) : resolve(res!),
-        }));
-    },
-    analyzeMetafile: (metafile, options) => {
-      return new Promise((resolve, reject) =>
+        })),
+
+    analyzeMetafile: (metafile, options) =>
+      new Promise((resolve, reject) =>
         service.analyzeMetafile({
           callName: 'analyzeMetafile',
           refs,
           metafile: typeof metafile === 'string' ? metafile : JSON.stringify(metafile),
           options,
           callback: (err, res) => err ? reject(err) : resolve(res!),
-        }));
-    },
+        })),
   };
   return longLivedService;
 }
@@ -365,7 +360,7 @@ let runServiceSync = (callback: (service: common.StreamService) => void): void =
       stdin = bytes;
     },
     isSync: true,
-    isWriteUnavailable: false,
+    hasFS: true,
     esbuild: ourselves,
   });
   callback(service);
@@ -434,11 +429,7 @@ let startWorkerThreadService = (worker_threads: typeof import('worker_threads'))
   let validateBuildSyncOptions = (options: types.BuildOptions | undefined): void => {
     if (!options) return
     let plugins = options.plugins
-    let incremental = options.incremental
-    let watch = options.watch
     if (plugins && plugins.length > 0) throw fakeBuildError(`Cannot use plugins in synchronous API calls`);
-    if (incremental) throw fakeBuildError(`Cannot use "incremental" with a synchronous build`);
-    if (watch) throw fakeBuildError(`Cannot use "watch" with a synchronous build`);
   };
 
   // MessagePort doesn't copy the properties of Error objects. We still want

--- a/lib/npm/node.ts
+++ b/lib/npm/node.ts
@@ -130,13 +130,13 @@ let fsAsync: common.StreamFS = {
 
 export let version = ESBUILD_VERSION;
 
-export let build: typeof types.build = (options: types.BuildOptions): Promise<any> =>
+export let build: typeof types.build = (options: types.BuildOptions) =>
   ensureServiceIsRunning().build(options);
 
 export let serve: typeof types.serve = (serveOptions, buildOptions) =>
   ensureServiceIsRunning().serve(serveOptions, buildOptions);
 
-export let transform: typeof types.transform = (input, options) =>
+export let transform: typeof types.transform = (input: string | Uint8Array, options?: types.TransformOptions) =>
   ensureServiceIsRunning().transform(input, options);
 
 export let formatMessages: typeof types.formatMessages = (messages, options) =>
@@ -145,7 +145,7 @@ export let formatMessages: typeof types.formatMessages = (messages, options) =>
 export let analyzeMetafile: typeof types.analyzeMetafile = (messages, options) =>
   ensureServiceIsRunning().analyzeMetafile(messages, options);
 
-export let buildSync: typeof types.buildSync = (options: types.BuildOptions): any => {
+export let buildSync: typeof types.buildSync = (options: types.BuildOptions) => {
   // Try using a long-lived worker thread to avoid repeated start-up overhead
   if (worker_threads && !isInternalWorkerThread) {
     if (!workerThreadService) workerThreadService = startWorkerThreadService(worker_threads);
@@ -165,7 +165,7 @@ export let buildSync: typeof types.buildSync = (options: types.BuildOptions): an
   return result!;
 };
 
-export let transformSync: typeof types.transformSync = (input, options) => {
+export let transformSync: typeof types.transformSync = (input: string | Uint8Array, options?: types.TransformOptions) => {
   // Try using a long-lived worker thread to avoid repeated start-up overhead
   if (worker_threads && !isInternalWorkerThread) {
     if (!workerThreadService) workerThreadService = startWorkerThreadService(worker_threads);
@@ -320,8 +320,8 @@ let ensureServiceIsRunning = (): Service => {
           defaultWD, callback: (err, res) => err ? reject(err) : resolve(res as types.ServeResult),
         }))
     },
-    transform: (input, options) => {
-      return new Promise((resolve, reject) =>
+    transform: (input: string | Uint8Array, options?: types.TransformOptions) => {
+      return new Promise<types.TransformResult>((resolve, reject) =>
         service.transform({
           callName: 'transform',
           refs,
@@ -397,7 +397,7 @@ interface MainToWorkerMessage {
 
 interface WorkerThreadService {
   buildSync(options: types.BuildOptions): types.BuildResult;
-  transformSync: typeof types.transformSync;
+  transformSync(input: string | Uint8Array, options?: types.TransformOptions): types.TransformResult;
   formatMessagesSync: typeof types.formatMessagesSync;
   analyzeMetafileSync: typeof types.analyzeMetafileSync;
 }

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -736,7 +736,13 @@ export function createChannel(streamIn: StreamIn): StreamOut {
           let outstanding = 1;
           let next = () => {
             if (--outstanding === 0) {
-              let result: types.TransformResult = { warnings, code: response!.code, map: response!.map }
+              let result: types.TransformResult = {
+                warnings,
+                code: response!.code,
+                map: response!.map,
+                mangleCache: undefined,
+                legalComments: undefined,
+              }
               if ('legalComments' in response!) result.legalComments = response?.legalComments
               if (response!.mangleCache) result.mangleCache = response?.mangleCache
               callback(null, result)
@@ -972,6 +978,11 @@ function buildOrServeImpl(
       let result: types.BuildResult = {
         errors: replaceDetailsInMessages(response!.errors, details),
         warnings: replaceDetailsInMessages(response!.warnings, details),
+        outputFiles: undefined,
+        rebuild: undefined,
+        stop: undefined,
+        metafile: undefined,
+        mangleCache: undefined,
       };
       copyResponseToResult(response!, result);
       runOnEndCallbacks(result, logPluginError, () => {
@@ -1031,6 +1042,11 @@ function buildOrServeImpl(
                   let result2: types.BuildResult = {
                     errors: replaceDetailsInMessages(watchResponse.errors, details),
                     warnings: replaceDetailsInMessages(watchResponse.warnings, details),
+                    outputFiles: undefined,
+                    rebuild: undefined,
+                    stop: undefined,
+                    metafile: undefined,
+                    mangleCache: undefined,
                   };
 
                   // Note: "onEnd" callbacks should run even when there is no "onRebuild" callback

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -4,7 +4,7 @@
 // additional byte array primitive. You must send a response after receiving a
 // request because the other end is blocking on the response coming back.
 
-import * as types from "./types";
+import type * as types from "./types";
 
 export interface BuildRequest {
   command: 'build';
@@ -15,27 +15,26 @@ export interface BuildRequest {
   stdinContents: Uint8Array | null;
   stdinResolveDir: string | null;
   absWorkingDir: string;
-  incremental: boolean;
   nodePaths: string[];
+  context: boolean;
   plugins?: BuildPlugin[];
-  serve?: ServeRequest;
   mangleCache?: Record<string, string | false>;
 }
 
 export interface ServeRequest {
+  command: 'serve';
+  key: number;
+  onRequest: boolean;
   port?: number;
   host?: string;
   servedir?: string;
+  keyfile?: string;
+  certfile?: string;
 }
 
 export interface ServeResponse {
   port: number;
   host: string;
-}
-
-export interface ServeStopRequest {
-  command: 'serve-stop';
-  key: number;
 }
 
 export interface BuildPlugin {
@@ -49,12 +48,19 @@ export interface BuildPlugin {
 export interface BuildResponse {
   errors: types.Message[];
   warnings: types.Message[];
-  rebuild: boolean;
-  watch: boolean;
   outputFiles?: BuildOutputFile[];
   metafile?: string;
   mangleCache?: Record<string, string | false>;
   writeToStdout?: Uint8Array;
+}
+
+export interface OnEndRequest extends BuildResponse {
+  command: 'on-end';
+}
+
+export interface OnEndResponse {
+  errors: types.Message[];
+  warnings: types.Message[];
 }
 
 export interface BuildOutputFile {
@@ -71,32 +77,25 @@ export interface RebuildRequest {
   key: number;
 }
 
-export interface RebuildDisposeRequest {
-  command: 'rebuild-dispose';
+export interface RebuildResponse {
+  errors: types.Message[];
+  warnings: types.Message[];
+}
+
+export interface DisposeRequest {
+  command: 'dispose';
   key: number;
 }
 
-export interface WatchStopRequest {
-  command: 'watch-stop';
+export interface WatchRequest {
+  command: 'watch';
   key: number;
 }
 
-export interface OnRequestRequest {
+export interface OnServeRequest {
   command: 'serve-request';
   key: number;
   args: types.ServeOnRequestArgs;
-}
-
-export interface OnWaitRequest {
-  command: 'serve-wait';
-  key: number;
-  error: string | null;
-}
-
-export interface OnWatchRebuildRequest {
-  command: 'watch-rebuild';
-  key: number;
-  args: BuildResponse;
 }
 
 export interface TransformRequest {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -208,19 +208,19 @@ export interface BuildIncremental extends BuildResult {
   rebuild: BuildInvalidate;
 }
 
-export interface BuildResult {
+export interface BuildResult<SpecificOptions extends BuildOptions = BuildOptions> {
   errors: Message[];
   warnings: Message[];
   /** Only when "write: false" */
-  outputFiles?: OutputFile[];
+  outputFiles: OutputFile[] | (SpecificOptions['write'] extends false ? never : undefined);
   /** Only when "incremental: true" */
-  rebuild?: BuildInvalidate;
+  rebuild: BuildInvalidate | (SpecificOptions['incremental'] extends true ? never : undefined);
   /** Only when "watch: true" */
-  stop?: () => void;
+  stop: (() => void) | (SpecificOptions['watch'] extends true ? never : undefined);
   /** Only when "metafile: true" */
-  metafile?: Metafile;
+  metafile: Metafile | (SpecificOptions['metafile'] extends true ? never : undefined);
   /** Only when "mangleCache" is present */
-  mangleCache?: Record<string, string | false>;
+  mangleCache: Record<string, string | false> | (SpecificOptions['mangleCache'] extends Object ? never : undefined);
 }
 
 export interface BuildFailure extends Error {
@@ -274,14 +274,14 @@ export interface TransformOptions extends CommonOptions {
   footer?: string;
 }
 
-export interface TransformResult {
+export interface TransformResult<SpecificOptions extends TransformOptions = TransformOptions> {
   code: string;
   map: string;
   warnings: Message[];
   /** Only when "mangleCache" is present */
-  mangleCache?: Record<string, string | false>;
+  mangleCache: Record<string, string | false> | (SpecificOptions['mangleCache'] extends Object ? never : undefined);
   /** Only when "legalComments" is "external" */
-  legalComments?: string;
+  legalComments: string | (SpecificOptions['legalComments'] extends 'external' ? never : undefined);
 }
 
 export interface TransformFailure extends Error {
@@ -488,10 +488,7 @@ export interface AnalyzeMetafileOptions {
  *
  * Documentation: https://esbuild.github.io/api/#build-api
  */
-export declare function build(options: BuildOptions & { write: false }): Promise<BuildResult & { outputFiles: OutputFile[] }>;
-export declare function build(options: BuildOptions & { incremental: true, metafile: true }): Promise<BuildIncremental & { metafile: Metafile }>;
-export declare function build(options: BuildOptions & { incremental: true }): Promise<BuildIncremental>;
-export declare function build(options: BuildOptions & { metafile: true }): Promise<BuildResult & { metafile: Metafile }>;
+export declare function build<SpecificOptions extends BuildOptions>(options: SpecificOptions): Promise<BuildResult<SpecificOptions>>;
 export declare function build(options: BuildOptions): Promise<BuildResult>;
 
 /**
@@ -516,6 +513,7 @@ export declare function serve(serveOptions: ServeOptions, buildOptions: BuildOpt
  *
  * Documentation: https://esbuild.github.io/api/#transform-api
  */
+export declare function transform<SpecificOptions extends TransformOptions>(input: string | Uint8Array, options?: SpecificOptions): Promise<TransformResult<SpecificOptions>>;
 export declare function transform(input: string | Uint8Array, options?: TransformOptions): Promise<TransformResult>;
 
 /**
@@ -548,7 +546,7 @@ export declare function analyzeMetafile(metafile: Metafile | string, options?: A
  *
  * Documentation: https://esbuild.github.io/api/#build-api
  */
-export declare function buildSync(options: BuildOptions & { write: false }): BuildResult & { outputFiles: OutputFile[] };
+export declare function buildSync<SpecificOptions extends BuildOptions>(options: SpecificOptions): BuildResult<SpecificOptions>;
 export declare function buildSync(options: BuildOptions): BuildResult;
 
 /**
@@ -559,7 +557,8 @@ export declare function buildSync(options: BuildOptions): BuildResult;
  *
  * Documentation: https://esbuild.github.io/api/#transform-api
  */
-export declare function transformSync(input: string, options?: TransformOptions): TransformResult;
+export declare function transformSync<SpecificOptions extends TransformOptions>(input: string, options?: SpecificOptions): TransformResult<SpecificOptions>;
+export declare function transformSync(input: string | Uint8Array, options?: TransformOptions): TransformResult;
 
 /**
  * A synchronous version of "formatMessages".

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -132,8 +132,6 @@ export interface BuildOptions extends CommonOptions {
   banner?: { [type: string]: string };
   /** Documentation: https://esbuild.github.io/api/#footer */
   footer?: { [type: string]: string };
-  /** Documentation: https://esbuild.github.io/api/#incremental */
-  incremental?: boolean;
   /** Documentation: https://esbuild.github.io/api/#entry-points */
   entryPoints?: string[] | Record<string, string>;
   /** Documentation: https://esbuild.github.io/api/#stdin */
@@ -144,12 +142,6 @@ export interface BuildOptions extends CommonOptions {
   absWorkingDir?: string;
   /** Documentation: https://esbuild.github.io/api/#node-paths */
   nodePaths?: string[]; // The "NODE_PATH" variable from Node.js
-  /** Documentation: https://esbuild.github.io/api/#watch */
-  watch?: boolean | WatchMode;
-}
-
-export interface WatchMode {
-  onRebuild?: (error: BuildFailure | null, result: BuildResult | null) => void;
 }
 
 export interface StdinOptions {
@@ -199,24 +191,11 @@ export interface OutputFile {
   readonly text: string;
 }
 
-export interface BuildInvalidate {
-  (): Promise<BuildIncremental>;
-  dispose(): void;
-}
-
-export interface BuildIncremental extends BuildResult {
-  rebuild: BuildInvalidate;
-}
-
 export interface BuildResult<SpecificOptions extends BuildOptions = BuildOptions> {
   errors: Message[];
   warnings: Message[];
   /** Only when "write: false" */
   outputFiles: OutputFile[] | (SpecificOptions['write'] extends false ? never : undefined);
-  /** Only when "incremental: true" */
-  rebuild: BuildInvalidate | (SpecificOptions['incremental'] extends true ? never : undefined);
-  /** Only when "watch: true" */
-  stop: (() => void) | (SpecificOptions['watch'] extends true ? never : undefined);
   /** Only when "metafile: true" */
   metafile: Metafile | (SpecificOptions['metafile'] extends true ? never : undefined);
   /** Only when "mangleCache" is present */
@@ -233,6 +212,8 @@ export interface ServeOptions {
   port?: number;
   host?: string;
   servedir?: string;
+  keyfile?: string
+  certfile?: string
   onRequest?: (args: ServeOnRequestArgs) => void;
 }
 
@@ -249,8 +230,6 @@ export interface ServeOnRequestArgs {
 export interface ServeResult {
   port: number;
   host: string;
-  wait: Promise<void>;
-  stop: () => void;
 }
 
 export interface TransformOptions extends CommonOptions {
@@ -301,7 +280,7 @@ export interface PluginBuild {
   onStart(callback: () =>
     (OnStartResult | null | void | Promise<OnStartResult | null | void>)): void;
   onEnd(callback: (result: BuildResult) =>
-    (void | Promise<void>)): void;
+    (OnEndResult | null | void | Promise<OnEndResult | null | void>)): void;
   onResolve(options: OnResolveOptions, callback: (args: OnResolveArgs) =>
     (OnResolveResult | null | undefined | Promise<OnResolveResult | null | undefined>)): void;
   onLoad(options: OnLoadOptions, callback: (args: OnLoadArgs) =>
@@ -309,7 +288,7 @@ export interface PluginBuild {
 
   // This is a full copy of the esbuild library in case you need it
   esbuild: {
-    serve: typeof serve,
+    context: typeof context,
     build: typeof build,
     buildSync: typeof buildSync,
     transform: typeof transform,
@@ -345,6 +324,11 @@ export interface ResolveResult {
 }
 
 export interface OnStartResult {
+  errors?: PartialMessage[];
+  warnings?: PartialMessage[];
+}
+
+export interface OnEndResult {
   errors?: PartialMessage[];
   warnings?: PartialMessage[];
 }
@@ -478,6 +462,16 @@ export interface AnalyzeMetafileOptions {
   verbose?: boolean;
 }
 
+export interface WatchOptions {
+}
+
+export interface BuildContext<SpecificOptions extends BuildOptions = BuildOptions> {
+  rebuild(): Promise<BuildResult<SpecificOptions>>
+  watch(options?: WatchOptions): void
+  serve(options?: ServeOptions): Promise<ServeResult>
+  dispose(): Promise<void>
+}
+
 /**
  * This function invokes the "esbuild" command-line tool for you. It returns a
  * promise that either resolves with a "BuildResult" object or rejects with a
@@ -492,15 +486,16 @@ export declare function build<SpecificOptions extends BuildOptions>(options: Spe
 export declare function build(options: BuildOptions): Promise<BuildResult>;
 
 /**
- * This function is similar to "build" but it serves the resulting files over
- * HTTP on a localhost address with the specified port.
+ * This is the advanced long-running form of "build" that supports additional
+ * features such as watch mode and a local development server.
  *
  * - Works in node: yes
  * - Works in browser: no
  *
- * Documentation: https://esbuild.github.io/api/#serve
+ * Documentation: https://esbuild.github.io/api/#context-api
  */
-export declare function serve(serveOptions: ServeOptions, buildOptions: BuildOptions): Promise<ServeResult>;
+export declare function context<T extends BuildOptions>(options: T): Promise<BuildContext<T>>;
+export declare function context(options: BuildOptions): Promise<BuildContext>;
 
 /**
  * This function transforms a single JavaScript file. It can be used to minify

--- a/pkg/api/serve_wasm.go
+++ b/pkg/api/serve_wasm.go
@@ -7,6 +7,15 @@ import "fmt"
 
 // Remove the serve API in the WebAssembly build. This removes 2.7mb of stuff.
 
-func serveImpl(serveOptions ServeOptions, buildOptions BuildOptions) (ServeResult, error) {
+func (*internalContext) Serve(ServeOptions) (ServeResult, error) {
 	return ServeResult{}, fmt.Errorf("The \"serve\" API is not supported when using WebAssembly")
+}
+
+type apiHandler struct {
+}
+
+func (*apiHandler) broadcastBuildResult(BuildResult, buildSummary) {
+}
+
+func (*apiHandler) stop() {
 }

--- a/pkg/cli/mangle_cache.go
+++ b/pkg/cli/mangle_cache.go
@@ -23,7 +23,6 @@ func parseMangleCache(osArgs []string, fs fs.FS, absPath string) (map[string]int
 	// Log problems with the mangle cache to stderr
 	log := logger.NewStderrLog(logger.OutputOptionsForArgs(osArgs))
 	defer log.Done()
-	// log.AddMsg(msg)
 
 	// Try to read the existing file
 	prettyPath := absPath

--- a/scripts/browser/index.html
+++ b/scripts/browser/index.html
@@ -36,9 +36,9 @@
     }]
   }
 
-  function expectThrownError(fn, err) {
+  async function expectThrownError(fn, err) {
     try {
-      fn()
+      await fn()
       throw new Error('Expected an error to be thrown')
     } catch (e) {
       assertStrictEqual(e.message, err)
@@ -143,16 +143,30 @@
         assertStrictEqual(result.outputFiles[0].text, 'const x = 1;\n')
       },
 
+      async watch() {
+        const context = await esbuild.context({})
+        try {
+          await expectThrownError(context.watch, 'Cannot use the "watch" API in this environment')
+        } finally {
+          context.dispose()
+        }
+      },
+
       async serve() {
-        expectThrownError(esbuild.serve, 'The "serve" API only works in node')
+        const context = await esbuild.context({})
+        try {
+          await expectThrownError(context.serve, 'Cannot use the "serve" API in this environment')
+        } finally {
+          context.dispose()
+        }
       },
 
       async esbuildBuildSync() {
-        expectThrownError(esbuild.buildSync, 'The "buildSync" API only works in node')
+        await expectThrownError(esbuild.buildSync, 'The "buildSync" API only works in node')
       },
 
       async esbuildTransformSync() {
-        expectThrownError(esbuild.transformSync, 'The "transformSync" API only works in node')
+        await expectThrownError(esbuild.transformSync, 'The "transformSync" API only works in node')
       },
     }
 

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -43,15 +43,6 @@ tests.push(
   }),
 )
 
-// Test enabling watch mode and serve mode, which is disallowed
-tests.push(
-  test(['--watch=forever', '--servedir=.'], {}, {
-    expectedStderr: `${errorIcon} [ERROR] Cannot use "watch" with "serve"
-
-`,
-  }),
-)
-
 // Test bogus paths with a file as a parent directory (this happens when you use "pnpx esbuild")
 tests.push(
   test(['entry.js', '--bundle'], {

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2,6 +2,7 @@ const { installForTests, removeRecursiveSync, writeFileAtomic } = require('./esb
 const assert = require('assert')
 const path = require('path')
 const util = require('util')
+const http = require('http')
 const url = require('url')
 const fs = require('fs')
 
@@ -11,6 +12,51 @@ const mkdirAsync = util.promisify(fs.mkdir)
 
 const repoDir = path.dirname(__dirname)
 const rootTestDir = path.join(repoDir, 'scripts', '.plugin-tests')
+
+function fetch(host, port, path) {
+  return new Promise((resolve, reject) => {
+    http.get({ host, port, path }, res => {
+      const chunks = []
+      res.on('data', chunk => chunks.push(chunk))
+      res.on('end', () => {
+        const content = Buffer.concat(chunks)
+        if (res.statusCode < 200 || res.statusCode > 299) {
+          const error = new Error(`${res.statusCode} when fetching ${path}: ${content}`)
+          error.statusCode = res.statusCode
+          reject(error)
+        } else {
+          content.headers = res.headers
+          resolve(content)
+        }
+      })
+    }).on('error', reject)
+  })
+}
+
+function fetchUntilSuccessOrTimeout(host, port, path) {
+  const seconds = 5
+  let timeout
+  let stop = false
+  const cancel = () => clearTimeout(timeout)
+  const promise = Promise.race([
+    new Promise((_, reject) => {
+      timeout = setTimeout(() => {
+        stop = true
+        reject(new Error(`Waited more than ${seconds} seconds while trying to fetch "http://${host}:${port}${path}"`))
+      }, seconds * 1000)
+    }),
+    (async () => {
+      while (!stop) {
+        try {
+          return await fetch(host, port, path)
+        } catch {
+        }
+      }
+    })(),
+  ])
+  promise.then(cancel, cancel)
+  return promise
+}
 
 let pluginTests = {
   async noPluginsWithBuildSync({ esbuild }) {
@@ -2391,6 +2437,28 @@ error: Invalid path suffix "%what" returned from plugin (must start with "?" or 
   },
 }
 
+const makeRebuildUntilPlugin = () => {
+  let onEnd
+
+  return {
+    rebuildUntil: (mutator, condition) => new Promise((resolve, reject) => {
+      let timeout = setTimeout(() => reject(new Error('Timeout after 30 seconds')), 30 * 1000)
+      onEnd = result => {
+        try { if (result && condition(result)) clearTimeout(timeout), resolve(result) }
+        catch (e) { clearTimeout(timeout), reject(e) }
+      }
+      mutator()
+    }),
+
+    plugin: {
+      name: 'rebuildUntil',
+      setup(build) {
+        build.onEnd(result => onEnd && onEnd(result))
+      },
+    },
+  }
+}
+
 // These tests have to run synchronously
 let syncTests = {
   async pluginWithWatchMode({ esbuild, testDir }) {
@@ -2402,15 +2470,12 @@ let syncTests = {
     await writeFileAsync(input, `import {x} from "./example.js"; exports.x = x`)
     await writeFileAsync(example, `export let x = 1`)
 
-    let onRebuild = () => { }
-    const result = await esbuild.build({
+    const { rebuildUntil, plugin } = makeRebuildUntilPlugin()
+    const ctx = await esbuild.context({
       entryPoints: [input],
       outfile,
       format: 'cjs',
       logLevel: 'silent',
-      watch: {
-        onRebuild: (...args) => onRebuild(args),
-      },
       bundle: true,
       plugins: [
         {
@@ -2422,44 +2487,34 @@ let syncTests = {
             })
           },
         },
+        plugin,
       ],
     })
-    const rebuildUntil = (mutator, condition) => {
-      let timeout
-      return new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error('Timeout after 30 seconds')), 30 * 1000)
-        onRebuild = args => {
-          try { if (condition(...args)) clearTimeout(timeout), resolve(args) }
-          catch (e) { clearTimeout(timeout), reject(e) }
-        }
-        mutator()
-      })
-    }
 
     try {
+      // First build
+      const result = await ctx.rebuild()
       let code = await readFileAsync(outfile, 'utf8')
       let exports = {}
       new Function('exports', code)(exports)
       assert.strictEqual(result.outputFiles, void 0)
-      assert.strictEqual(typeof result.stop, 'function')
       assert.strictEqual(exports.x, 1)
+      await ctx.watch()
 
       // First rebuild: edit
       {
-        const [error2, result2] = await rebuildUntil(
+        const result2 = await rebuildUntil(
           () => setTimeout(() => writeFileAtomic(example, `export let x = 2`), 250),
           () => fs.readFileSync(outfile, 'utf8') !== code,
         )
         code = await readFileAsync(outfile, 'utf8')
         exports = {}
         new Function('exports', code)(exports)
-        assert.strictEqual(error2, null)
         assert.strictEqual(result2.outputFiles, void 0)
-        assert.strictEqual(result2.stop, result.stop)
         assert.strictEqual(exports.x, 2)
       }
     } finally {
-      result.stop()
+      await ctx.dispose()
     }
   },
 
@@ -2474,15 +2529,12 @@ let syncTests = {
     await writeFileAsync(input, `import {x} from "<virtual>"; exports.x = x`)
     await writeFileAsync(example, `export let x = 1`)
 
-    let onRebuild = () => { }
-    const result = await esbuild.build({
+    const { rebuildUntil, plugin } = makeRebuildUntilPlugin()
+    const ctx = await esbuild.context({
       entryPoints: [input],
       outfile,
       format: 'cjs',
       logLevel: 'silent',
-      watch: {
-        onRebuild: (...args) => onRebuild(args),
-      },
       bundle: true,
       plugins: [
         {
@@ -2497,44 +2549,34 @@ let syncTests = {
             })
           },
         },
+        plugin,
       ],
     })
-    const rebuildUntil = (mutator, condition) => {
-      let timeout
-      return new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error('Timeout after 30 seconds')), 30 * 1000)
-        onRebuild = args => {
-          try { if (condition(...args)) clearTimeout(timeout), resolve(args) }
-          catch (e) { clearTimeout(timeout), reject(e) }
-        }
-        mutator()
-      })
-    }
 
     try {
+      // First build
+      const result = await ctx.rebuild()
       let code = await readFileAsync(outfile, 'utf8')
       let exports = {}
       new Function('exports', code)(exports)
       assert.strictEqual(result.outputFiles, void 0)
-      assert.strictEqual(typeof result.stop, 'function')
       assert.strictEqual(exports.x, 1)
+      await ctx.watch()
 
       // First rebuild: edit
       {
-        const [error2, result2] = await rebuildUntil(
+        const result2 = await rebuildUntil(
           () => setTimeout(() => writeFileAtomic(example, `export let x = 2`), 250),
           () => fs.readFileSync(outfile, 'utf8') !== code,
         )
         code = await readFileAsync(outfile, 'utf8')
         exports = {}
         new Function('exports', code)(exports)
-        assert.strictEqual(error2, null)
         assert.strictEqual(result2.outputFiles, void 0)
-        assert.strictEqual(result2.stop, result.stop)
         assert.strictEqual(exports.x, 2)
       }
     } finally {
-      result.stop()
+      await ctx.dispose()
     }
   },
 
@@ -2547,15 +2589,12 @@ let syncTests = {
     await mkdirAsync(otherDir, { recursive: true })
     await writeFileAsync(input, `import {x} from "<virtual>"; exports.x = x`)
 
-    let onRebuild = () => { }
-    const result = await esbuild.build({
+    const { rebuildUntil, plugin } = makeRebuildUntilPlugin()
+    const ctx = await esbuild.context({
       entryPoints: [input],
       outfile,
       format: 'cjs',
       logLevel: 'silent',
-      watch: {
-        onRebuild: (...args) => onRebuild(args),
-      },
       bundle: true,
       plugins: [
         {
@@ -2570,44 +2609,33 @@ let syncTests = {
             })
           },
         },
+        plugin,
       ],
     })
-    const rebuildUntil = (mutator, condition) => {
-      let timeout
-      return new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error('Timeout after 30 seconds')), 30 * 1000)
-        onRebuild = args => {
-          try { if (condition(...args)) clearTimeout(timeout), resolve(args) }
-          catch (e) { clearTimeout(timeout), reject(e) }
-        }
-        mutator()
-      })
-    }
 
     try {
+      const result = await ctx.rebuild()
       let code = await readFileAsync(outfile, 'utf8')
       let exports = {}
       new Function('exports', code)(exports)
       assert.strictEqual(result.outputFiles, void 0)
-      assert.strictEqual(typeof result.stop, 'function')
       assert.strictEqual(exports.x, 0)
+      await ctx.watch()
 
       // First rebuild: edit
       {
-        const [error2, result2] = await rebuildUntil(
+        const result2 = await rebuildUntil(
           () => setTimeout(() => writeFileAtomic(path.join(otherDir, 'file.txt'), `...`), 250),
           () => fs.readFileSync(outfile, 'utf8') !== code,
         )
         code = await readFileAsync(outfile, 'utf8')
         exports = {}
         new Function('exports', code)(exports)
-        assert.strictEqual(error2, null)
         assert.strictEqual(result2.outputFiles, void 0)
-        assert.strictEqual(result2.stop, result.stop)
         assert.strictEqual(exports.x, 1)
       }
     } finally {
-      result.stop()
+      await ctx.dispose()
     }
   },
 
@@ -2619,11 +2647,10 @@ let syncTests = {
     let errorToThrow = null
     let valueToReturn = null
 
-    const result = await esbuild.build({
+    const ctx = await esbuild.context({
       entryPoints: [input],
       write: false,
       logLevel: 'silent',
-      incremental: true,
       plugins: [
         {
           name: 'some-plugin',
@@ -2637,53 +2664,55 @@ let syncTests = {
         },
       ],
     })
-    assert.strictEqual(onStartTimes, 1)
-
-    await result.rebuild()
-    assert.strictEqual(onStartTimes, 2)
-
-    await result.rebuild()
-    assert.strictEqual(onStartTimes, 3)
-
-    errorToThrow = new Error('throw test')
     try {
-      await result.rebuild()
-      throw new Error('Expected an error to be thrown')
-    } catch (e) {
-      assert.notStrictEqual(e.errors, void 0)
-      assert.strictEqual(e.errors.length, 1)
-      assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
-      assert.strictEqual(e.errors[0].text, 'throw test')
-    } finally {
-      errorToThrow = null
-    }
+      assert.strictEqual(onStartTimes, 0)
 
-    valueToReturn = { errors: [{ text: 'return test', location: { file: 'foo.js', line: 2 } }] }
-    try {
-      await result.rebuild()
-      throw new Error('Expected an error to be thrown')
-    } catch (e) {
-      assert.notStrictEqual(e.errors, void 0)
-      assert.strictEqual(e.errors.length, 1)
-      assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
-      assert.strictEqual(e.errors[0].text, 'return test')
-      assert.notStrictEqual(e.errors[0].location, null)
-      assert.strictEqual(e.errors[0].location.file, 'foo.js')
-      assert.strictEqual(e.errors[0].location.line, 2)
-    } finally {
+      await ctx.rebuild()
+      assert.strictEqual(onStartTimes, 1)
+
+      await ctx.rebuild()
+      assert.strictEqual(onStartTimes, 2)
+
+      errorToThrow = new Error('throw test')
+      try {
+        await ctx.rebuild()
+        throw new Error('Expected an error to be thrown')
+      } catch (e) {
+        assert.notStrictEqual(e.errors, void 0)
+        assert.strictEqual(e.errors.length, 1)
+        assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
+        assert.strictEqual(e.errors[0].text, 'throw test')
+      } finally {
+        errorToThrow = null
+      }
+
+      valueToReturn = { errors: [{ text: 'return test', location: { file: 'foo.js', line: 2 } }] }
+      try {
+        await ctx.rebuild()
+        throw new Error('Expected an error to be thrown')
+      } catch (e) {
+        assert.notStrictEqual(e.errors, void 0)
+        assert.strictEqual(e.errors.length, 1)
+        assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
+        assert.strictEqual(e.errors[0].text, 'return test')
+        assert.notStrictEqual(e.errors[0].location, null)
+        assert.strictEqual(e.errors[0].location.file, 'foo.js')
+        assert.strictEqual(e.errors[0].location.line, 2)
+      } finally {
+        valueToReturn = null
+      }
+
+      assert.strictEqual(onStartTimes, 2)
+      valueToReturn = new Promise(resolve => setTimeout(() => {
+        onStartTimes++
+        resolve()
+      }, 500))
+      await ctx.rebuild()
+      assert.strictEqual(onStartTimes, 3)
       valueToReturn = null
+    } finally {
+      await ctx.dispose()
     }
-
-    assert.strictEqual(onStartTimes, 3)
-    valueToReturn = new Promise(resolve => setTimeout(() => {
-      onStartTimes++
-      resolve()
-    }, 500))
-    await result.rebuild()
-    assert.strictEqual(onStartTimes, 4)
-    valueToReturn = null
-
-    result.rebuild.dispose()
   },
 
   async onStartCallbackWithDelay({ esbuild }) {
@@ -2725,11 +2754,10 @@ let syncTests = {
     let valueToReturn = null
     let mutateFn = null
 
-    const result = await esbuild.build({
+    const ctx = await esbuild.context({
       entryPoints: [input],
       write: false,
       logLevel: 'silent',
-      incremental: true,
       plugins: [
         {
           name: 'some-plugin',
@@ -2744,56 +2772,64 @@ let syncTests = {
         },
       ],
     })
-    assert.strictEqual(onEndTimes, 1)
-
-    await result.rebuild()
-    assert.strictEqual(onEndTimes, 2)
-
-    await result.rebuild()
-    assert.strictEqual(onEndTimes, 3)
-
-    errorToThrow = new Error('throw test')
     try {
-      await result.rebuild()
-      throw new Error('Expected an error to be thrown')
-    } catch (e) {
-      assert.notStrictEqual(e.errors, void 0)
-      assert.strictEqual(e.errors.length, 1)
-      assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
-      assert.strictEqual(e.errors[0].text, 'throw test')
+      assert.strictEqual(onEndTimes, 0)
+
+      await ctx.rebuild()
+      assert.strictEqual(onEndTimes, 1)
+
+      await ctx.rebuild()
+      assert.strictEqual(onEndTimes, 2)
+
+      errorToThrow = new Error('throw test')
+      try {
+        await ctx.rebuild()
+        throw new Error('Expected an error to be thrown')
+      } catch (e) {
+        assert.notStrictEqual(e.errors, void 0)
+        assert.strictEqual(e.errors.length, 1)
+        assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
+        assert.strictEqual(e.errors[0].text, 'throw test')
+      } finally {
+        errorToThrow = null
+      }
+
+      assert.strictEqual(onEndTimes, 2)
+      valueToReturn = new Promise(resolve => setTimeout(() => {
+        onEndTimes++
+        resolve()
+      }, 500))
+      await ctx.rebuild()
+      assert.strictEqual(onEndTimes, 3)
+      valueToReturn = null
+
+      mutateFn = result => result.warnings.push(true)
+      const result2 = await ctx.rebuild()
+      assert.deepStrictEqual(result2.warnings, [true])
+      mutateFn = () => { }
+      const result3 = await ctx.rebuild()
+      assert.deepStrictEqual(result3.warnings, [])
+
+      // Adding an error this way does not fail the build (we don't scan the build object for modifications)
+      mutateFn = result => result.errors.push({ text: 'test failure' })
+      await ctx.rebuild()
+      mutateFn = () => { }
+
+      // Instead, plugins should return any additional errors from the "onEnd" callback itself
+      valueToReturn = { errors: [{ text: 'test failure 2' }] }
+      try {
+        await ctx.rebuild()
+        throw new Error('Expected an error to be thrown')
+      } catch (e) {
+        assert.notStrictEqual(e.errors, void 0)
+        assert.strictEqual(e.errors.length, 1)
+        assert.strictEqual(e.errors[0].pluginName, 'some-plugin')
+        assert.strictEqual(e.errors[0].text, 'test failure 2')
+        assert.strictEqual(e.errors[0].location, null)
+      }
     } finally {
-      errorToThrow = null
+      await ctx.dispose()
     }
-
-    assert.strictEqual(onEndTimes, 3)
-    valueToReturn = new Promise(resolve => setTimeout(() => {
-      onEndTimes++
-      resolve()
-    }, 500))
-    await result.rebuild()
-    assert.strictEqual(onEndTimes, 4)
-    valueToReturn = null
-
-    mutateFn = result => result.warnings.push(true)
-    const result2 = await result.rebuild()
-    assert.deepStrictEqual(result2.warnings, [true])
-    mutateFn = () => { }
-    const result3 = await result.rebuild()
-    assert.deepStrictEqual(result3.warnings, [])
-
-    mutateFn = result => result.errors.push({ text: 'test failure' })
-    try {
-      await result.rebuild()
-      throw new Error('Expected an error to be thrown')
-    } catch (e) {
-      assert.notStrictEqual(e.errors, void 0)
-      assert.strictEqual(e.errors.length, 1)
-      assert.strictEqual(e.errors[0].pluginName, void 0)
-      assert.strictEqual(e.errors[0].text, 'test failure')
-      assert.strictEqual(e.errors[0].location, void 0)
-    }
-
-    result.rebuild.dispose()
   },
 
   async onEndCallbackMutateContents({ esbuild, testDir }) {
@@ -2845,16 +2881,13 @@ let syncTests = {
 
     let onStartCalls = 0
     let onEndCalls = 0
-    let onRebuild = () => { }
 
-    const result = await esbuild.build({
+    const { rebuildUntil, plugin } = makeRebuildUntilPlugin()
+    const ctx = await esbuild.context({
       entryPoints: [input],
       outfile,
       format: 'cjs',
       logLevel: 'silent',
-      watch: {
-        onRebuild: (...args) => onRebuild(args),
-      },
       bundle: true,
       metafile: true,
       plugins: [
@@ -2875,51 +2908,149 @@ let syncTests = {
             })
           },
         },
+        plugin,
       ],
     })
 
-    assert.strictEqual(onStartCalls, 1)
-    assert.strictEqual(onEndCalls, 1)
-
-    const rebuildUntil = (mutator, condition) => {
-      let timeout
-      return new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error('Timeout after 30 seconds')), 30 * 1000)
-        onRebuild = args => {
-          try { if (condition(...args)) clearTimeout(timeout), resolve(args) }
-          catch (e) { clearTimeout(timeout), reject(e) }
-        }
-        mutator()
-      })
-    }
-
     try {
+      assert.strictEqual(onStartCalls, 0)
+      assert.strictEqual(onEndCalls, 0)
+
+      const result = await rebuildUntil(
+        () => ctx.watch(),
+        () => true,
+      )
+
+      assert.notStrictEqual(onStartCalls, 0)
+      assert.notStrictEqual(onEndCalls, 0)
+
+      const onStartAfterWatch = onStartCalls
+      const onEndAfterWatch = onEndCalls
+
       let code = await readFileAsync(outfile, 'utf8')
       let exports = {}
       new Function('exports', code)(exports)
       assert.strictEqual(result.outputFiles, void 0)
-      assert.strictEqual(typeof result.stop, 'function')
       assert.strictEqual(exports.x, 1)
 
       // First rebuild: edit
       {
-        const [error2, result2] = await rebuildUntil(
+        const result2 = await rebuildUntil(
           () => setTimeout(() => writeFileAtomic(example, `export let x = 2`), 250),
           () => fs.readFileSync(outfile, 'utf8') !== code,
         )
         code = await readFileAsync(outfile, 'utf8')
         exports = {}
         new Function('exports', code)(exports)
-        assert.strictEqual(error2, null)
         assert.strictEqual(result2.outputFiles, void 0)
-        assert.strictEqual(result2.stop, result.stop)
         assert.strictEqual(exports.x, 2)
       }
 
-      assert.notStrictEqual(onStartCalls, 1)
-      assert.notStrictEqual(onEndCalls, 1)
+      assert.notStrictEqual(onStartCalls, onStartAfterWatch)
+      assert.notStrictEqual(onEndCalls, onEndAfterWatch)
     } finally {
-      result.stop()
+      await ctx.dispose()
+    }
+  },
+
+  async pluginServeWriteTrueOnEnd({ esbuild, testDir }) {
+    const outfile = path.join(testDir, 'out.js')
+    const input = path.join(testDir, 'in.js')
+    await writeFileAsync(input, `console.log(1+2`)
+
+    let latestResult
+    const ctx = await esbuild.context({
+      entryPoints: [input],
+      outfile,
+      logLevel: 'silent',
+      plugins: [
+        {
+          name: 'some-plugin',
+          setup(build) {
+            build.onEnd(result => {
+              latestResult = result
+            })
+          },
+        },
+      ],
+    })
+
+    try {
+      const server = await ctx.serve()
+
+      // Fetch once
+      try {
+        await fetch(server.host, server.port, '/out.js')
+        throw new Error('Expected an error to be thrown')
+      } catch (err) {
+        assert.strictEqual(err.statusCode, 503)
+      }
+      assert.strictEqual(latestResult.errors.length, 1)
+      assert.strictEqual(latestResult.errors[0].text, 'Expected ")" but found end of file')
+
+      // Fix the error
+      await writeFileAsync(input, `console.log(1+2)`)
+
+      // Fetch again
+      const buffer = await fetchUntilSuccessOrTimeout(server.host, server.port, '/out.js')
+      assert.strictEqual(buffer.toString(), 'console.log(1 + 2);\n')
+      assert.strictEqual(latestResult.errors.length, 0)
+      assert.strictEqual(latestResult.outputFiles, undefined)
+      assert.strictEqual(fs.readFileSync(outfile, 'utf8'), 'console.log(1 + 2);\n')
+    } finally {
+      await ctx.dispose()
+    }
+  },
+
+  async pluginServeWriteFalseOnEnd({ esbuild, testDir }) {
+    const outfile = path.join(testDir, 'out.js')
+    const input = path.join(testDir, 'in.js')
+    await writeFileAsync(input, `console.log(1+2`)
+
+    let latestResult
+    const ctx = await esbuild.context({
+      entryPoints: [input],
+      outfile,
+      logLevel: 'silent',
+      write: false,
+      plugins: [
+        {
+          name: 'some-plugin',
+          setup(build) {
+            build.onEnd(result => {
+              latestResult = result
+            })
+          },
+        },
+      ],
+    })
+
+    try {
+      const server = await ctx.serve()
+
+      // Fetch once
+      try {
+        await fetch(server.host, server.port, '/out.js')
+        throw new Error('Expected an error to be thrown')
+      } catch (err) {
+        assert.strictEqual(err.statusCode, 503)
+      }
+      assert.strictEqual(latestResult.errors.length, 1)
+      assert.strictEqual(latestResult.errors[0].text, 'Expected ")" but found end of file')
+      assert.strictEqual(latestResult.outputFiles.length, 0)
+
+      // Fix the error
+      await writeFileAsync(input, `console.log(1+2)`)
+
+      // Fetch again
+      const buffer = await fetchUntilSuccessOrTimeout(server.host, server.port, '/out.js')
+      assert.strictEqual(buffer.toString(), 'console.log(1 + 2);\n')
+      assert.strictEqual(latestResult.errors.length, 0)
+      assert.strictEqual(latestResult.outputFiles.length, 1)
+      assert.strictEqual(latestResult.outputFiles[0].text, 'console.log(1 + 2);\n')
+      assert.strictEqual(fs.existsSync(outfile), false)
+    } finally {
+      await ctx.dispose()
     }
   },
 }

--- a/scripts/ts-type-tests.js
+++ b/scripts/ts-type-tests.js
@@ -37,71 +37,45 @@ const tests = {
     esbuild.transform('')
     esbuild.transform('', {})
   `,
+
+  mangleCache: `
+    import * as esbuild from 'esbuild'
+    esbuild.buildSync({ mangleCache: {} }).mangleCache['x']
+    esbuild.build({ mangleCache: {} })
+      .then(result => result.mangleCache['x'])
+  `,
   writeFalseOutputFiles: `
     import * as esbuild from 'esbuild'
     esbuild.buildSync({ write: false }).outputFiles[0]
-    esbuild.build({ write: false }).then(result => result.outputFiles[0])
-  `,
-  incrementalTrueRebuild: `
-    import * as esbuild from 'esbuild'
-    esbuild.build({ incremental: true }).then(result => {
-      result.rebuild().then(result => {
-        result.rebuild().then(() => {
-          result.rebuild.dispose()
-        })
-      })
-      result.rebuild.dispose()
-    })
-    async function a() {
-      let result = await esbuild.build({ incremental: true })
-      let result2 = await result.rebuild()
-      await result2.rebuild()
-      result2.rebuild.dispose()
-      result.rebuild.dispose()
-    }
+    esbuild.build({ write: false })
+      .then(result => result.outputFiles[0])
   `,
   metafileTrue: `
-    import {build, analyzeMetafile} from 'esbuild';
-    build({ metafile: true }).then(result => {
-      analyzeMetafile(result.metafile)
-    })
+    import {build, buildSync, analyzeMetafile} from 'esbuild';
+    analyzeMetafile(buildSync({ metafile: true }).metafile)
+    build({ metafile: true })
+      .then(result => analyzeMetafile(result.metafile))
   `,
-  incrementalAndMetafileTrue: `
-    import {build, analyzeMetafile} from 'esbuild';
-    build({
-      incremental: true,
-      metafile: true,
-    }).then(result => {
-      analyzeMetafile(result.metafile)
-    })
-  `,
-  ifRebuild: `
+
+  contextMangleCache: `
     import * as esbuild from 'esbuild'
-    let options: any
-    esbuild.build(options).then(result => {
-      if (result.rebuild) {
-        result.rebuild().then(result => {
-          if (result.rebuild) {
-            result.rebuild().then(result => {
-              result.rebuild.dispose()
-            })
-          }
-          result.rebuild.dispose()
-        })
-      }
-    })
-    async function a() {
-      let result = await esbuild.build(options)
-      if (result.rebuild) {
-        let result2 = await result.rebuild()
-        if (result2.rebuild) {
-          await result2.rebuild()
-          result2.rebuild.dispose()
-        }
-        result.rebuild.dispose()
-      }
-    }
+    esbuild.context({ mangleCache: {} })
+      .then(context => context.rebuild())
+      .then(result => result.mangleCache['x'])
   `,
+  contextWriteFalseOutputFiles: `
+    import * as esbuild from 'esbuild'
+    esbuild.context({ write: false })
+      .then(context => context.rebuild())
+      .then(result => result.outputFiles[0])
+  `,
+  contextMetafileTrue: `
+    import {context, analyzeMetafile} from 'esbuild';
+    context({ metafile: true })
+      .then(context => context.rebuild())
+      .then(result => analyzeMetafile(result.metafile))
+  `,
+
   allOptionsTransform: `
     export {}
     import {transform} from 'esbuild'


### PR DESCRIPTION
At a high level, the breaking changes in this PR fix some long-standing issues with the design of esbuild's incremental, watch, and serve APIs. This PR also introduces some exciting new features such as live reloading. In detail:

* Move everything related to incremental builds to a new `context` API ([#1037](https://github.com/evanw/esbuild/issues/1037), [#1606](https://github.com/evanw/esbuild/issues/1606), [#2280](https://github.com/evanw/esbuild/issues/2280), [#2418](https://github.com/evanw/esbuild/issues/2418))

    This change removes the `incremental` and `watch` options as well as the `serve()` method, and introduces a new `context()` method. The context method takes the same arguments as the `build()` method but only validates its arguments and does not do an initial build. Instead, builds can be triggered using the `rebuild()`, `watch()`, and `serve()` methods on the returned context object. The new context API looks like this:

    ```js
    // Create a context for incremental builds
    const context = await esbuild.context({
      entryPoints: ['app.ts'],
      bundle: true,
    })

    // Manually do an incremental build
    const result = await context.rebuild()

    // Enable watch mode
    await context.watch()

    // Enable serve mode
    await context.serve()

    // Dispose of the context
    context.dispose()
    ```

    The switch to the context API solves a major issue with the previous API which is that if the initial build fails, a promise is thrown in JavaScript which prevents you from accessing the returned result object. That prevented you from setting up long-running operations such as watch mode when the initial build contained errors. It also makes tearing down incremental builds simpler as there is now a single way to do it instead of three separate ways.

    In addition, this PR also makes some subtle changes to how incremental builds work. Previously every call to `rebuild()` started a new build. If you weren't careful, then builds could actually overlap. This doesn't cause any problems with esbuild itself, but could potentially cause problems with plugins (esbuild doesn't even give you a way to identify which overlapping build a given plugin callback is running on). Overlapping builds also arguably aren't useful, or at least aren't useful enough to justify the confusion and complexity that they bring. With this PR, there is now only ever a single active build per context. Calling `rebuild()` before the previous rebuild has finished now "merges" with the existing rebuild instead of starting a new build.

* Allow using `watch` and `serve` together ([#805](https://github.com/evanw/esbuild/issues/805), [#1650](https://github.com/evanw/esbuild/issues/1650), [#2576](https://github.com/evanw/esbuild/issues/2576))

    Previously it was not possible to use watch mode and serve mode together. The rationale was that watch mode is one way of automatically rebuilding your project and serve mode is another (since serve mode automatically rebuilds on every request). However, people want to combine these two features to make "live reloading" where the browser automatically reloads the page when files are changed on the file system.

    This PR now allows you to use these two features together. You can only call the `watch()` and `serve()` APIs once each per context, but if you call them together on the same context then esbuild will automatically rebuild both when files on the file system are changed *and* when the server serves a request.

* Support "live reloading" through server-sent events ([#802](https://github.com/evanw/esbuild/issues/802))

    [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) are a simple way to pass one-directional messages asynchronously from the server to the client. Serve mode now provides a `/esbuild` endpoint with an `change` event that triggers every time esbuild's output changes. So you can now implement simple "live reloading" (i.e. reloading the page when a file is edited and saved) like this:

    ```js
    new EventSource('/esbuild').addEventListener('change', () => location.reload())
    ```

    The event payload is a JSON object with the following shape:

    ```ts
    interface ChangeEvent {
      added: string[]
      removed: string[]
      updated: string[]
    }
    ```

    This JSON should also enable more complex live reloading scenarios. For example, the following code hot-swaps changed CSS `<link>` tags in place without reloading the page (but still reloads when there are other types of changes):

    ```js
    new EventSource('/esbuild').addEventListener('change', e => {
      const { added, removed, updated } = JSON.parse(e.data)
      if (!added.length && !removed.length && updated.length === 1) {
        for (const link of document.getElementsByTagName("link")) {
          const url = new URL(link.href)
          if (url.host === location.host && url.pathname === updated[0]) {
            const next = link.cloneNode()
            next.href = updated[0] + '?' + Math.random().toString(36).slice(2)
            next.onload = () => link.remove()
            link.parentNode.insertBefore(next, link.nextSibling)
            return
          }
        }
      }
      location.reload()
    })
    ```

    Implementing live reloading like this has a few known caveats:

    * These events only trigger when esbuild's output changes. They do not trigger when files unrelated to the build being watched are changed. If your HTML file references other files that esbuild doesn't know about and those files are changed, you can either manually reload the page or you can implement your own live reloading infrastructure instead of using esbuild's built-in behavior.

    * The `EventSource` API is supposed to automatically reconnect for you. However, there's a bug in Firefox that breaks this if the server is ever temporarily unreachable: https://bugzilla.mozilla.org/show_bug.cgi?id=1809332. Workarounds are to use any other browser, to manually reload the page if this happens, or to write more complicated code that manually closes and re-creates the `EventSource` object if there is a connection error. I'm hopeful that this bug will be fixed.

    * Browser vendors have decided to not implement HTTP/2 without TLS. This means that each `/esbuild` event source will take up one of your precious 6 simultaneous per-domain HTTP/1.1 connections. So if you open more than six HTTP tabs that use this live-reloading technique, you will be unable to use live reloading in some of those tabs (and other things will likely also break). The workaround is to enable HTTPS, which is now possible to do in esbuild itself (see below).

* Add built-in support for HTTPS ([#2169](https://github.com/evanw/esbuild/issues/2169))

    You can now tell esbuild's built-in development server to use HTTPS instead of HTTP. This is sometimes necessary because browser vendors have started making modern web features unavailable to HTTP websites. Previously you had to put a proxy in front of esbuild to enable HTTPS since esbuild's development server only supported HTTP. But with this release, you can now enable HTTPS with esbuild without an additional proxy.

    To enable HTTPS with esbuild:

    1. Generate a self-signed certificate. There are many ways to do this. Here's one way, assuming you have `openssl` installed:

        ```
        openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 9999 -nodes -subj /CN=127.0.0.1
        ```

    2. Add `--keyfile=key.pem` and `--certfile=cert.pem` to your esbuild development server command
    3. Click past the scary warning in your browser when you load your page

    If you have more complex needs than this, you can still put a proxy in front of esbuild and use that for HTTPS instead. Note that if you see the message "Client sent an HTTP request to an HTTPS server" when you load your page, then you are using the incorrect protocol. Replace `http://` with `https://` in your browser's URL bar.

    Keep in mind that esbuild's HTTPS support has nothing to do with security. The only reason esbuild now supports HTTPS is because browsers have made it impossible to do local development with certain modern web features without jumping through these extra hoops. *Please do not use esbuild's development server for anything that needs to be secure.* It's only intended for local development and no considerations have been made for production environments whatsoever.

* Better support copying `index.html` into the output directory ([#621](https://github.com/evanw/esbuild/issues/621), [#1771](https://github.com/evanw/esbuild/issues/1771))

    Right now esbuild only supports JavaScript and CSS as first-class content types. Previously this meant that if you were building a website with a HTML file, a JavaScript file, and a CSS file, you could use esbuild to build the JavaScript file and the CSS file into the output directory but not to copy the HTML file into the output directory. You needed a separate `cp` command for that.

    Or so I thought. It turns out that the `copy` loader added in version 0.14.44 of esbuild is sufficient to have esbuild copy the HTML file into the output directory as well. You can add something like `index.html --loader:.html=copy` and esbuild will copy `index.html` into the output directory for you. The benefits of this are a) you don't need a separate `cp` command and b) the `index.html` file will automatically be re-copied when esbuild is in watch mode and the contents of `index.html` are edited. This also goes for other non-HTML file types that you might want to copy.

    This pretty much already worked. The one thing that didn't work was that esbuild's built-in development server previously only supported implicitly loading `index.html` (e.g. loading `/about/index.html` when you visit `/about/`) when `index.html` existed on the file system. Previously esbuild didn't support implicitly loading `index.html` if it was a build result. That bug has been fixed with this PR so it should now be practical to use the `copy` loader to do this.

* Fix `onEnd` not being called in serve mode ([#1384](https://github.com/evanw/esbuild/issues/1384))

    Previous releases had a bug where plugin `onEnd` callbacks weren't called when using the top-level `serve()` API. This API no longer exists and the internals have been reimplemented such that `onEnd` callbacks should now always be called at the end of every build.

* Incremental builds now write out build results differently ([#2104](https://github.com/evanw/esbuild/issues/2104))

    Previously build results were always written out after every build. However, this could cause the output directory to fill up with files from old builds if code splitting was enabled, since the file names for code splitting chunks contain content hashes and old files were not deleted.

    With this PR, incremental builds in esbuild will now delete old output files from previous builds that are no longer relevant. Subsequent incremental builds will also no longer overwrite output files whose contents haven't changed since the previous incremental build.

* The `onRebuild` watch mode callback was removed ([#980](https://github.com/evanw/esbuild/issues/980), [#2499](https://github.com/evanw/esbuild/issues/2499))

    Previously watch mode accepted an `onRebuild` callback which was called whenever watch mode rebuilt something. This was not great in practice because if you are running code after a build, you likely want that code to run after every build, not just after the second and subsequent builds. This PR removes option to provide an `onRebuild` callback. You can create a plugin with an `onEnd` callback instead. The `onEnd` plugin API already exists, and is a way to run some code after every build.

* You can now return errors from `onEnd` ([#2625](https://github.com/evanw/esbuild/issues/2625))

    It's now possible to add additional build errors and/or warnings to the current build from within your `onEnd` callback by returning them in an array. This is identical to how the `onStart` callback already works. The evaluation of `onEnd` callbacks have been moved around a bit internally to make this possible.

    Note that the build will only fail (i.e. reject the promise) if the additional errors are returned from `onEnd`. Adding additional errors to the result object that's passed to `onEnd` won't affect esbuild's behavior at all.

* Print URLs and ports from the Go and JS APIs ([#2393](https://github.com/evanw/esbuild/issues/2393))

    Previously esbuild's CLI printed out something like this when serve mode is active:

    ```
     > Local:   http://127.0.0.1:8000/
     > Network: http://192.168.0.1:8000/
    ```

    The CLI still does this, but now the JS and Go serve mode APIs will do this too. This only happens when the log level is set to `verbose`, `debug`, or `info` but not when it's set to `warning`, `error`, or `silent`.

### Upgrade guide for existing code:

* Rebuild (a.k.a. incremental build):

    Before:

    ```js
    const result = await esbuild.build({ ...buildOptions, incremental: true });
    builds.push(result);
    for (let i = 0; i < 4; i++) builds.push(await result.rebuild());
    await result.rebuild.dispose(); // To free resources
    ```

    After:

    ```js
    const ctx = await esbuild.context(buildOptions);
    for (let i = 0; i < 5; i++) builds.push(await ctx.rebuild());
    await ctx.dispose(); // To free resources
    ```

    Previously the first build was done differently than subsequent builds. Now both the first build and subsequent builds are done using the same API.

* Serve:

    Before:

    ```js
    const serveResult = await esbuild.serve(serveOptions, buildOptions);
    ...
    serveResult.stop(); await serveResult.wait; // To free resources
    ```

    After:

    ```js
    const ctx = await esbuild.context(buildOptions);
    const serveResult = await ctx.serve(serveOptions);
    ...
    await ctx.dispose(); // To free resources
    ```

* Watch:

    Before:

    ```js
    const result = await esbuild.build({ ...buildOptions, watch: true });
    ...
    result.stop(); // To free resources
    ```

    After:

    ```js
    const ctx = await esbuild.context(buildOptions);
    await ctx.watch();
    ...
    await ctx.dispose(); // To free resources
    ```

* Watch with `onRebuild`:

    Before:

    ```js
    const onRebuild = (error, result) => {
      if (error) console.log('subsequent build:', error);
      else console.log('subsequent build:', result);
    };
    try {
      const result = await esbuild.build({ ...buildOptions, watch: { onRebuild } });
      console.log('first build:', result);
      ...
      result.stop(); // To free resources
    } catch (error) {
      console.log('first build:', error);
    }
    ```

    After:

    ```js
    const plugins = [{
      name: 'my-plugin',
      setup(build) {
        let count = 0;
        build.onEnd(result => {
          if (count++ === 0) console.log('first build:', result);
          else console.log('subsequent build:', result);
        });
      },
    }];
    const ctx = await esbuild.context({ ...buildOptions, plugins });
    await ctx.watch();
    ...
    await ctx.dispose(); // To free resources
    ```

    The `onRebuild` function has now been removed. The replacement is to make a plugin with an `onEnd` callback.

    Previously `onRebuild` did not fire for the first build (only for subsequent builds). This was usually problematic, so using `onEnd` instead of `onRebuild` is likely less error-prone. But if you need to emulate the old behavior of `onRebuild` that ignores the first build, then you'll need to manually count and ignore the first build in your plugin (as demonstrated above).

Notice how all of these API calls are now done off the new context object. You should now be able to use all three kinds of incremental builds (`rebuild`, `serve`, and `watch`) together on the same context object. Also notice how calling `dispose` on the context is now the common way to discard the context and free resources in all of these situations.

Fixes #621
Fixes #802
Fixes #805
Fixes #980
Fixes #1037
Fixes #1384
Fixes #1606
Fixes #1650
Fixes #1771
Fixes #2104
Fixes #2169
Fixes #2280
Fixes #2393
Fixes #2418
Fixes #2499
Fixes #2576
Fixes #2625
