### PR TITLE
Support native system access from wasm

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -632,11 +632,52 @@ export interface InitializeOptions {
   wasmModule?: WebAssembly.Module
 
   /**
+   * Enable system access (fs / process) when using WebAssembly. This requires
+   * that the host environment provide a namespace providing all APIs in
+   * Node.js' "fs" and "process" built-in modules.
+   * 
+   * By default this feature is disabled. To enable it, implementations for the
+   * "fs" and "process" namespaces must be provided by specifying either a
+   * namespace containing for "fs" and "process", or specifiers to an ES module that exports these bindings
+   * as a default export. The former is unsupported when using "worker: true".
+   */
+  wasmSystemAccess?: WasmSystemAccess
+
+  /**
    * By default esbuild runs the WebAssembly-based browser API in a web worker
    * to avoid blocking the UI thread. This can be disabled by setting "worker"
    * to false.
    */
   worker?: boolean
+}
+
+export interface WasmSystemAccess {
+  /**
+   * A module specifier to an ES module exporting an object that has a "node:fs"
+   * compatible signature.
+   *
+   * Mutually exclusive with the "fsNamespace" option. 
+   */
+  fsSpecifier?: string,
+  /**
+   * An object with a "node:fs" compatible signature.
+   * 
+   * Mutually exclusive with the "fsSpecifier" option.
+   */
+  fsNamespace?: any
+  /**
+   * A module specifier to an ES module exporting an object that has a
+   * "node:process" compatible signature.
+   * 
+   * Mutually exclusive with the "processNamespace" option.
+   */
+  processSpecifier?: string
+  /**
+   * An object with a "node:process" compatible signature.
+   * 
+   * Mutually exclusive with the "processSpecifier" option.
+   */
+  processNamespace?: any
 }
 
 export let version: string

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -92,7 +92,7 @@ async function generateWorkerCode({ esbuildPath, wasm_exec_js, minify, target })
     for (let o = self; o; o = Object.getPrototypeOf(o))
       for (let k of Object.getOwnPropertyNames(o))
         if (!(k in globalThis))
-          Object.defineProperty(globalThis, k, { get: () => self[k] })
+          Object.defineProperty(globalThis, k, { get: () => self[k], set: (value) => Object.defineProperty(globalThis, k, { value }), configurable: true })
     ${wasm_exec_js.replace(/\bfs\./g, 'globalThis.fs.')}
     ${fs.readFileSync(path.join(repoDir, 'lib', 'shared', 'worker.ts'), 'utf8')}
     return m => onmessage(m)


### PR DESCRIPTION
This commit adds support for native system access for WASM. This is used
through a new `wasmSystemAccess` option on the `esbuild.initialize`
options bag. This options bag can contain either a specifier or
namespace for a Node.js compatible `fs` and `process` module. During
setup these are injected into `globalThis.fs` and `globalThis.process`,
where Go's WASM runtime uses them to back the regular Go FS APIs.
Finally, if this option is set, we set the `hasFS` option on
`createChannel`, and everything just works :)

Example for Deno:

```ts
import * as esbuild from "./deno/wasm.js"

await esbuild.initialize({ wasmSystemAccess: {
  fsSpecifier: "node:fs",
  processSpecifier: "node:process"
} })

await esbuild.build({
  format: "esm",
  entryPoints: ["./lib/deno/mod.ts"],
  target: "esnext",
  outfile: "./out.js"
})
```

Closes #690