### PR TITLE
perf(linker): Fixes brute force chunk cycle detection 

### DIFF
--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -445,24 +445,24 @@ func (c *linkerContext) mangleProps(mangleCache map[string]interface{}) {
 // can cause initialization bugs. So let's forbid these cycles for now to guard
 // against code splitting bugs that could cause us to generate buggy chunks.
 func (c *linkerContext) enforceNoCyclicChunkImports() {
-	var validate func(int, []int)
-	validate = func(chunkIndex int, path []int) {
+	// var validate func(int, []int)
+	validate := func(chunkIndex int, path []int) {
 		for _, otherChunkIndex := range path {
 			if chunkIndex == otherChunkIndex {
 				c.log.AddError(nil, logger.Range{}, "Internal error: generated chunks contain a circular import")
 				return
 			}
 		}
-		path = append(path, chunkIndex)
-		for _, chunkImport := range c.chunks[chunkIndex].crossChunkImports {
-			// Ignore cycles caused by dynamic "import()" expressions. These are fine
-			// because they don't necessarily cause initialization order issues and
-			// they don't indicate a bug in our chunk generation algorithm. They arise
-			// normally in real code (e.g. two files that import each other).
-			if chunkImport.importKind != ast.ImportDynamic {
-				validate(int(chunkImport.chunkIndex), path)
-			}
-		}
+		// path = append(path, chunkIndex)
+		// for _, chunkImport := range c.chunks[chunkIndex].crossChunkImports {
+		// 	// Ignore cycles caused by dynamic "import()" expressions. These are fine
+		// 	// because they don't necessarily cause initialization order issues and
+		// 	// they don't indicate a bug in our chunk generation algorithm. They arise
+		// 	// normally in real code (e.g. two files that import each other).
+		// 	if chunkImport.importKind != ast.ImportDynamic {
+		// 		validate(int(chunkImport.chunkIndex), path)
+		// 	}
+		// }
 	}
 	path := make([]int, 0, len(c.chunks))
 	for i := range c.chunks {

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -445,28 +445,76 @@ func (c *linkerContext) mangleProps(mangleCache map[string]interface{}) {
 // can cause initialization bugs. So let's forbid these cycles for now to guard
 // against code splitting bugs that could cause us to generate buggy chunks.
 func (c *linkerContext) enforceNoCyclicChunkImports() {
-	// var validate func(int, []int)
-	validate := func(chunkIndex int, path []int) {
-		for _, otherChunkIndex := range path {
-			if chunkIndex == otherChunkIndex {
-				c.log.AddError(nil, logger.Range{}, "Internal error: generated chunks contain a circular import")
-				return
+	var validate func(int, map[int]bool, map[int]bool) bool
+	inPath := make(map[int]bool)
+	visited := make(map[int]bool)
+
+	validate = func(chunkIndex int, visited, inPath map[int]bool) bool {
+		if visited[chunkIndex] {
+			return false
+		}
+		if inPath[chunkIndex] {
+			c.log.AddError(nil, logger.Range{}, "Internal error: generated chunks contain a circular import")
+			return true
+		}
+
+		inPath[chunkIndex] = true
+
+		for _, chunkImport := range c.chunks[chunkIndex].crossChunkImports {
+			if chunkImport.importKind != ast.ImportDynamic {
+				if validate(int(chunkImport.chunkIndex), visited, inPath) {
+					return true
+				}
 			}
 		}
-		// path = append(path, chunkIndex)
-		// for _, chunkImport := range c.chunks[chunkIndex].crossChunkImports {
-		// 	// Ignore cycles caused by dynamic "import()" expressions. These are fine
-		// 	// because they don't necessarily cause initialization order issues and
-		// 	// they don't indicate a bug in our chunk generation algorithm. They arise
-		// 	// normally in real code (e.g. two files that import each other).
-		// 	if chunkImport.importKind != ast.ImportDynamic {
-		// 		validate(int(chunkImport.chunkIndex), path)
-		// 	}
-		// }
+
+		visited[chunkIndex] = true
+		return false
 	}
-	path := make([]int, 0, len(c.chunks))
+
+	for chunkIndex := range c.chunks {
+		if validate(chunkIndex, visited, inPath) {
+			break // leave early
+		}
+	}
+}
+
+func (c *linkerContext) enforceNoCyclicChunkImportsColor() {
+	var validate func(int, map[int]int) bool
+
+	// DFS memoization with 3-colors, more space efficient
+	// 0: white (unvisited), 1: gray (visiting), 2: black (visited)
+	colors := make(map[int]int)
+	validate = func(chunkIndex int, colors map[int]int) bool {
+		if colors[chunkIndex] == 1 {
+			c.log.AddError(nil, logger.Range{}, "Internal error: generated chunks contain a circular import")
+			return true
+		}
+
+		if colors[chunkIndex] == 2 {
+			return false
+		}
+
+		colors[chunkIndex] = 1
+
+		for _, chunkImport := range c.chunks[chunkIndex].crossChunkImports {
+			if chunkImport.importKind != ast.ImportDynamic {
+
+				// Recursively validate otherChunkIndex
+				if validate(int(chunkImport.chunkIndex), colors) {
+					return true
+				}
+			}
+		}
+
+		colors[chunkIndex] = 2
+		return false
+	}
+
 	for i := range c.chunks {
-		validate(i, path)
+		if validate(i, colors) {
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #3068

## Approach

Given that the behavior is concerned only on _detecting_ a cycle rather than _identifying_ them, the simplest possible revision would be to improve current approach's shortcomings. Practically, this would mean

1. Memoize: store and use the results of validating a given node
2. Reduce the search space: skip nodes that have already been visited

I used an approach borrowed from [topological sorting](https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search), in which nodes are marked with a state (not-visited, visiting and visited), and if they've already been visited, we skip them. Furthermore, if we find a cycle, we halt. That gives us a linear execution time, rather than exponential.

## Results and reproducibility

It's clear that the impact of this would only be seen on some areas of the input space. Particularly, past a given graph complexity. Consuming the change from this fork, the vendor build which was taking up to ~400s, dropped to 4s, a **100x (anecdotal) improvement**. The app build's incremental times dropped from ~150s to ~30s, a 5x improvement.

Since this is a plain algorithmic revision, I believe that the point could be proven with a benchmarked test, and didn't see the need to generate a sufficiently complex npm dependency graph and run a full `esbuild build` on it.

Code Sandbox: https://codesandbox.io/p/sandbox/blue-http-750ebf?file=%2Flinker_test.go&selection=%5B%7B%22endColumn%22%3A6%2C%22endLineNumber%22%3A10%2C%22startColumn%22%3A6%2C%22startLineNumber%22%3A10%7D%5D

<pre>
PASS
BenchmarkLegacy100Sparse          100000             12931 ns/op             896 B/op          1 allocs/op
BenchmarkLegacy200Sparse             100          15657528 ns/op            1818 B/op          3 allocs/op
<b>BenchmarkLegacy300Sparse               1        19536221791 ns/op          28712 B/op        446 allocs/op</b>
BenchmarkRevision50Sparse         100000             12944 ns/op            2542 B/op          7 allocs/op
BenchmarkRevision100Sparse         50000             26291 ns/op            5279 B/op         11 allocs/op
BenchmarkRevision200Sparse         30000             55162 ns/op           10769 B/op         18 allocs/op
<b>BenchmarkRevision300Sparse         20000             98047 ns/op           20824 B/op         23 allocs/op</b>
BenchmarkRevision1000Sparse         3000            454412 ns/op           88313 B/op         67 allocs/op
</pre>
