### PR TITLE
fix CVE-2023-45288: Upgrade Golang to `v1.22.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ['*']
+    branches: ["*"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   workflow_dispatch:
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read #  to fetch code (actions/checkout)
 
 jobs:
   esbuild-platforms:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.12
+          go-version: 1.22.2
         id: go
 
       - name: Setup Node.js environment
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.12
+          go-version: 1.22.2
         id: go
 
       - name: Setup Node.js environment
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.12
+          go-version: 1.22.2
         id: go
 
       - name: Setup Node.js environment
@@ -273,7 +273,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.12
+          go-version: 1.22.2
         id: go
 
       # Make sure esbuild works with old versions of Deno. Note: It's important

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,11 +2,11 @@ name: Validate release builds
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read #  to fetch code (actions/checkout)
 
 jobs:
   release:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.12
+          go-version: 1.22.2
         id: go
 
       - name: Validation checks

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-all:
 	@$(MAKE) --no-print-directory -j6 test-common test-deno ts-type-tests test-wasm-node test-wasm-browser lib-typecheck test-yarnpnp
 
 check-go-version:
-	@go version | grep ' go1\.20\.12 ' || (echo 'Please install Go version 1.20.12' && false)
+	@go version | grep ' go1\.22\.2 ' || (echo 'Please install Go version 1.22.2' && false)
 
 # Note: Don't add "-race" here by default. The Go race detector is currently
 # only supported on the following configurations:


### PR DESCRIPTION
### What happened？
There are high 1 security vulnerabilities found in Golang `1.20.12`
 
* [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m)
 
### What did I do？
Upgrade golang to `v1.22.2` on the github workflow. Basically addressing this [issue](https://github.com/evanw/esbuild/issues/3751)
 
### What did you expect to happen？
Ideally, no insecure library should be used.
 
### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

