### PR TITLE
Unfold nested blocks when minifySyntax is enabled

### DIFF
--- a/internal/bundler_tests/snapshots/snapshots_default.txt
+++ b/internal/bundler_tests/snapshots/snapshots_default.txt
@@ -5281,14 +5281,12 @@ foo();
 TestStrictModeNestedFnDeclKeepNamesVariableInliningIssue1552
 ---------- /out/entry.js ----------
 export function outer() {
-  {
-    let inner = function() {
-      return Math.random();
-    };
-    __name(inner, "inner");
-    const x = inner();
-    console.log(x);
-  }
+  let inner = function() {
+    return Math.random();
+  };
+  __name(inner, "inner");
+  const x = inner();
+  console.log(x);
 }
 __name(outer, "outer"), outer();
 

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -10275,6 +10275,12 @@ func (p *parser) visitAndAppendStmt(stmts []js_ast.Stmt, stmt js_ast.Stmt) []js_
 			}
 		}
 
+		if p.options.minifySyntax && len(s.Fn.Body.Block.Stmts) == 1 {
+			if block, ok := s.Fn.Body.Block.Stmts[0].Data.(*js_ast.SBlock); ok {
+				s.Fn.Body.Block = *block
+			}
+		}
+
 		// Handle exporting this function from a namespace
 		if s.IsExport && p.enclosingNamespaceArgRef != nil {
 			s.IsExport = false
@@ -11026,6 +11032,11 @@ func (p *parser) visitClass(nameScopeLoc logger.Loc, class *js_ast.Class, defaul
 			// "class { static {} }" => "class {}"
 			if p.options.minifySyntax && len(property.ClassStaticBlock.Block.Stmts) == 0 {
 				continue
+			}
+			if p.options.minifySyntax && len(property.ClassStaticBlock.Block.Stmts) == 1 {
+				if block, ok := property.ClassStaticBlock.Block.Stmts[0].Data.(*js_ast.SBlock); ok {
+					property.ClassStaticBlock.Block = *block
+				}
 			}
 
 			// Keep this property
@@ -14353,6 +14364,9 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 					e.PreferExpr = true
 				}
 			}
+			if s, ok := e.Body.Block.Stmts[0].Data.(*js_ast.SBlock); ok {
+				e.Body.Block = *s
+			}
 		}
 
 		p.fnOnlyDataVisit.isInsideAsyncArrowFn = oldInsideAsyncArrowFn
