### PR TITLE
Remove unreachable code on js_print.go

### DIFF
--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -485,10 +485,7 @@ func (p *printer) printIdentifierUTF16(name []uint16) {
 func (p *printer) printNumber(value float64, level js_ast.L) {
 	absValue := math.Abs(value)
 
-	if value != value {
-		p.printSpaceBeforeIdentifier()
-		p.print("NaN")
-	} else if value == positiveInfinity || value == negativeInfinity {
+	if value == positiveInfinity || value == negativeInfinity {
 		wrap := (p.options.MinifySyntax && level >= js_ast.LMultiply) ||
 			(value == negativeInfinity && level >= js_ast.LPrefix)
 		if wrap {


### PR DESCRIPTION
Since `if value != value` will always be false, I think the if statement's code is unreachable.
I tried to infer if it was a typo, but I couldn't find a plausible replacement for the "value" variable in this if statement.