### PR TITLE
fix: quotes cannot be removed when the value of animation-name is a CSS Wide keywords

### DIFF
--- a/internal/css_parser/css_decls_animation.go
+++ b/internal/css_parser/css_decls_animation.go
@@ -87,6 +87,7 @@ func (p *parser) processAnimationShorthand(tokens []css_ast.Token) {
 }
 
 func (p *parser) processAnimationName(tokens []css_ast.Token) {
+	// Convert any local names
 	for i, t := range tokens {
 		if t.Kind == css_lexer.TIdent || t.Kind == css_lexer.TString {
 			p.handleSingleAnimationName(&tokens[i])
@@ -95,10 +96,8 @@ func (p *parser) processAnimationName(tokens []css_ast.Token) {
 }
 
 func (p *parser) handleSingleAnimationName(token *css_ast.Token) {
-	if token.Kind == css_lexer.TIdent {
-		if lower := strings.ToLower(token.Text); lower == "none" || cssWideAndReservedKeywords[lower] {
-			return
-		}
+	if lower := strings.ToLower(token.Text); lower == "none" || cssWideAndReservedKeywords[lower] {
+		return
 	}
 
 	token.Kind = css_lexer.TSymbol

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1337,6 +1337,8 @@ func TestAtKeyframes(t *testing.T) {
 	// them silently breaking in Chrome.
 	expectPrinted(t, "@keyframes 'name' {}", "@keyframes name {\n}\n", "")
 	expectPrinted(t, "@keyframes 'name 2' {}", "@keyframes name\\ 2 {\n}\n", "")
+	// TODO: this should be @keyframes "none"
+	// expectPrinted(t, "@keyframes 'none' {}", "@keyframes \"none\" {\n}\n", "")
 
 	expectPrinted(t, "@keyframes name { from { color: red } }", "@keyframes name {\n  from {\n    color: red;\n  }\n}\n", "")
 	expectPrinted(t, "@keyframes name { 100% { color: red } }", "@keyframes name {\n  100% {\n    color: red;\n  }\n}\n", "")
@@ -1383,6 +1385,12 @@ func TestAnimationName(t *testing.T) {
 	// them silently breaking in Chrome.
 	expectPrinted(t, "div { animation-name: 'name' }", "div {\n  animation-name: name;\n}\n", "")
 	expectPrinted(t, "div { animation-name: 'name 2' }", "div {\n  animation-name: name\\ 2;\n}\n", "")
+	expectPrinted(t, "div { animation-name: 'none' }", "div {\n  animation-name: \"none\";\n}\n", "")
+	expectPrinted(t, "div { animation-name: 'None' }", "div {\n  animation-name: \"None\";\n}\n", "")
+	expectPrinted(t, "div { animation-name: 'unset' }", "div {\n  animation-name: \"unset\";\n}\n", "")
+	expectPrinted(t, "div { animation-name: 'revert' }", "div {\n  animation-name: \"revert\";\n}\n", "")
+	expectPrinted(t, "div { animation-name: none }", "div {\n  animation-name: none;\n}\n", "")
+	expectPrinted(t, "div { animation-name: unset }", "div {\n  animation-name: unset;\n}\n", "")
 	expectPrinted(t, "div { animation: 2s linear 'name 2', 3s infinite 'name 3' }", "div {\n  animation: 2s linear name\\ 2, 3s infinite name\\ 3;\n}\n", "")
 }
 


### PR DESCRIPTION
Continuing to improve: https://github.com/evanw/esbuild/commit/4973f9e45fbf9e5fcfadc7d6f193bddafe901267 and https://github.com/evanw/esbuild/commit/e77404a482479c1739e929e6caab36b8b6bb8868