### PR TITLE
Clarify the `module` condition's purpose in the code comment

### DIFF
--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1406,7 +1406,7 @@ func validateBuildOptions(
 		options.Mode = config.ModeConvertFormat
 	}
 
-	// Automatically enable the "module" condition for better tree shaking
+	// Automatically enable the "module" condition that allows package authors to avoid dual package hazard when their packages are bundled
 	if options.Conditions == nil && options.Platform != config.PlatformNeutral {
 		options.Conditions = []string{"module"}
 	}


### PR DESCRIPTION
I think that this better reflects the purpose of this condition and that this clarification might be useful for other tool authors. After all, `esbuild` might be treated as a reference implementation of certain things