### PR TITLE
Resolve css after ts in node_modules

### DIFF
--- a/internal/bundler_tests/bundler_ts_test.go
+++ b/internal/bundler_tests/bundler_ts_test.go
@@ -2719,6 +2719,40 @@ func TestTSPreferJSOverTSInsideNodeModules(t *testing.T) {
 	})
 }
 
+func TestTSPreferTSOverCssInsideNodeModules(t *testing.T) {
+	// We now prefer ".js" over ".ts" inside "node_modules"
+	ts_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/Users/user/project/src/main.ts": `
+				// Implicit extensions
+				import './relative/path'
+				import 'package/path'
+
+				// Explicit extensions
+				import './relative2/path.css'
+				import 'package2/path.css'
+			`,
+
+			"/Users/user/project/src/relative/path.ts": `console.log('success')`,
+			"/Users/user/project/src/relative/path.css": `failure`,
+
+			"/Users/user/project/src/relative2/path.ts": `console.log('FAILURE')`,
+			"/Users/user/project/src/relative2/path.css": `html {}`,
+
+			"/Users/user/project/node_modules/package/path.ts": `console.log('success')`,
+			"/Users/user/project/node_modules/package/path.css": `failure`,
+
+			"/Users/user/project/node_modules/package2/path.ts": `console.log('FAILURE')`,
+			"/Users/user/project/node_modules/package2/path.css": `html {}`,
+		},
+		entryPaths: []string{"/Users/user/project/src/main.ts"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+		},
+	})
+}
+
 func TestTSExperimentalDecoratorsManglePropsDefineSemantics(t *testing.T) {
 	ts_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler_tests/snapshots/snapshots_ts.txt
+++ b/internal/bundler_tests/snapshots/snapshots_ts.txt
@@ -1744,14 +1744,32 @@ TestTSPreferJSOverTSInsideNodeModules
 // Users/user/project/src/relative/path.ts
 console.log("success");
 
-// Users/user/project/node_modules/package/path.js
-console.log("success");
+// Users/user/project/node_modules/package/path.ts
+console.log("FAILURE");
 
 // Users/user/project/src/relative2/path.js
 console.log("success");
 
 // Users/user/project/node_modules/package2/path.js
 console.log("success");
+
+================================================================================
+TestTSPreferTSOverCssInsideNodeModules
+---------- /out/main.js ----------
+// Users/user/project/src/relative/path.ts
+console.log("success");
+
+// Users/user/project/node_modules/package/path.ts
+console.log("success");
+
+---------- /out/main.css ----------
+/* Users/user/project/src/relative2/path.css */
+html {
+}
+
+/* Users/user/project/node_modules/package2/path.css */
+html {
+}
 
 ================================================================================
 TestTSSiblingEnum

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -252,12 +252,17 @@ func NewResolver(call config.APICall, fs fs.FS, log logger.Log, caches *cache.Ca
 	// for imports of files inside of "node_modules" directories
 	nodeModulesExtensionOrder := make([]string, 0, len(options.ExtensionOrder))
 	for _, ext := range options.ExtensionOrder {
-		if loader, ok := options.ExtensionToLoader[ext]; !ok || !loader.IsTypeScript() {
+		if loader, ok := options.ExtensionToLoader[ext]; !ok || !loader.IsTypeScript() || !loader.IsCSS() {
 			nodeModulesExtensionOrder = append(nodeModulesExtensionOrder, ext)
 		}
 	}
 	for _, ext := range options.ExtensionOrder {
 		if loader, ok := options.ExtensionToLoader[ext]; ok && loader.IsTypeScript() {
+			nodeModulesExtensionOrder = append(nodeModulesExtensionOrder, ext)
+		}
+	}
+	for _, ext := range options.ExtensionOrder {
+		if loader, ok := options.ExtensionToLoader[ext]; ok && loader.IsCSS() {
 			nodeModulesExtensionOrder = append(nodeModulesExtensionOrder, ext)
 		}
 	}


### PR DESCRIPTION
Addresses #3341 

Typescript files in node_modules will currently resolve css files over ts files when importing without extension. 