### PR TITLE
add Safari compat data for arbitrary module namespace names

### DIFF
--- a/compat-table/src/index.ts
+++ b/compat-table/src/index.ts
@@ -465,8 +465,9 @@ import('./kangax').then(kangax => {
     // From https://bugzilla.mozilla.org/show_bug.cgi?id=1670044
     js.ArbitraryModuleNamespaceNames.Firefox = { 87: { force: true } }
 
-    // This feature has been implemented in Safari but I have no idea what version
-    // this bug corresponds to: https://bugs.webkit.org/show_bug.cgi?id=217576
+    // From https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes#:~:text=Added%20support%20for%20Arbitrary%20module%20namespace%20identifier%20names.
+    js.ArbitraryModuleNamespaceNames.Safari = { '14.1': { force: true } }
+    js.ArbitraryModuleNamespaceNames.IOS = { '14.5': { force: true } }
   }
 
   // Import assertions (note: these were removed from the JavaScript specification and never standardized)

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -194,7 +194,9 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Chrome:  {{start: v{90, 0, 0}}},
 		ES:      {{start: v{2022, 0, 0}}},
 		Firefox: {{start: v{87, 0, 0}}},
+		IOS:     {{start: v{14, 5, 0}}},
 		Node:    {{start: v{16, 0, 0}}},
+		Safari:  {{start: v{14, 1, 0}}},
 	},
 	ArraySpread: {
 		// Note: The latest version of "IE" failed 15 tests including: spread syntax for iterable objects: spreading non-iterables is a runtime error


### PR DESCRIPTION
This PR adds Safari compat data for "arbitrary module namespace names" feature.