### PR TITLE
fix: use the built in way for Go to check permissions (fix for Windows and cross platform)

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"errors"
 	"fmt"
+	fs_real "io/fs"
 	"path"
 	"regexp"
 	"sort"
@@ -1460,7 +1461,7 @@ func (r resolverQuery) dirInfoUncached(path string) *dirInfo {
 
 	// List the directories
 	entries, err, originalError := r.fs.ReadDirectory(path)
-	if err == syscall.EACCES || err == syscall.EPERM {
+	if errors.Is(err, fs_real.ErrPermission) {
 		// Just pretend this directory is empty if we can't access it. This is the
 		// case on Unix for directories that only have the execute permission bit
 		// set. It means we will just pass through the empty directory and


### PR DESCRIPTION
instead of explicitly checking EACCES and EPERM, Go has a built in way to check permissions (Windows fix and is cross-platform)

fixes the Windows issue reported by cuzfrog: https://github.com/evanw/esbuild/issues/938