### PR TITLE
lower async generator functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -653,6 +653,9 @@ demo/test262: | github/test262
 test262: esbuild | demo/test262
 	node --experimental-vm-modules scripts/test262.js
 
+test262-async: esbuild | demo/test262
+	node --experimental-vm-modules scripts/test262-async.js
+
 ################################################################################
 # This runs UglifyJS's test suite through esbuild
 

--- a/internal/bundler_tests/bundler_lower_test.go
+++ b/internal/bundler_tests/bundler_lower_test.go
@@ -3042,3 +3042,103 @@ func TestLowerUsingInsideTSNamespace(t *testing.T) {
 		},
 	})
 }
+
+func TestLowerAsyncGenerator(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				async function* foo() {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				}
+				foo = async function* () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				}
+				foo = { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+				class Foo { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+				Foo = class { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:                  config.ModePassThrough,
+			AbsOutputDir:          "/out",
+			UnsupportedJSFeatures: compat.AsyncGenerator,
+		},
+	})
+}
+
+func TestLowerAsyncGeneratorNoAwait(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				async function* foo() {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				}
+				foo = async function* () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				}
+				foo = { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+				class Foo { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+				Foo = class { async *bar () {
+					yield
+					yield x
+					yield *x
+					await x
+					for await (x of y) {}
+				} }
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:                  config.ModePassThrough,
+			AbsOutputDir:          "/out",
+			UnsupportedJSFeatures: compat.AsyncGenerator | compat.AsyncAwait,
+		},
+	})
+}

--- a/internal/bundler_tests/snapshots/snapshots_lower.txt
+++ b/internal/bundler_tests/snapshots/snapshots_lower.txt
@@ -980,6 +980,242 @@ export {
 };
 
 ================================================================================
