### PR TITLE
fix(sec): upgrade webpack to 5.76.0

### DIFF
--- a/require/webpack5/package-lock.json
+++ b/require/webpack5/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "ts-loader": "9.4.2",
         "typescript": "4.9.3",
-        "webpack": "5.75.0",
+        "webpack": "5.76.0",
         "webpack-cli": "5.0.0"
       }
     },
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -2170,9 +2170,9 @@
       }
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/require/webpack5/package.json
+++ b/require/webpack5/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "ts-loader": "9.4.2",
     "typescript": "4.9.3",
-    "webpack": "5.75.0",
+    "webpack": "5.76.0",
     "webpack-cli": "5.0.0"
   }
 }


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in webpack 5.75.0
- [CVE-2023-28154](https://www.oscs1024.com/hd/CVE-2023-28154)


### What did I do？
Upgrade webpack from 5.75.0 to 5.76.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS