### PR TITLE
make install script have stable src code

### DIFF
--- a/lib/npm/node-install.ts
+++ b/lib/npm/node-install.ts
@@ -7,7 +7,11 @@ import zlib = require('zlib')
 import https = require('https')
 import child_process = require('child_process')
 
-declare const ESBUILD_VERSION: string
+const pkgJSONPath = path.join(__dirname, 'package.json')
+const ESBUILD_VERSION = `${
+  JSON.parse(fs.readFileSync(pkgJSONPath, 'utf-8')).version
+}`
+
 const toPath = path.join(__dirname, 'bin', 'esbuild')
 let isToPathJS = true
 

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -24,7 +24,6 @@ const buildNeutralLib = (esbuildPath) => {
     '--outfile=' + path.join(npmDir, 'install.js'),
     '--bundle',
     '--target=' + nodeTarget,
-    '--define:ESBUILD_VERSION=' + JSON.stringify(version),
     '--external:esbuild',
     '--platform=node',
     '--log-level=warning',


### PR DESCRIPTION
This is making security tooling have a high noise ratio for `esbuild` since every time a patch is published, even if it doesn't do anything new it looks like it has a new install script due to inlined version numbers; instead this PR makes it read out of package.json which has the value.