+TestLowerAsyncGenerator
+---------- /out/entry.js ----------
+function foo() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+}
+foo = function() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+};
+foo = { bar() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+} };
+class Foo {
+  bar() {
+    return __asyncGenerator(this, null, function* () {
+      yield;
+      yield x;
+      yield* __yieldStar(x);
+      yield new __await(x);
+      try {
+        for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+          x = temp.value;
+        }
+      } catch (temp) {
+        error = [temp];
+      } finally {
+        try {
+          more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+        } finally {
+          if (error)
+            throw error[0];
+        }
+      }
+    });
+  }
+}
+Foo = class {
+  bar() {
+    return __asyncGenerator(this, null, function* () {
+      yield;
+      yield x;
+      yield* __yieldStar(x);
+      yield new __await(x);
+      try {
+        for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+          x = temp.value;
+        }
+      } catch (temp) {
+        error = [temp];
+      } finally {
+        try {
+          more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+        } finally {
+          if (error)
+            throw error[0];
+        }
+      }
+    });
+  }
+};
+
+================================================================================
+TestLowerAsyncGeneratorNoAwait
+---------- /out/entry.js ----------
+function foo() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+}
+foo = function() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+};
+foo = { bar() {
+  return __asyncGenerator(this, null, function* () {
+    yield;
+    yield x;
+    yield* __yieldStar(x);
+    yield new __await(x);
+    try {
+      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+        x = temp.value;
+      }
+    } catch (temp) {
+      error = [temp];
+    } finally {
+      try {
+        more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+      } finally {
+        if (error)
+          throw error[0];
+      }
+    }
+  });
+} };
+class Foo {
+  bar() {
+    return __asyncGenerator(this, null, function* () {
+      yield;
+      yield x;
+      yield* __yieldStar(x);
+      yield new __await(x);
+      try {
+        for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+          x = temp.value;
+        }
+      } catch (temp) {
+        error = [temp];
+      } finally {
+        try {
+          more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+        } finally {
+          if (error)
+            throw error[0];
+        }
+      }
+    });
+  }
+}
+Foo = class {
+  bar() {
+    return __asyncGenerator(this, null, function* () {
+      yield;
+      yield x;
+      yield* __yieldStar(x);
+      yield new __await(x);
+      try {
+        for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield new __await(iter.next())).done; more = false) {
+          x = temp.value;
+        }
+      } catch (temp) {
+        error = [temp];
+      } finally {
+        try {
+          more && (temp = iter.return) && (yield new __await(temp.call(iter)));
+        } finally {
+          if (error)
+            throw error[0];
+        }
+      }
+    });
+  }
+};
+
+================================================================================
 TestLowerAsyncSuperES2016NoBundle
 ---------- /out.js ----------
 class Derived extends Base {

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -732,7 +732,7 @@ func TestAsyncGeneratorFns(t *testing.T) {
 	expectParseErrorWithUnsupportedFeatures(t, compat.AsyncAwait|compat.Generator, "(async function () {});", err)
 	expectParseErrorWithUnsupportedFeatures(t, compat.AsyncAwait|compat.Generator, "({ async foo() {} });", err)
 
-	err = "<stdin>: ERROR: Transforming async generator functions to the configured target environment is not supported yet\n"
+	err = ""
 	expectParseErrorWithUnsupportedFeatures(t, compat.AsyncGenerator, "async function* gen() {}", err)
 	expectParseErrorWithUnsupportedFeatures(t, compat.AsyncGenerator, "(async function* () {});", err)
 	expectParseErrorWithUnsupportedFeatures(t, compat.AsyncGenerator, "({ async *foo() {} });", err)

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -6697,13 +6697,6 @@ class Foo {
   nonIdArrayRest: ({ esbuild }) => futureSyntax(esbuild, 'let [...[x]] = y', 'es2015', 'es2016'),
   topLevelAwait: ({ esbuild }) => futureSyntax(esbuild, 'await foo', 'es2020', 'esnext'),
   topLevelForAwait: ({ esbuild }) => futureSyntax(esbuild, 'for await (foo of bar) ;', 'es2020', 'esnext'),
-
-  // Future syntax: async generator functions
-  asyncGenFnStmt: ({ esbuild }) => futureSyntax(esbuild, 'async function* foo() {}', 'es2017', 'es2018'),
-  asyncGenFnExpr: ({ esbuild }) => futureSyntax(esbuild, '(async function*() {})', 'es2017', 'es2018'),
-  asyncGenObjFn: ({ esbuild }) => futureSyntax(esbuild, '({ async* foo() {} })', 'es2017', 'es2018'),
-  asyncGenClassStmtFn: ({ esbuild }) => futureSyntax(esbuild, 'class Foo { async* foo() {} }', 'es2017', 'es2018'),
-  asyncGenClassExprFn: ({ esbuild }) => futureSyntax(esbuild, '(class { async* foo() {} })', 'es2017', 'es2018'),
 }
 
 function registerClassPrivateTests(target) {

--- a/scripts/test262-async.js
+++ b/scripts/test262-async.js
@@ -1,0 +1,114 @@
+// This file runs test262 tests for the async iteration proposal:
+// https://github.com/tc39/proposal-async-iteration. It's intended
+// to be informative (to identify failure points) but not to be
+// run in CI. Not even node/V8 passes all of these tests.
+
+const esbuild = require('./esbuild').installForTests()
+const ts = require('./node_modules/typescript')
+const fs = require('fs')
+const vm = require('vm')
+
+const test262Dir = __dirname + '/../demo/test262'
+const shim = ``
+  + fs.readFileSync(test262Dir + '/harness/assert.js', 'utf8')
+  + fs.readFileSync(test262Dir + '/harness/asyncHelpers.js', 'utf8')
+  + fs.readFileSync(test262Dir + '/harness/compareArray.js', 'utf8')
+  + fs.readFileSync(test262Dir + '/harness/propertyHelper.js', 'utf8')
+  + fs.readFileSync(test262Dir + '/harness/sta.js', 'utf8')
+
+async function main() {
+  const tests = []
+
+  for (const dir of [
+    test262Dir + '/test/language/statements/async-generator',
+    test262Dir + '/test/language/statements/for-await-of',
+  ]) {
+    for (const name of fs.readdirSync(dir)) {
+      if (name.endsWith('.js')) {
+        tests.push(dir + '/' + name)
+      }
+    }
+  }
+
+  for (const test of tests) {
+    const stuck = () => console.log(`❌ ${test}: stuck`)
+    process.on('exit', stuck)
+
+    let js = fs.readFileSync(test, 'utf8')
+    let negative = /negative:/.test(js)
+
+    let flags = /flags:.*/.exec(js)
+    flags = flags && new Set(/flags: \[([^\]]*)\]/.exec(js)[1].split(', '))
+
+    let didFail = false
+
+    const check = async (kind, codePromise) => {
+      let error
+      try {
+        let { code } = await codePromise
+        code = shim + code
+        if (flags && flags.has('onlyStrict')) {
+          code = '"use strict";\n' + code
+        }
+        await new Promise((resolve, reject) => {
+          if (flags && flags.has('async')) {
+            vm.runInContext(code, vm.createContext({ $DONE: err => err ? reject(err) : resolve() }))
+          } else {
+            vm.runInContext(code, vm.createContext({}))
+            resolve()
+          }
+        })
+      } catch (err) {
+        error = err
+      }
+      if (!error === !negative) {
+        return true
+      }
+      if (!didFail) {
+        didFail = true
+        console.log(`\n❌ \x1B[37m${test}\x1B[0m`)
+      }
+      if (kind === 'native') kind = '\x1B[32m[' + kind + ']\x1B[0m'
+      else if (kind.startsWith('ts')) kind = '\x1B[34m[' + kind + ']\x1B[0m'
+      else kind = '\x1B[33m[' + kind + ']\x1B[0m'
+      console.log(`  ${kind} ${(error + '' || 'unexpected success').replace(/\n/g, '\\n')}`)
+      return false
+    }
+
+    const tsTranspile = async (compilerOptions) => {
+      const { outputText } = ts.transpileModule(js, { compilerOptions })
+      return { code: outputText }
+    }
+
+    // See if node's native support checks out (it currently doesn't due to recent specification changes)
+    await check('native', { code: js })
+
+    // Ignore tests that check whether "yield" can be used as a valid
+    // identifier. This obviously doesn't work when we must transform
+    // async functions into generator functions, but that's fine.
+    const hasYieldKeyword = test.includes('yield-ident-valid') || test.includes('array-elem-target-yield-valid')
+
+    // Check "tsc"
+    await check('ts=esnext', tsTranspile({ target: ts.ScriptTarget.ESNext }))
+    await check('ts=es2017', tsTranspile({ target: ts.ScriptTarget.ES2017 }))
+    if (!hasYieldKeyword) {
+      await check('ts=es2016', { code: ts.transpileModule(js, { compilerOptions: { target: ts.ScriptTarget.ES2016 } }).outputText })
+    }
+
+    // Check "esbuild"
+    await check('target=esnext', esbuild.transform(js, { keepNames: true, target: 'esnext' }))
+    await check('target=es2017', esbuild.transform(js, { keepNames: true, target: 'es2017' }))
+    await check('for-await=false', esbuild.transform(js, { keepNames: true, supported: { 'for-await': false } }))
+    if (!hasYieldKeyword) {
+      await check('target=es2016', esbuild.transform(js, { keepNames: true, target: 'es2016' }))
+      await check('async-await=false', esbuild.transform(js, { keepNames: true, supported: { 'async-await': false } }))
+      await check('for-await=false,async-await=false', esbuild.transform(js, { keepNames: true, supported: { 'for-await': false, 'async-await': false } }))
+    }
+
+    process.off('exit', stuck)
+  }
+
+  console.log(`Done`)
+}
+
+main()


### PR DESCRIPTION
With this PR, esbuild will now transform `async` generator functions into normal generator functions when the configured target environment doesn't support them. These functions behave similar to normal generator functions except that they use the `Symbol.asyncIterator` interface instead of the `Symbol.iterator` interface and the iteration methods return promises. Here's an example (helper functions are omitted):

```js
// Original code
async function* foo() {
  yield Promise.resolve(1)
  await new Promise(r => setTimeout(r, 100))
  yield *[Promise.resolve(2)]
}
async function bar() {
  for await (const x of foo()) {
    console.log(x)
  }
}
bar()

// New output (with --target=es6)
function foo() {
  return __asyncGenerator(this, null, function* () {
    yield Promise.resolve(1);
    yield new __await(new Promise((r) => setTimeout(r, 100)));
    yield* __yieldStar([Promise.resolve(2)]);
  });
}
function bar() {
  return __async(this, null, function* () {
    try {
      for (var iter = __forAwait(foo()), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
        const x = temp.value;
        console.log(x);
      }
    } catch (temp) {
      error = [temp];
    } finally {
      try {
        more && (temp = iter.return) && (yield temp.call(iter));
      } finally {
        if (error)
          throw error[0];
      }
    }
  });
}
bar();
```

This is an older feature that was added to JavaScript in ES2018 but I didn't implement the transformation then because it's a rarely-used feature. Note that esbuild already added support for transforming `for await` loops (the other part of the [asynchronous iteration proposal](https://github.com/tc39/proposal-async-iteration)) a year ago, so support for asynchronous iteration should now be complete.

I have never used this feature myself and code that uses this feature is hard to come by, so this transformation has not yet been tested on real-world code. If you do write code that uses this feature, please let me know if esbuild's `async` generator transformation doesn't work with your code.

Fixes #2780