### PR TITLE
Update golang.org/x/sys v0.1.0 for CWE-266

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ module github.com/evanw/esbuild
 // themselves for old OS versions. Please do not change this.
 go 1.13
 
-require golang.org/x/sys v0.10.0
+require golang.org/x/sys v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ module github.com/evanw/esbuild
 // themselves for old OS versions. Please do not change this.
 go 1.13
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
+require golang.org/x/sys v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
As per this PR:
https://github.com/evanw/esbuild/pull/3248

The minimum version that fixes the CWE is v0.1.0, will that work with the old version you are using?

https://pkg.go.dev/golang.org/x/sys?tab=versions
<img width="350" alt="Screenshot 2023-07-20 at 12 56 58 pm" src="https://github.com/evanw/esbuild/assets/2882739/e5b63d5c-43b2-431e-b0bf-e1d9abd3eabd">
