### PR TITLE
Updated the deprecated ioutil dependency

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sync"
@@ -1127,7 +1126,7 @@ func (service *serviceType) handleTransformRequest(id uint32, request map[string
 	transformInput := input
 	if inputFS {
 		fs.BeforeFileOpen()
-		bytes, err := ioutil.ReadFile(input)
+		bytes, err := os.ReadFile(input)
 		fs.AfterFileClose()
 		if err == nil {
 			err = os.Remove(input)
@@ -1145,7 +1144,7 @@ func (service *serviceType) handleTransformRequest(id uint32, request map[string
 	if inputFS && len(result.Code) > 0 {
 		file := input + ".code"
 		fs.BeforeFileOpen()
-		if err := ioutil.WriteFile(file, result.Code, 0644); err == nil {
+		if err := os.WriteFile(file, result.Code, 0644); err == nil {
 			result.Code = []byte(file)
 			codeFS = true
 		}
@@ -1155,7 +1154,7 @@ func (service *serviceType) handleTransformRequest(id uint32, request map[string
 	if inputFS && len(result.Map) > 0 {
 		file := input + ".map"
 		fs.BeforeFileOpen()
-		if err := ioutil.WriteFile(file, result.Map, 0644); err == nil {
+		if err := os.WriteFile(file, result.Map, 0644); err == nil {
 			result.Map = []byte(file)
 			mapFS = true
 		}

--- a/internal/bundler_tests/bundler_test.go
+++ b/internal/bundler_tests/bundler_test.go
@@ -8,7 +8,6 @@ package bundler_tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -216,7 +215,7 @@ func (s *suite) compareSnapshot(t *testing.T, testName string, generated string)
 		s.path = snapshotsDir + "/snapshots_" + s.name + ".txt"
 		s.generatedSnapshots = make(map[string]string)
 		s.expectedSnapshots = make(map[string]string)
-		if contents, err := ioutil.ReadFile(s.path); err == nil {
+		if contents, err := os.ReadFile(s.path); err == nil {
 			// Replacing CRLF with LF is necessary to fix tests in GitHub actions,
 			// which for some reason check out the source code in CLRF mode
 			for _, part := range strings.Split(strings.ReplaceAll(string(contents), "\r\n", "\n"), snapshotSplitter) {
@@ -268,7 +267,7 @@ func (s *suite) updateSnapshots() {
 		}
 		contents += fmt.Sprintf("%s\n%s", key, s.generatedSnapshots[key])
 	}
-	if err := ioutil.WriteFile(s.path, []byte(contents), 0644); err != nil {
+	if err := os.WriteFile(s.path, []byte(contents), 0644); err != nil {
 		panic(err)
 	}
 }

--- a/internal/fs/fs_real.go
+++ b/internal/fs/fs_real.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -199,7 +198,7 @@ func (fs *realFS) ReadDirectory(dir string) (entries DirEntries, canonicalError 
 func (fs *realFS) ReadFile(path string) (contents string, canonicalError error, originalError error) {
 	BeforeFileOpen()
 	defer AfterFileClose()
-	buffer, originalError := ioutil.ReadFile(path)
+	buffer, originalError := os.ReadFile(path)
 	canonicalError = fs.canonicalizeError(originalError)
 
 	// Allocate the string once
@@ -514,7 +513,7 @@ func (fs *realFS) WatchData() WatchData {
 
 		case stateFileUnusableModKey:
 			paths[path] = func() string {
-				if buffer, err := ioutil.ReadFile(path); err != nil || string(buffer) != data.fileContents {
+				if buffer, err := os.ReadFile(path); err != nil || string(buffer) != data.fileContents {
 					return path
 				}
 				return ""

--- a/internal/fs/fs_zip.go
+++ b/internal/fs/fs_zip.go
@@ -19,7 +19,7 @@ package fs
 
 import (
 	"archive/zip"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 	"sync"
@@ -266,7 +266,7 @@ func (fs *zipFS) ReadFile(path string) (contents string, canonicalError error, o
 	defer reader.Close()
 
 	// Then try to read it
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		file.err = err
 		return "", err, err

--- a/internal/resolver/yarnpnp_test.go
+++ b/internal/resolver/yarnpnp_test.go
@@ -3,7 +3,7 @@ package resolver
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +28,7 @@ type pnpTest struct {
 
 func TestYarnPnP(t *testing.T) {
 	t.Helper()
-	contents, err := ioutil.ReadFile("testExpectations.json")
+	contents, err := os.ReadFile("testExpectations.json")
 	if err != nil {
 		t.Fatalf("Failed to read testExpectations.json: %s", err.Error())
 	}

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -1482,7 +1481,7 @@ func rebuildImpl(args rebuildArgs, oldSummary buildSummary) rebuildState {
 							fs.BeforeFileOpen()
 							defer fs.AfterFileClose()
 							if oldHash, ok := oldSummary[result.AbsPath]; ok && oldHash == newSummary[result.AbsPath] {
-								if contents, err := ioutil.ReadFile(result.AbsPath); err == nil && bytes.Equal(contents, result.Contents) {
+								if contents, err := os.ReadFile(result.AbsPath); err == nil && bytes.Equal(contents, result.Contents) {
 									// Skip writing out files that haven't changed since last time
 									return
 								}
@@ -1495,7 +1494,7 @@ func rebuildImpl(args rebuildArgs, oldSummary buildSummary) rebuildState {
 								if result.IsExecutable {
 									mode = 0755
 								}
-								if err := ioutil.WriteFile(result.AbsPath, result.Contents, mode); err != nil {
+								if err := os.WriteFile(result.AbsPath, result.Contents, mode); err != nil {
 									log.AddError(nil, logger.Range{}, fmt.Sprintf(
 										"Failed to write to output file: %s", err.Error()))
 								}

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -7,7 +7,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"sort"
@@ -1099,7 +1099,7 @@ func runImpl(osArgs []string) int {
 			if buildOptions.Stdin == nil {
 				buildOptions.Stdin = &api.StdinOptions{}
 			}
-			bytes, err := ioutil.ReadAll(os.Stdin)
+			bytes, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
 					"Could not read from stdin: %s", err.Error()))
@@ -1158,7 +1158,7 @@ func runImpl(osArgs []string) int {
 					logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
 						"Failed to create output directory: %s", err.Error()))
 				} else {
-					if err := ioutil.WriteFile(metafileAbsPath, []byte(json), 0644); err != nil {
+					if err := os.WriteFile(metafileAbsPath, []byte(json), 0644); err != nil {
 						logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
 							"Failed to write to output file: %s", err.Error()))
 					}
@@ -1205,7 +1205,7 @@ func runImpl(osArgs []string) int {
 						"Failed to create output directory: %s", err.Error()))
 				} else {
 					bytes := printMangleCache(mangleCache, mangleCacheOrder, buildOptions.Charset == api.CharsetASCII)
-					if err := ioutil.WriteFile(mangleCacheAbsPath, bytes, 0644); err != nil {
+					if err := os.WriteFile(mangleCacheAbsPath, bytes, 0644); err != nil {
 						logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
 							"Failed to write to output file: %s", err.Error()))
 					}
@@ -1283,7 +1283,7 @@ func runImpl(osArgs []string) int {
 
 	case transformOptions != nil:
 		// Read the input from stdin
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
 				"Could not read from stdin: %s", err.Error()))

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -104,7 +104,7 @@ async function generateWorkerCode({ esbuildPath, wasm_exec_js, minify, target })
   // a bug. Specifically when using the "input" option of "execFileSync" to
   // provide stdin, sometimes (~2% of the time?) node writes all of the input
   // but then doesn't close the stream. The Go side is stuck reading from stdin
-  // within "ioutil.ReadAll(os.Stdin)" so I suspect it's a bug in node, not in
+  // within "io.ReadAll(os.Stdin)" so I suspect it's a bug in node, not in
   // Go. Explicitly calling "stdin.end()" on the node side appears to fix it.
   const wasmExecAndWorker = (await new Promise((resolve, reject) => {
     const proc = childProcess.execFile(esbuildPath, args, { cwd: repoDir }, (err, stdout) => {


### PR DESCRIPTION
The ioutil package has been deprecated as of Go v1.16: https://go.dev/doc/go1.16#ioutil

This commit replaces ioutil functions with their respective io/os functions.