### PR TITLE
fix deprecated Deno APIs "Deno.stderr.rid" "Deno.isatty()" "Deno.run()"

### DIFF
--- a/scripts/deno-tests.js
+++ b/scripts/deno-tests.js
@@ -14,6 +14,8 @@ try {
 }
 Deno.mkdirSync(rootTestDir, { recursive: true })
 
+await esbuildNative.initialize()
+
 function test(name, backends, fn) {
   const singleTest = (name, fn) => Deno.test({
     name,
@@ -37,7 +39,7 @@ function test(name, backends, fn) {
             await fn({ esbuild: esbuildNative, testDir })
             await Deno.remove(testDir, { recursive: true }).catch(() => null)
           } finally {
-            esbuildNative.stop()
+            // esbuildNative.stop()
           }
         })
         break
@@ -75,6 +77,7 @@ function test(name, backends, fn) {
 
 window.addEventListener("unload", (e) => {
   try {
+    esbuildNative.stop()
     Deno.removeSync(rootTestDir, { recursive: true })
   } catch {
     // root test dir possibly already removed, so ignore


### PR DESCRIPTION
[Deno v1.40.0](https://github.com/denoland/deno/releases/tag/v1.40.0) was released deprecating:

* `Deno.isatty()`
* `Deno.stderr.rid`

`Deno.run` was previously deprecated to be replaced with `Deno.Command`.

This PR does the minimum to replace the deprecated APIs and fixes #3609

I had to modify `deno-tests.js` to call `esbuildNative.initialize()` and `esbuildNative.stop()` only once before and after the tests. Deno test was complaing about "Leaking async ops" and failing the first test despite the asserts being true.

I think the child process read/write code could be smaller now (e.g. without the need for `startWriteFromQueueWorker`) but I haven't done any extra refactoring here.