### PR TITLE
Update golang.org/x/sys v0.10.0 for CWE-266

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ module github.com/evanw/esbuild
 // themselves for old OS versions. Please do not change this.
 go 1.13
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
+require golang.org/x/sys v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Hi,
I am getting this CWE when using esbuild in our containers.

https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXSYSUNIX-3310442