### PR TITLE
Exports tsconfigRaw types

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -85,23 +85,25 @@ interface CommonOptions {
   logOverride?: Record<string, LogLevel>
 
   /** Documentation: https://esbuild.github.io/api/#tsconfig-raw */
-  tsconfigRaw?: string | {
-    compilerOptions?: {
-      alwaysStrict?: boolean
-      baseUrl?: boolean
-      experimentalDecorators?: boolean
-      importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
-      jsx?: 'preserve' | 'react-native' | 'react' | 'react-jsx' | 'react-jsxdev'
-      jsxFactory?: string
-      jsxFragmentFactory?: string
-      jsxImportSource?: string
-      paths?: Record<string, string[]>
-      preserveValueImports?: boolean
-      strict?: boolean
-      target?: string
-      useDefineForClassFields?: boolean
-      verbatimModuleSyntax?: boolean
-    }
+  tsconfigRaw?: string | TsconfigRaw
+}
+
+export interface TsconfigRaw {
+  compilerOptions?: {
+    alwaysStrict?: boolean
+    baseUrl?: boolean
+    experimentalDecorators?: boolean
+    importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
+    jsx?: 'preserve' | 'react-native' | 'react' | 'react-jsx' | 'react-jsxdev'
+    jsxFactory?: string
+    jsxFragmentFactory?: string
+    jsxImportSource?: string
+    paths?: Record<string, string[]>
+    preserveValueImports?: boolean
+    strict?: boolean
+    target?: string
+    useDefineForClassFields?: boolean
+    verbatimModuleSyntax?: boolean
   }
 }
 


### PR DESCRIPTION
This pull request exports the `tsconfigRaw` object type to the end user. This makes it easier to manipulate `tsconfig` passed to esbuild programmatically.