### PR TITLE
fix(TsconfigRaw): `baseUrl` to be string

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -91,7 +91,7 @@ interface CommonOptions {
 export interface TsconfigRaw {
   compilerOptions?: {
     alwaysStrict?: boolean
-    baseUrl?: boolean
+    baseUrl?: string
     experimentalDecorators?: boolean
     importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
     jsx?: 'preserve' | 'react-native' | 'react' | 'react-jsx' | 'react-jsxdev'


### PR DESCRIPTION
- https://www.typescriptlang.org/tsconfig#baseUrl
- https://github.com/sindresorhus/type-fest/blob/main/source/tsconfig-json.d.ts#L709