### PR TITLE
test: failing tests for constant folding and TDZ issues

### DIFF
--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -2675,6 +2675,15 @@ func TestConstantFolding(t *testing.T) {
 	expectPrinted(t, "x = -0 == false", "x = true;\n")
 	expectPrinted(t, "x = 1 == true", "x = true;\n")
 	expectPrinted(t, "x = 2 == true", "x = false;\n")
+
+	expectPrintedMangle(t, `{ const x = 0; const f = () => x; f(); };`, "(() => 0)();\n")
+	expectPrintedMangle(t, `{ const f = () => x; const x = 0; f(); };`, "(() => 0)();\n")
+	expectPrintedMangle(t, `const f = () => x; const x = 0; f();`, "(() => 0)();\n")
+}
+
+func TestTemporalDeadZone(t *testing.T) {
+	expectPrintedMangle(t, "{ number; const number=10; };", "{\n  number;\n  const number = 10;\n}\n")
+	expectPrintedMangle(t, "{ const x = y; const y = 1; }", "{\n  const x = y, y = 1;\n}\n")
 }
 
 func TestConstantFoldingScopes(t *testing.T) {


### PR DESCRIPTION
RE: https://github.com/evanw/esbuild/issues/3125

Spent a bit of time trying to fix these in `js_parser.go` but couldn't solve it. This PR has a few failing tests which illustrate the problem.

There are two issues:

(1) Constant propagation not working properly when the constant is declared after it is used

Consider this program:
```js
{ 
  const f = () => x; 
  const x = 0; 
  f();
}
```

The definition of `x` should be hoisted to the top of the enclosing block. Since it is constant, it is eligible for constant folding/propagation. The propagation should respect the Temporal Dead Zone; accessing `x` before it is initialized should raise a `ReferenceError: Cannot access 'x' before initialization`.

`esbuild` minifies this program to `(() => x)()`. I believe this is because `x` is correctly identified as a constant, but then isn't able to do the substitution into the function body because it is defined after the function that uses it.

(2) Dead statement removal doesn't respect the Temporal Dead Zone

Consider this program:
```js
{
  number; 
  const number=10;
}
```

This should crash with an error `ReferenceError: Cannot access 'number' before initialization`.

However, `esbuild` minifies it to something like `{const n=10}`, omitting the `number;` statement.