@@ -14396,6 +14410,12 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 				expr = p.keepExprSymbolName(expr, p.symbols[name.Ref.InnerIndex].OriginalName)
 			} else if nameToKeep != "" {
 				expr = p.keepExprSymbolName(expr, nameToKeep)
+			}
+		}
+
+		if p.options.minifySyntax && len(e.Fn.Body.Block.Stmts) == 1 {
+			if s, ok := e.Fn.Body.Block.Stmts[0].Data.(*js_ast.SBlock); ok {
+				e.Fn.Body.Block = *s
 			}
 		}
 

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -3189,6 +3189,16 @@ func TestMangleBlock(t *testing.T) {
 	expectPrintedMangle(t, "while(1) { function* x() {} }", "for (; ; ) {\n  function* x() {\n  }\n}\n")
 	expectPrintedMangle(t, "while(1) { async function x() {} }", "for (; ; ) {\n  async function x() {\n  }\n}\n")
 	expectPrintedMangle(t, "while(1) { async function* x() {} }", "for (; ; ) {\n  async function* x() {\n  }\n}\n")
+
+	expectPrintedMangle(t, "function f() {{ let a = ''; console.log(a); console.log(a); }}", "function f() {\n  let a = \"\";\n  console.log(a), console.log(a);\n}\n")
+	expectPrintedMangle(t, "const f = () => {{ let a = ''; console.log(a); console.log(a); }}", "const f = () => {\n  let a = \"\";\n  console.log(a), console.log(a);\n};\n")
+	expectPrintedMangle(t, "const f = function() {{ let a = ''; console.log(a); console.log(a); }}", "const f = function() {\n  let a = \"\";\n  console.log(a), console.log(a);\n};\n")
+	expectPrintedMangle(t, "const obj = { m() {{ let a = ''; console.log(a); console.log(a); }} }", "const obj = { m() {\n  let a = \"\";\n  console.log(a), console.log(a);\n} };\n")
+	expectPrintedMangle(t, "class F { static {{ let a = ''; console.log(a); console.log(a); }} }", "class F {\n  static {\n    let a = \"\";\n    console.log(a), console.log(a);\n  }\n}\n")
+	expectPrintedMangle(t, "class F { m() {{ let a = ''; console.log(a); console.log(a); }} }", "class F {\n  m() {\n    let a = \"\";\n    console.log(a), console.log(a);\n  }\n}\n")
+	expectPrintedMangle(t, "function f() {if (true) { let a = ''; console.log(a); console.log(a); }}", "function f() {\n  let a = \"\";\n  console.log(a), console.log(a);\n}\n")
+	expectPrintedMangle(t, "function f() {if (true) { let a = ''; console.log(a); console.log(a); } else { console.log() }}", "function f() {\n  let a = \"\";\n  console.log(a), console.log(a);\n}\n")
+	expectPrintedMangle(t, "function f() {{ let a = ''; console.log(a); console.log(a); }; let b = '';}", "function f() {\n  {\n    let a = \"\";\n    console.log(a), console.log(a);\n  }\n  let b = \"\";\n}\n")
 }
 
 func TestMangleSwitch(t *testing.T) {


### PR DESCRIPTION
### Summary

For an input like this,
```js
function fn1 () {
  if (true) {
    let a = 'foo';
    console.log(a);
    console.log(a);
  }
}
```
esbuild currently outputs 
```js
function fn1() {
  {
    let a = "foo";
    console.log(a), console.log(a);
  }
}
```
. But this can be minified to
```js
function fn1() {
  let a = "foo";
  console.log(a), console.log(a);
}
```
. This PR implements removing these braces.

### Supported cases
```js
function fn1 () {
  if (true) {
    let a = 'foo';
    console.log(a);
    console.log(a);
  }
}

const fn2 = () => {
  if (true) {
    let a = 'foo';
    console.log(a);
    console.log(a);
  }
};

const fn3 = function () {
  if (true) {
    let a = 'foo';
    console.log(a);
    console.log(a);
  }
};

const obj = {
  method2() {
    if (true) {
      let a = 'foo';
      console.log(a);
      console.log(a);
    }
  }
};

class Foo {
  static {
    if (true) {
      let a = 'foo';
      console.log(a);
      console.log(a);
    }
  }
}
```
[current esbuild try](https://esbuild.github.io/try/#dAAwLjE4LjIALS1taW5pZnktc3ludGF4AGZ1bmN0aW9uIGZuMSAoKSB7CiAgaWYgKHRydWUpIHsKICAgIGxldCBhID0gJ2Zvbyc7CiAgICBjb25zb2xlLmxvZyhhKTsKICAgIGNvbnNvbGUubG9nKGEpOwogIH0KfQoKY29uc3QgZm4yID0gKCkgPT4gewogIGlmICh0cnVlKSB7CiAgICBsZXQgYSA9ICdmb28nOwogICAgY29uc29sZS5sb2coYSk7CiAgICBjb25zb2xlLmxvZyhhKTsKICB9Cn07Cgpjb25zdCBmbjMgPSBmdW5jdGlvbiAoKSB7CiAgaWYgKHRydWUpIHsKICAgIGxldCBhID0gJ2Zvbyc7CiAgICBjb25zb2xlLmxvZyhhKTsKICAgIGNvbnNvbGUubG9nKGEpOwogIH0KfTsKCmNvbnN0IG9iaiA9IHsKICBtZXRob2QyKCkgewogICAgaWYgKHRydWUpIHsKICAgICAgbGV0IGEgPSAnZm9vJzsKICAgICAgY29uc29sZS5sb2coYSk7CiAgICAgIGNvbnNvbGUubG9nKGEpOwogICAgfQogIH0KfTsKCmNsYXNzIEZvbyB7CiAgc3RhdGljIHsKICAgIGlmICh0cnVlKSB7CiAgICAgIGxldCBhID0gJ2Zvbyc7CiAgICAgIGNvbnNvbGUubG9nKGEpOwogICAgICBjb25zb2xlLmxvZyhhKTsKICAgIH0KICB9Cn0)

### Other benefits
When this code is passed to Rollup,
```js
export function fn1 () {
  {
    let a = 'foo';
    console.log(a);
    console.log(a);
  }
}
```
Rollup outputs
```js
export function fn1() {
  {
    let a = "foo";
    console.log(a), console.log(a);
  }
}
```
([Rollup REPL](https://rollupjs.org/repl/?version=3.25.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGZ1bmN0aW9uJTIwZm4xJTIwKCklMjAlN0IlNUNuJTIwJTIwaWYlMjAodHJ1ZSklMjAlN0IlNUNuJTIwJTIwJTIwJTIwbGV0JTIwYSUyMCUzRCUyMCdmb28nJTNCJTVDbiUyMCUyMCUyMCUyMGNvbnNvbGUubG9nKGEpJTNCJTVDbiUyMCUyMCUyMCUyMGNvbnNvbGUubG9nKGEpJTNCJTVDbiUyMCUyMCU3RCU1Q24lN0QlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwZm4yJTIwJTNEJTIwKCklMjAlM0QlM0UlMjAlN0IlNUNuJTIwJTIwaWYlMjAodHJ1ZSklMjAlN0IlNUNuJTIwJTIwJTIwJTIwbGV0JTIwYSUyMCUzRCUyMCdmb28nJTNCJTVDbiUyMCUyMCUyMCUyMGNvbnNvbGUubG9nKGEpJTNCJTVDbiUyMCUyMCUyMCUyMGNvbnNvbGUubG9nKGEpJTNCJTVDbiUyMCUyMCU3RCU1Q24lN0QlM0IlNUNuJTVDbmV4cG9ydCUyMGNvbnN0JTIwZm4zJTIwJTNEJTIwZnVuY3Rpb24lMjAoKSUyMCU3QiU1Q24lMjAlMjBpZiUyMCh0cnVlKSUyMCU3QiU1Q24lMjAlMjAlMjAlMjBsZXQlMjBhJTIwJTNEJTIwJ2ZvbyclM0IlNUNuJTIwJTIwJTIwJTIwY29uc29sZS5sb2coYSklM0IlNUNuJTIwJTIwJTIwJTIwY29uc29sZS5sb2coYSklM0IlNUNuJTIwJTIwJTdEJTVDbiU3RCUzQiU1Q24lNUNuZXhwb3J0JTIwY29uc3QlMjBvYmolMjAlM0QlMjAlN0IlNUNuJTIwJTIwbWV0aG9kMigpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMGlmJTIwKHRydWUpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMCUyMCUyMGxldCUyMGElMjAlM0QlMjAnZm9vJyUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBjb25zb2xlLmxvZyhhKSUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBjb25zb2xlLmxvZyhhKSUzQiU1Q24lMjAlMjAlMjAlMjAlN0QlNUNuJTIwJTIwJTdEJTVDbiU3RCUzQiU1Q24lNUNuZXhwb3J0JTIwY2xhc3MlMjBGb28lMjAlN0IlNUNuJTIwJTIwc3RhdGljJTIwJTdCJTVDbiUyMCUyMCUyMCUyMGlmJTIwKHRydWUpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMCUyMCUyMGxldCUyMGElMjAlM0QlMjAnZm9vJyUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBjb25zb2xlLmxvZyhhKSUzQiU1Q24lMjAlMjAlMjAlMjAlMjAlMjBjb25zb2xlLmxvZyhhKSUzQiU1Q24lMjAlMjAlMjAlMjAlN0QlNUNuJTIwJTIwJTdEJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTdEJTdE)).

When this output is passed to esbuild, esbuild currently outputs the braces as-is ([current esbuild try](https://esbuild.github.io/try/#dAAwLjE4LjIALS1taW5pZnktc3ludGF4AGZ1bmN0aW9uIGZuMSAoKSB7CiAgewogICAgbGV0IGEgPSAnZm9vJzsKICAgIGNvbnNvbGUubG9nKGEpOwogICAgY29uc29sZS5sb2coYSk7CiAgfQp9Cgpjb25zdCBmbjIgPSAoKSA9PiB7CiAgewogICAgbGV0IGEgPSAnZm9vJzsKICAgIGNvbnNvbGUubG9nKGEpOwogICAgY29uc29sZS5sb2coYSk7CiAgfQp9OwoKY29uc3QgZm4zID0gZnVuY3Rpb24gKCkgewogIHsKICAgIGxldCBhID0gJ2Zvbyc7CiAgICBjb25zb2xlLmxvZyhhKTsKICAgIGNvbnNvbGUubG9nKGEpOwogIH0KfTsKCmNvbnN0IG9iaiA9IHsKICBtZXRob2QyKCkgewogICAgewogICAgICBsZXQgYSA9ICdmb28nOwogICAgICBjb25zb2xlLmxvZyhhKTsKICAgICAgY29uc29sZS5sb2coYSk7CiAgICB9CiAgfQp9OwoKY2xhc3MgRm9vIHsKICBzdGF0aWMgewogICAgewogICAgICBsZXQgYSA9ICdmb28nOwogICAgICBjb25zb2xlLmxvZyhhKTsKICAgICAgY29uc29sZS5sb2coYSk7CiAgICB9CiAgfQp9CgpleHBvcnQgeyBGb28sIGZuMSwgZm4yLCBmbjMsIG9iaiB9Ow)).

This PR works for these cases, too.

### Related information

A block inside `if` / `for`/`while` seems to be already supported: [esbuild try](https://esbuild.github.io/try/#dAAwLjE4LjIALS1taW5pZnktc3ludGF4AGZ1bmN0aW9uIGZvbygpIHsKICBpZiAodmFsdWUpIHsKICAgIHsKICAgICAgbGV0IGEgPSAnZm9vJzsKICAgICAgY29uc29sZS5sb2coYSk7CiAgICAgIGNvbnNvbGUubG9nKGEpOwogICAgfQogIH0KCiAgZm9yIChsZXQgaSA9IDA7IGkgPCAxMDsgaSsrKSB7CiAgICB7CiAgICAgIGxldCBhID0gJ2Zvbyc7CiAgICAgIGNvbnNvbGUubG9nKGEpOwogICAgICBjb25zb2xlLmxvZyhhKTsKICAgIH0KICB9CgogIHdoaWxlICh2YWx1ZTIpIHsKICAgIHsKICAgICAgbGV0IGEgPSAnZm9vJzsKICAgICAgY29uc29sZS5sb2coYSk7CiAgICAgIGNvbnNvbGUubG9nKGEpOwogICAgfQogIH0KfQ)

terser doesn't support this: https://github.com/terser/terser/issues/1363