### PR TITLE
fix: allow resolving package.json within packages

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2623,6 +2623,11 @@ func (r resolverQuery) finalizeImportsExportsResult(
 			if relPath, ok := r.fs.Rel(absDirPath, absolute.Primary.Text); ok {
 				query := "." + path.Join("/", strings.ReplaceAll(relPath, "\\", "/"))
 
+				// If we are trying to look up package.json, return it directly.
+				if path.Base(absImportPath) == "package.json" {
+					return PathPair{Primary: logger.Path{Text: absImportPath, Namespace: "file"}}, true, nil
+				}
+
 				// If that succeeds, try to do a reverse lookup using the
 				// "exports" map for the currently-active set of conditions
 				if ok, subpath, token := r.esmPackageExportsReverseResolve(


### PR DESCRIPTION
Enables the following type of import:

```
const pkg = require('@mantine/core/package.json');
```

This is used to access the contents of package.json which is usually not exported by any of the exports within the package.json.

Reproduction of the issue:

```
package main

import (
	"errors"

	esbuild_api "github.com/evanw/esbuild/pkg/api"
)

func main() {
	res := esbuild_api.Build(esbuild_api.BuildOptions{
		EntryPoints: []string{"entry.js"},

		LogLevel: esbuild_api.LogLevelVerbose,
		Platform: esbuild_api.PlatformBrowser,
		Format:   esbuild_api.FormatESModule,

		Bundle:  true,
		Write:   true,
		Outfile: "out.js",

		Plugins: []esbuild_api.Plugin{buildPlugin()},
		Loader: map[string]esbuild_api.Loader{
			".json": esbuild_api.LoaderFile,
		},
	})
	if len(res.Errors) != 0 {
		panic(res.Errors[0].Text)
	}
}

func buildPlugin() esbuild_api.Plugin {
	return esbuild_api.Plugin{
		Name: "logger",
		Setup: func(pb esbuild_api.PluginBuild) {
			pb.OnResolve(esbuild_api.OnResolveOptions{
				Filter:    ".",
				Namespace: "file",
			}, func(ora esbuild_api.OnResolveArgs) (esbuild_api.OnResolveResult, error) {
				var result esbuild_api.OnResolveResult
				if ora.Importer == "logger" {
					return result, nil
				}

				resResult := pb.Resolve("@mantine/core/package.json", esbuild_api.ResolveOptions{
					// Importer: ora.Importer,
					// Namespace:  ora.Namespace,
					// Namespace:  "logger",
					Namespace:  "file",
					Importer:   "logger",
					ResolveDir: ora.ResolveDir,
					Kind:       esbuild_api.ResolveJSImportStatement,
				})
				if len(resResult.Errors) != 0 {
					return result, errors.New(resResult.Errors[0].Text)
				}

				return result, nil
			})
		},
	}
}
```

Importing package.json currently works with some packages (like `react`) but not others (like `@mantine/core`).