### PR TITLE
fix(cli): should not hang for empty stdin

### DIFF
--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -1099,6 +1099,11 @@ func runImpl(osArgs []string) int {
 			if buildOptions.Stdin == nil {
 				buildOptions.Stdin = &api.StdinOptions{}
 			}
+			// Check is Stdin empty
+			stat, _ := os.Stdin.Stat()
+			if stat.Size() <= 0 {
+				return 0
+			}
 			bytes, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
 				logger.PrintErrorToStderr(osArgs, fmt.Sprintf(
@@ -1282,6 +1287,11 @@ func runImpl(osArgs []string) int {
 		}
 
 	case transformOptions != nil:
+		// Check is Stdin empty
+		stat, _ := os.Stdin.Stat()
+		if stat.Size() <= 0 {
+			return 0
+		}
 		// Read the input from stdin
 		bytes, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {


### PR DESCRIPTION
I want to see the output of running `esbuild --log-level=verbose` and found the esbuild hang forever.

After investigating, the hanging is caused by empty stdin.