### PR TITLE
fix(compat-table): refine Destructuring support status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 
     Previously using TypeScript experimental decorators combined with the `--mangle-props` setting could result in a crash, as the experimental decorator transform was not expecting a mangled property as a class member. This release fixes the crash so you can now combine both of these features together safely.
 
+* Fix a bug in esbuild's compatibility table script ([#3179](https://github.com/evanw/esbuild/pull/3179))
+
+    Setting esbuild's `target` to a specific JavaScript engine tells esbuild to use the JavaScript syntax feature compatibility data from https://kangax.github.io/compat-table/es6/ for that engine to determine which syntax features to allow. However, esbuild's script that builds this internal compatibility table had a bug that incorrectly ignores tests for engines that still have outstanding implementation bugs which were never fixed. This change fixes this bug with the script.
+
+    The only case where this changed the information in esbuild's internal compatibility table is that the `hermes` target is marked as no longer supporting destructuring. This is because there is a failing destructuring-related test for Hermes on https://kangax.github.io/compat-table/es6/. If you want to use destructuring with Hermes anyway, you can pass `--supported:destructuring=true` to esbuild to override the `hermes` target and force esbuild to accept this syntax.
+
+    This fix was contributed by [@ArrayZoneYour](https://github.com/ArrayZoneYour).
+
 ## 0.18.4
 
 * Bundling no longer unnecessarily transforms class syntax ([#1360](https://github.com/evanw/esbuild/issues/1360), [#1328](https://github.com/evanw/esbuild/issues/1328), [#1524](https://github.com/evanw/esbuild/issues/1524), [#2416](https://github.com/evanw/esbuild/issues/2416))

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -395,8 +395,10 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Edge:    {{start: v{18, 0, 0}}},
 		ES:      {{start: v{2015, 0, 0}}},
 		Firefox: {{start: v{53, 0, 0}}},
+		IOS:     {{start: v{10, 0, 0}}},
 		Node:    {{start: v{6, 5, 0}}},
 		Opera:   {{start: v{38, 0, 0}}},
+		Safari:  {{start: v{10, 0, 0}}},
 	},
 	DynamicImport: {
 		Chrome:  {{start: v{63, 0, 0}}},

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -395,11 +395,8 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Edge:    {{start: v{18, 0, 0}}},
 		ES:      {{start: v{2015, 0, 0}}},
 		Firefox: {{start: v{53, 0, 0}}},
-		Hermes:  {{start: v{0, 7, 0}}},
-		IOS:     {{start: v{10, 0, 0}}},
 		Node:    {{start: v{6, 5, 0}}},
 		Opera:   {{start: v{38, 0, 0}}},
-		Safari:  {{start: v{10, 0, 0}}},
 	},
 	DynamicImport: {
 		Chrome:  {{start: v{63, 0, 0}}},

--- a/scripts/compat-table.js
+++ b/scripts/compat-table.js
@@ -139,10 +139,11 @@ function mergeVersions(target, res, omit = []) {
   // like "chrome44: true, chrome45: true, chrome46: true, ..." so we want to
   // take the minimum version to find the boundary.
   const lowestVersionMap = {}
-  // If current feature target is not supported for all versions, we will tag
-  // version[target] = { unsupported: true } to exclude it even other 
-  // sub-features is supported
-  const unsupportedEngines = new Set();
+
+  // If the current feature target is not supported for all versions, we will
+  // tag version[target] = { unsupported: true } to exclude it even when other
+  // sub-features are supported.
+  const unsupportedEngines = new Set()
 
   for (const key in res) {
     const match = /^([a-z_]+)[0-9_]+$/.exec(key)
@@ -166,13 +167,13 @@ function mergeVersions(target, res, omit = []) {
   // support a given feature if the version is greater than the maximum version
   // for all subtests. This is the inverse of the minimum test below.
   const highestVersionMap = versions[target] || (versions[target] = {})
-  unsupportedEngines.forEach(function(engine) {
+  for (const engine of unsupportedEngines) {
     versions[target][engine] = [{ start: null, end: null, unsupported: true }]
-  })
+  }
   for (const engine in lowestVersionMap) {
     if (highestVersionMap[engine] && highestVersionMap[engine].unsupported) {
-      // ignore unsupported engines
-      continue;
+      // Ignore unsupported engines
+      continue
     }
     const version = lowestVersionMap[engine]
     if (!highestVersionMap[engine] || compareVersions({ version }, { version: highestVersionMap[engine][0].start }) > 0) {


### PR DESCRIPTION
https://kangax.github.io/compat-table/es6/

`Destructuring` is not fully supported in SF & Hermes, fix `compat-table.js` bug to correct it.

![image](https://github.com/evanw/esbuild/assets/21001457/302e46fd-557e-4c07-8eed-b672353bdad9)
