### PR TITLE
Provide API to create a custom esbuild CLI with plugins

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -28,7 +28,14 @@ import (
 // "esbuild" executable such as the lack of auxiliary flags (e.g. "--help" and
 // "--version") but it is otherwise exactly the same code.
 func Run(osArgs []string) int {
-	return runImpl(osArgs)
+	return runImpl(osArgs, []api.Plugin{})
+}
+
+// This function invokes the esbuild CLI. It takes an array of command-line
+// arguments (excluding the executable argument itself) and returns an exit
+// code. It also takes adds some plugins that need to be added to the run
+func RunWithPlugins(osArgs []string, plugin []api.Plugin) int {
+	return runImpl(osArgs, plugin)
 }
 
 // This parses an array of strings into an options object suitable for passing

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -1127,7 +1127,7 @@ func addAnalyzePlugin(buildOptions *api.BuildOptions, analyze analyzeMode, osArg
 	buildOptions.Metafile = true
 }
 
-func runImpl(osArgs []string) int {
+func runImpl(osArgs []string, plugins []api.Plugin) int {
 	// Special-case running a server
 	for _, arg := range osArgs {
 		if arg == "--serve" ||
@@ -1278,6 +1278,8 @@ func runImpl(osArgs []string) int {
 			}
 		}
 
+		buildOptions.Plugins = plugins
+		// buildOptions.Plugins = append(buildOptions.Plugins, scssPlugin)
 		// Handle post-build actions with a plugin so they also work in watch mode
 		buildOptions.Plugins = append(buildOptions.Plugins, api.Plugin{
 			Name: "PostBuildActions",

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -1279,7 +1279,6 @@ func runImpl(osArgs []string, plugins []api.Plugin) int {
 		}
 
 		buildOptions.Plugins = plugins
-		// buildOptions.Plugins = append(buildOptions.Plugins, scssPlugin)
 		// Handle post-build actions with a plugin so they also work in watch mode
 		buildOptions.Plugins = append(buildOptions.Plugins, api.Plugin{
 			Name: "PostBuildActions",


### PR DESCRIPTION
This is very important as it allows to create create a CLI version of esbuild with a custom set of Go Plugin (in our case we needed scss). Without it we have to fork esbuild and add it which is not very nice.

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
