### PR TITLE
feat #3666 add optional exclude option for plugin `onLoad` and `onResolve` hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@
     })(Foo || {});
     ```
 
+* Add `exclude?: RegExp` option to `onLoad` on `onResolve` hooks
+
+    Allows plugins to stamp out files and folders to not execute the hook.
+
+    ```js
+    const myPlugin = {
+      name: 'my-plugin',
+      setup(build) {
+        build.onResolve({ filter: /.js$/, exclude: /^(static|my-lib)\// }, args => {
+        })
+        build.onLoad({ filter: /.js$/, exclude: /\/node_modules\// }, args => {
+        })
+      }
+    }
+    ```
+
 ## 0.20.1
 
 * Fix a bug with the CSS nesting transform ([#3648](https://github.com/evanw/esbuild/issues/3648))

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -885,7 +885,7 @@ func RunOnResolvePlugins(
 	// Apply resolver plugins in order until one succeeds
 	for _, plugin := range plugins {
 		for _, onResolve := range plugin.OnResolve {
-			if !config.PluginAppliesToPath(applyPath, onResolve.Filter, onResolve.Namespace) {
+			if !config.PluginAppliesToPath(applyPath, onResolve.Filter, onResolve.Exclude, onResolve.Namespace) {
 				continue
 			}
 
@@ -1002,7 +1002,7 @@ func runOnLoadPlugins(
 	// Apply loader plugins in order until one succeeds
 	for _, plugin := range plugins {
 		for _, onLoad := range plugin.OnLoad {
-			if !config.PluginAppliesToPath(source.KeyPath, onLoad.Filter, onLoad.Namespace) {
+			if !config.PluginAppliesToPath(source.KeyPath, onLoad.Filter, onLoad.Exclude, onLoad.Namespace) {
 				continue
 			}
 

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1306,12 +1306,13 @@ let handlePlugins = async (
           let registeredNote = extractCallerV8(new Error(registeredText), streamIn, 'onResolve')
           let keys: OptionKeys = {}
           let filter = getFlag(options, keys, 'filter', mustBeRegExp)
+          let exclude = getFlag(options, keys, 'exclude', mustBeRegExp)
           let namespace = getFlag(options, keys, 'namespace', mustBeString)
           checkForInvalidFlags(options, keys, `in onResolve() call for plugin ${quote(name)}`)
           if (filter == null) throw new Error(`onResolve() call is missing a filter`)
           let id = nextCallbackID++
           onResolveCallbacks[id] = { name: name!, callback, note: registeredNote }
-          plugin.onResolve.push({ id, filter: filter.source, namespace: namespace || '' })
+          plugin.onResolve.push({ id, filter: filter.source, exclude: exclude?.source || '', namespace: namespace || '' })
         },
 
         onLoad(options, callback) {
@@ -1319,12 +1320,13 @@ let handlePlugins = async (
           let registeredNote = extractCallerV8(new Error(registeredText), streamIn, 'onLoad')
           let keys: OptionKeys = {}
           let filter = getFlag(options, keys, 'filter', mustBeRegExp)
+          let exclude = getFlag(options, keys, 'exclude', mustBeRegExp)
           let namespace = getFlag(options, keys, 'namespace', mustBeString)
           checkForInvalidFlags(options, keys, `in onLoad() call for plugin ${quote(name)}`)
           if (filter == null) throw new Error(`onLoad() call is missing a filter`)
           let id = nextCallbackID++
           onLoadCallbacks[id] = { name: name!, callback, note: registeredNote }
-          plugin.onLoad.push({ id, filter: filter.source, namespace: namespace || '' })
+          plugin.onLoad.push({ id, filter: filter.source, exclude: exclude?.source || '', namespace: namespace || '' })
         },
 
         onDispose(callback) {

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -42,8 +42,8 @@ export interface BuildPlugin {
   name: string
   onStart: boolean
   onEnd: boolean
-  onResolve: { id: number, filter: string, namespace: string }[]
-  onLoad: { id: number, filter: string, namespace: string }[]
+  onResolve: { id: number, filter: string, exclude: string, namespace: string }[]
+  onLoad: { id: number, filter: string, exclude: string, namespace: string }[]
 }
 
 export interface BuildResponse {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -368,6 +368,7 @@ export interface OnEndResult {
 /** Documentation: https://esbuild.github.io/plugins/#on-resolve-options */
 export interface OnResolveOptions {
   filter: RegExp
+  exclude?: RegExp
   namespace?: string
 }
 
@@ -416,6 +417,7 @@ export interface OnResolveResult {
 /** Documentation: https://esbuild.github.io/plugins/#on-load-options */
 export interface OnLoadOptions {
   filter: RegExp
+  exclude?: RegExp
   namespace?: string
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -603,6 +603,7 @@ type OnEndResult struct {
 // Documentation: https://esbuild.github.io/plugins/#on-resolve-options
 type OnResolveOptions struct {
 	Filter    string
+	Exclude   string
 	Namespace string
 }
 
@@ -637,6 +638,7 @@ type OnResolveResult struct {
 // Documentation: https://esbuild.github.io/plugins/#on-load-options
 type OnLoadOptions struct {
 	Filter    string
+	Exclude   string
 	Namespace string
 }
 

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1929,7 +1929,7 @@ func resolveKindToImportKind(kind ResolveKind) ast.ImportKind {
 
 func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnResolveArgs) (OnResolveResult, error)) {
 	filter, err := config.CompileFilterForPlugin(impl.plugin.Name, "OnResolve", options.Filter)
-	if filter == nil {
+	if filter == nil || err != nil  {
 		impl.log.AddError(nil, logger.Range{}, err.Error())
 		return
 	}
@@ -1985,7 +1985,7 @@ func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnReso
 
 func (impl *pluginImpl) onLoad(options OnLoadOptions, callback func(OnLoadArgs) (OnLoadResult, error)) {
 	filter, err := config.CompileFilterForPlugin(impl.plugin.Name, "OnLoad", options.Filter)
-	if err != nil {
+	if filter == nil || err != nil {
 		impl.log.AddError(nil, logger.Range{}, err.Error())
 		return
 	}

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1933,10 +1933,16 @@ func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnReso
 		impl.log.AddError(nil, logger.Range{}, err.Error())
 		return
 	}
+	exclude, err := config.CompileExcludeForPlugin(impl.plugin.Name, "OnResolve", options.Exclude)
+	if err != nil {
+		impl.log.AddError(nil, logger.Range{}, err.Error())
+		return
+	}
 
 	impl.plugin.OnResolve = append(impl.plugin.OnResolve, config.OnResolve{
 		Name:      impl.plugin.Name,
 		Filter:    filter,
+		Exclude:   exclude,
 		Namespace: options.Namespace,
 		Callback: func(args config.OnResolveArgs) (result config.OnResolveResult) {
 			response, err := callback(OnResolveArgs{
@@ -1979,13 +1985,19 @@ func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnReso
 
 func (impl *pluginImpl) onLoad(options OnLoadOptions, callback func(OnLoadArgs) (OnLoadResult, error)) {
 	filter, err := config.CompileFilterForPlugin(impl.plugin.Name, "OnLoad", options.Filter)
-	if filter == nil {
+	if err != nil {
+		impl.log.AddError(nil, logger.Range{}, err.Error())
+		return
+	}
+	exclude, err := config.CompileExcludeForPlugin(impl.plugin.Name, "OnLoad", options.Exclude)
+	if err != nil {
 		impl.log.AddError(nil, logger.Range{}, err.Error())
 		return
 	}
 
 	impl.plugin.OnLoad = append(impl.plugin.OnLoad, config.OnLoad{
 		Filter:    filter,
+		Exclude:   exclude,
 		Namespace: options.Namespace,
 		Callback: func(args config.OnLoadArgs) (result config.OnLoadResult) {
 			with := make(map[string]string)

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -2354,7 +2354,7 @@ error: Invalid path suffix "%what" returned from plugin (must start with "?" or 
       ],
       onLoad: [
         { path: pathFor('a') },
-        // { path: pathFor('c') }, should have been excluded via `exclude: /_b(\.js)?$/`
+        // { path: pathFor('b') }, should have been excluded via `exclude: /_b(\.js)?$/`
         { path: pathFor('c') },
       ],
     }, null, 2)


### PR DESCRIPTION
This allows plugins that are very broadly applied to user code, to ignore files and folders it knows not to touch, like `node_modules`, static files or shared folders.

As the cost of calling a plugin is not 0, especially `onResolve` hooks, this could help improve performance of plugins.

See #3666 

used like:

```js
const myPlugin = {
  name: 'my-plugin',
  setup(build) {
    build.onResolve({ filter: /.js$/, exclude: /^(static|my-lib)\// }, args => {
    })
    build.onLoad({ filter: /.js$/, exclude: /\/node_modules\// }, args => {
    })
  }
}
```

the exclude is optional and the filter-only syntax stil works.