### PR TITLE
pref(wasm): deduplicated web-worker code in browser.js

### DIFF
--- a/lib/npm/browser.ts
+++ b/lib/npm/browser.ts
@@ -78,13 +78,15 @@ const startRunningService = async (wasmURL: string | URL, wasmModule: WebAssembl
     terminate: () => void
   }
 
+  const webWorkerFunction = WEB_WORKER_FUNCTION;
+
   if (useWorker) {
     // Run esbuild off the main thread
-    let blob = new Blob([`onmessage=${WEB_WORKER_SOURCE_CODE}(postMessage)`], { type: 'text/javascript' })
+    let blob = new Blob([`onmessage=${webWorkerFunction.toString()}(postMessage)`], { type: 'text/javascript' })
     worker = new Worker(URL.createObjectURL(blob))
   } else {
     // Run esbuild on the main thread
-    let onmessage = WEB_WORKER_FUNCTION((data: Uint8Array) => worker.onmessage!({ data }))
+    let onmessage = webWorkerFunction((data: Uint8Array) => worker.onmessage!({ data }))
     worker = {
       onmessage: null,
       postMessage: data => setTimeout(() => onmessage({ data })),

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -185,7 +185,6 @@ exports.buildWasmLib = async (esbuildPath) => {
       '--target=' + umdBrowserTarget,
       '--format=cjs',
       '--define:ESBUILD_VERSION=' + JSON.stringify(version),
-      '--define:WEB_WORKER_SOURCE_CODE=' + JSON.stringify(wasmWorkerCodeUMD),
       '--banner:js=' + umdPrefix,
       '--footer:js=' + umdSuffix,
       '--log-level=warning',
@@ -199,7 +198,6 @@ exports.buildWasmLib = async (esbuildPath) => {
       '--target=' + esmBrowserTarget,
       '--format=esm',
       '--define:ESBUILD_VERSION=' + JSON.stringify(version),
-      '--define:WEB_WORKER_SOURCE_CODE=' + JSON.stringify(wasmWorkerCodeESM),
       '--log-level=warning',
     ].concat(minifyFlags), { cwd: repoDir }).toString().replace('WEB_WORKER_FUNCTION', wasmWorkerCodeESM)
     fs.writeFileSync(path.join(esmDir, minify ? 'browser.min.js' : 'browser.js'), browserESM)


### PR DESCRIPTION
## Problem

In the WASM distribution, a pretty large Web Worker function was being duplicated and creating bloat.

## Changes

Reuse Web Worker code by leveraging `toString()`.

File|Size before|Size after
-|-|-
`lib/browser.js` | `122 KB` | `95 KB`
`lib/browser.min.js` | `50 KB` | `40KB`
`esm/browser.js` | `118 KB` | `93 KB`
`esm/browser.min.js` | `48 KB` | `39 KB`