### PR TITLE
chore(linker): remove meaningless re-assignment to `isFileInThisChunk`

### DIFF
--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -3757,7 +3757,6 @@ func (c *linkerContext) findImportedPartsInJSOrder(chunk *chunkInfo) (js []uint3
 
 				// Then include this part after the files it imports
 				if isPartInThisChunk {
-					isFileInThisChunk = true
 					if canFileBeSplit && uint32(partIndex) != js_ast.NSExportPartIndex && c.shouldIncludePart(repr, part) {
 						if sourceIndex == runtime.SourceIndex {
 							jsPartsPrefix = appendOrExtendPartRange(jsPartsPrefix, sourceIndex, uint32(partIndex))


### PR DESCRIPTION
`isPartInThisChunk` could only be `true` while `isFileInThisChunk = true`. So the `isFileInThisChunk = true` in https://github.com/evanw/esbuild/blob/e08ee8990905f24b987a7ddffde89e20cbf3cf6a/internal/linker/linker.go#L3759-L3760
seems meaningless.


See https://github.com/evanw/esbuild/blob/e08ee8990905f24b987a7ddffde89e20cbf3cf6a/internal/linker/linker.go#L3732-L3784 for more details.