### PR TITLE
A fix for browser mapping to false together with an onLoad plugin

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -908,6 +908,11 @@ func runOnLoadPlugins(
 	}
 	tracker := logger.MakeLineColumnTracker(importSource)
 
+	// Force disabled modules to be empty
+	if source.KeyPath.IsDisabled() {
+		return loaderPluginResult{loader: config.LoaderEmpty}, true
+	}
+
 	// Apply loader plugins in order until one succeeds
 	for _, plugin := range plugins {
 		for _, onLoad := range plugin.OnLoad {
@@ -963,11 +968,6 @@ func runOnLoadPlugins(
 				pluginData:    result.PluginData,
 			}, true
 		}
-	}
-
-	// Force disabled modules to be empty
-	if source.KeyPath.IsDisabled() {
-		return loaderPluginResult{loader: config.LoaderEmpty}, true
 	}
 
 	// Read normal modules from disk


### PR DESCRIPTION
If there's some mapping to `false` under the `browser` field in `package.json`, it's replaced with empty content as expected. However, if there's an `onLoad` plugin passed to esbuild suitable for the disabled file, then currently the loader will be used and the file will be bundled.