### PR TITLE
allow load plugin result with empty loader to have null contents

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1035,11 +1035,12 @@ func runOnLoadPlugins(
 			}
 
 			// Otherwise, continue on to the next loader if this loader didn't succeed
-			if result.Contents == nil {
+			if result.Contents != nil {
+				source.Contents = *result.Contents
+			} else if result.Loader != config.LoaderEmpty {
 				continue
 			}
 
-			source.Contents = *result.Contents
 			loader := result.Loader
 			if loader == config.LoaderNone {
 				loader = config.LoaderJS

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -1008,6 +1008,28 @@ let pluginTests = {
     assert.strictEqual(result.outputFiles[3].text, `// virtual-ns:input a/b/c.d.e\nconsole.log("input a/b/c.d.e");\n`)
   },
 
+  async emptyLoaderNoContents({ esbuild, testDir }) {
+    const input = path.join(testDir, 'in.js')
+    const output = path.join(testDir, 'out.js')
+    await writeFileAsync(input, 'export default 123')
+    await esbuild.build({
+      entryPoints: [input],
+      bundle: true,
+      outfile: output,
+      format: 'cjs',
+      plugins: [{
+        name: 'name',
+        setup(build) {
+          build.onLoad({ filter: /\.js$/ }, args => {
+            return { loader: 'empty' }
+          })
+        },
+      }],
+    })
+    const result = await readFileAsync(output, 'utf-8')
+    assert.doesNotMatch(result, /123/);
+  },
+
   async entryPointFileNamespace({ esbuild, testDir }) {
     const input = path.join(testDir, 'in.js')
     let worked = false


### PR DESCRIPTION
Currently, a plugin that returns a `loader` value of `empty` also requires the `contents` field to be set to a non-null value for the loader to be used. Since the provided contents will never be used in the empty loader case, the `contents` field is now no longer required in the case when an `empty` loader is returned. This removes the chance of a plugin unintentionally not using the returned empty loader.