### PR TITLE
pkg/api: fix Rebuild always write to output files

### DIFF
--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1578,7 +1578,14 @@ func rebuildImpl(args rebuildArgs, oldHashes map[string]string) (rebuildState, m
 							defer waitGroup.Done()
 							fs.BeforeFileOpen()
 							defer fs.AfterFileClose()
-							if oldHash, ok := oldHashes[result.AbsPath]; ok && oldHash == newHashes[result.AbsPath] {
+							oldHash, ok := oldHashes[result.AbsPath]
+							if ok {
+								if oldHash == newHashes[result.AbsPath] {
+									// Skip writing out files that haven't changed since last time
+									return
+								}
+							} else {
+								// The old hash is empty on the first build, we compare them by content.
 								if contents, err := ioutil.ReadFile(result.AbsPath); err == nil && bytes.Equal(contents, result.Contents) {
 									// Skip writing out files that haven't changed since last time
 									return


### PR DESCRIPTION
On the first Rebuild, the oldHashes is empty, so the condition that checking between old and new hash will always false which makes the output files always written.

This changes fix this issue by moving the content comparison only if no old hash found.