### PR TITLE
Re-enable `unref` in Deno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.20.3
 
-* Re-enable `unref` behaviour for Deno
+* Re-enable `unref` behaviour for Deno ([#3701](https://github.com/evanw/esbuild/issues/3701))
 
     Version 0.20.0 of esbuild changed how the esbuild child process is run in esbuild's API for Deno. Previously it used `Deno.run` but that API is being removed in favor of `Deno.Command`. As part of this change, esbuild is now calling the new `unref` function on esbuild's long-lived child process, which is supposed to allow Deno to exit when your code has finished running even though the child process is still around (previously you had to explicitly call esbuild's `stop()` function to terminate the child process for Deno to be able to exit).
 

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -664,20 +664,23 @@ export let version: string
 
 // Call this function to terminate esbuild's child process. The child process
 // is not terminated and re-created after each API call because it's more
-// efficient to keep it around when there are multiple API calls.
+// efficient to keep it around when there are multiple API calls. This child
+// process normally exits automatically when the parent process exits, so you
+// usually don't need to call this function.
 //
-// In node this happens automatically before the parent node process exits. So
-// you only need to call this if you know you will not make any more esbuild
-// API calls and you want to clean up resources.
-//
-// Unlike node, Deno lacks the necessary APIs to clean up child processes
-// automatically. You must manually call stop() in Deno when you're done
-// using esbuild or Deno will continue running forever.
+// One reason you might want to call this is if you know you will not make any
+// more esbuild API calls and you want to clean up resources (since the esbuild
+// child process takes up some memory even when idle).
 //
 // Another reason you might want to call this is if you are using esbuild from
 // within a Deno test. Deno fails tests that create a child process without
 // killing it before the test ends, so you have to call this function (and
 // await the returned promise) in every Deno test that uses esbuild.
+//
+// You may also start esbuild once at the top level of your test suite instead
+// of starting and stopping the esbuild process for every test. This will not
+// interfere with the resource sanitizer, and will improve the efficiency of
+// your tests because the esbuild process can be reused between tests. 
 export declare function stop(): Promise<void>
 
 // Note: These declarations exist to avoid type errors when you omit "dom" from

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -675,12 +675,13 @@ export let version: string
 // Another reason you might want to call this is if you are using esbuild from
 // within a Deno test. Deno fails tests that create a child process without
 // killing it before the test ends, so you have to call this function (and
-// await the returned promise) in every Deno test that uses esbuild.
+// await the returned promise) in every Deno test that starts esbuild.
 //
-// You may also start esbuild once at the top level of your test suite instead
-// of starting and stopping the esbuild process for every test. This will not
-// interfere with the resource sanitizer, and will improve the efficiency of
-// your tests because the esbuild process can be reused between tests. 
+// You may also start esbuild once at the top level of your test suite (by
+// calling `initialize()`) instead of starting and stopping the esbuild process
+// for every test. This will not interfere with the resource sanitizer, and will
+// improve the efficiency of your tests because the esbuild process can be
+// reused between tests. 
 export declare function stop(): Promise<void>
 
 // Note: These declarations exist to avoid type errors when you omit "dom" from


### PR DESCRIPTION
This re-enables unref-by-default in Deno, and fixes the event loop starvation issue by explicitly re-ref'ing the esbuild sub-process when a user calls `stop()`.

Background: https://github.com/evanw/esbuild/issues/3682#issuecomment-1999391689