### PR TITLE
Don't rewrite __proto__ to shorthand.

### DIFF
--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -1330,6 +1330,7 @@ func TestObject(t *testing.T) {
 
 	expectPrintedMangle(t, "x = {['_proto_']: x}", "x = { _proto_: x };\n")
 	expectPrintedMangle(t, "x = {['__proto__']: x}", "x = { [\"__proto__\"]: x };\n")
+	expectPrinted(t, "({ __proto__: __proto__ })", "({ __proto__: __proto__ });\n")
 
 	expectParseError(t, "({set foo() {}})", "<stdin>: ERROR: Setter \"foo\" must have exactly one argument\n")
 	expectParseError(t, "({get foo(x) {}})", "<stdin>: ERROR: Getter \"foo\" must have zero arguments\n")

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1242,7 +1242,7 @@ func (p *printer) printProperty(property js_ast.Property) {
 			if !p.options.UnsupportedFeatures.Has(compat.ObjectExtensions) && property.ValueOrNil.Data != nil && !p.willPrintExprCommentsAtLoc(property.ValueOrNil.Loc) {
 				switch e := property.ValueOrNil.Data.(type) {
 				case *js_ast.EIdentifier:
-					if helpers.UTF16EqualsString(key.Value, p.renamer.NameForSymbol(e.Ref)) {
+					if helpers.UTF16EqualsString(key.Value, p.renamer.NameForSymbol(e.Ref)) && !helpers.UTF16EqualsString(key.Value, "__proto__") {
 						if p.options.AddSourceMappings {
 							p.addSourceMappingForName(property.Key.Loc, helpers.UTF16ToString(key.Value), e.Ref)
 						}


### PR DESCRIPTION
These are different:

    ({ __proto__: __proto__ })

and

    ({ __proto__ })

And the former should not be rewritten to the latter.