### PR TITLE
Mention `linked` sourcemap support in cli help

### DIFF
--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -330,7 +330,7 @@ func parseOptionsImpl(
 			default:
 				return parseOptionsExtras{}, cli_helpers.MakeErrorWithNote(
 					fmt.Sprintf("Invalid value %q in %q", value, arg),
-					"Valid values are \"inline\", \"external\", or \"both\".",
+					"Valid values are \"linked\", \"inline\", \"external\", or \"both\".",
 				)
 			}
 			if buildOpts != nil {


### PR DESCRIPTION
When using the cli, the `linked` support is not mentioned 