### PR TITLE
Move the (recommended) live event reload source to `/.well-known/esbuild`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@
 
     This makes esbuild's TypeScript output smaller and faster when processing code that does this. I noticed this issue when I ran the TypeScript compiler's source code through esbuild's bundler. Now that the TypeScript compiler is going to be bundled with esbuild in the upcoming TypeScript 5.0 release, improvements like this will also improve the TypeScript compiler itself!
 
+* The recommended event source for live reload has changed to a custon [well-known URI](https://en.wikipedia.org/wiki/Well-known_URI) at `/.well-known/esbuild`. The old `/esbuild` path will continue to work, but consider updating the URL:
+
+    ```js
+    new EventSource('/.well-known/esbuild').addEventListener('change', () => location.reload())
+    ```
+
+
 ## 0.17.5
 
 * Parse `const` type parameters from TypeScript 5.0

--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -120,7 +120,7 @@ func (h *apiHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 
 	// Special-case the esbuild event stream
-	if req.Method == "GET" && req.URL.Path == "/esbuild" && req.Header.Get("Accept") == "text/event-stream" {
+	if req.Method == "GET" && (req.URL.Path == "/.well-known/esbuild" || req.URL.Path == "/esbuild") && req.Header.Get("Accept") == "text/event-stream" {
 		h.serveEventStream(start, req, res)
 		return
 	}


### PR DESCRIPTION
This updates https://esbuild.github.io/api/#live-reload to support `/.well-known/esbuild` in addition to `/esbuild` and updates the release notes to recommend it. The docs would need a separate update.

I'd like to propose this change because the `/.well-known/` directory is a standard location to define a hardcoded path like this without collisions for real website content[^1].
It is not necessary to register such a path to use it, and it's unlikely that another use case would "legitimately" start using `/.well-known/esbuild`, but it's possible to register the path at https://github.com/protocol-registries/well-known-uris to reduce the risk of collisions even further.

[^1]: In this case, it might seem unlikely that `/esbuild` would be used as a path by an app. But it's common to use such paths to server "preview" versions of sites, named on new tools that use them. So an app at `https://example.com/` might plausibly host their preview site at `https://example.com/esbuild` if they're in the process of switching to `esbuild`. If one was building a product with `esbuild`-related features, it might also be reasonable to host a splash page for this at `/esbuild`. Apps and sites can work around this by renaming the relevant path if they want to use live reloading in development, but it's easy to support a much less collision-prone path.