### PR TITLE
feat: make plugin event subscribers chainable

### DIFF
--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1292,6 +1292,7 @@ let handlePlugins = async (
           let registeredNote = extractCallerV8(new Error(registeredText), streamIn, 'onStart')
           onStartCallbacks.push({ name: name!, callback, note: registeredNote })
           plugin.onStart = true
+          return this
         },
 
         onEnd(callback) {
@@ -1299,6 +1300,7 @@ let handlePlugins = async (
           let registeredNote = extractCallerV8(new Error(registeredText), streamIn, 'onEnd')
           onEndCallbacks.push({ name: name!, callback, note: registeredNote })
           plugin.onEnd = true
+          return this
         },
 
         onResolve(options, callback) {
@@ -1312,6 +1314,7 @@ let handlePlugins = async (
           let id = nextCallbackID++
           onResolveCallbacks[id] = { name: name!, callback, note: registeredNote }
           plugin.onResolve.push({ id, filter: filter.source, namespace: namespace || '' })
+          return this
         },
 
         onLoad(options, callback) {
@@ -1325,10 +1328,12 @@ let handlePlugins = async (
           let id = nextCallbackID++
           onLoadCallbacks[id] = { name: name!, callback, note: registeredNote }
           plugin.onLoad.push({ id, filter: filter.source, namespace: namespace || '' })
+          return this
         },
 
         onDispose(callback) {
           onDisposeCallbacks.push(callback)
+          return this
         },
 
         esbuild: streamIn.esbuild,

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -299,22 +299,22 @@ export interface PluginBuild {
 
   /** Documentation: https://esbuild.github.io/plugins/#on-start */
   onStart(callback: () =>
-    (OnStartResult | null | void | Promise<OnStartResult | null | void>)): void
+    (OnStartResult | null | void | Promise<OnStartResult | null | void>)): PluginBuild
 
   /** Documentation: https://esbuild.github.io/plugins/#on-end */
   onEnd(callback: (result: BuildResult) =>
-    (OnEndResult | null | void | Promise<OnEndResult | null | void>)): void
+    (OnEndResult | null | void | Promise<OnEndResult | null | void>)): PluginBuild
 
   /** Documentation: https://esbuild.github.io/plugins/#on-resolve */
   onResolve(options: OnResolveOptions, callback: (args: OnResolveArgs) =>
-    (OnResolveResult | null | undefined | Promise<OnResolveResult | null | undefined>)): void
+    (OnResolveResult | null | undefined | Promise<OnResolveResult | null | undefined>)): PluginBuild
 
   /** Documentation: https://esbuild.github.io/plugins/#on-load */
   onLoad(options: OnLoadOptions, callback: (args: OnLoadArgs) =>
-    (OnLoadResult | null | undefined | Promise<OnLoadResult | null | undefined>)): void
+    (OnLoadResult | null | undefined | Promise<OnLoadResult | null | undefined>)): PluginBuild
 
   /** Documentation: https://esbuild.github.io/plugins/#on-dispose */
-  onDispose(callback: () => void): void
+  onDispose(callback: () => void): PluginBuild
 
   // This is a full copy of the esbuild library in case you need it
   esbuild: {

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -3251,6 +3251,22 @@ let syncTests = {
     await onDisposePromise
     assert.strictEqual(onDisposeWasCalled, true)
   },
+
+  async pluginSubscribersChainable({ esbuild }) {
+    let noop = () => {}
+    await esbuild.build({
+      write: false,
+      plugins: [{
+        name: 'x', setup(build) {
+          assert.strictEqual(build.onStart(noop), build)
+          assert.strictEqual(build.onEnd(noop), build)
+          assert.strictEqual(build.onLoad({ filter: /./ }, noop), build)
+          assert.strictEqual(build.onResolve({ filter: /./ }, noop), build)
+          assert.strictEqual(build.onDispose(noop), build)
+        }
+      }]
+    })
+  },
 }
 
 async function main() {


### PR DESCRIPTION
await esbuild.build({
      write: false,
      plugins: [{
        name: 'x', setup(build) {
          build.onStart(noop)
          assert.strictEqual(build.onEnd(noop), build)
          assert.strictEqual(build.onLoad({ filter: /./ }, noop), build)
          assert.strictEqual(build.onResolve({ filter: /./ }, noop), build)
          assert.strictEqual(build.onDispose(noop), build)
        }
      }]
    })