### PR TITLE
Allow makefile addition to build Go wasip1 .wasm binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ platform-unixlike: version-go
 	@test -n "$(GOARCH)" || (echo "The environment variable GOARCH must be provided" && false)
 	@test -n "$(NPMDIR)" || (echo "The environment variable NPMDIR must be provided" && false)
 	node scripts/esbuild.js "$(NPMDIR)/package.json" --version
-	CGO_ENABLED=0 GOOS="$(GOOS)" GOARCH="$(GOARCH)" go build $(GO_FLAGS) -o "$(NPMDIR)/bin/esbuild" ./cmd/esbuild
+	CGO_ENABLED=0 GOOS="$(GOOS)" GOARCH="$(GOARCH)" go build $(GO_FLAGS) -o "$(NPMDIR)/bin/esbuild$(EXTENSION)" ./cmd/esbuild
 
 platform-android-x64: platform-wasm
 	node scripts/esbuild.js npm/@esbuild/android-x64/package.json --version
@@ -359,6 +359,9 @@ platform-netbsd-x64:
 
 platform-openbsd-x64:
 	@$(MAKE) --no-print-directory GOOS=openbsd GOARCH=amd64 NPMDIR=npm/@esbuild/openbsd-x64 platform-unixlike
+
+platform-wasip1:
+	@$(MAKE) --no-print-directory GOOS=wasip1 GOARCH=wasm NPMDIR=npm/@esbuild/wasip1-wasm platform-unixlike EXTENSION=.wasm
 
 platform-linux-x64:
 	@$(MAKE) --no-print-directory GOOS=linux GOARCH=amd64 NPMDIR=npm/@esbuild/linux-x64 platform-unixlike

--- a/npm/@esbuild/wasip1-wasm/README.md
+++ b/npm/@esbuild/wasip1-wasm/README.md
@@ -1,0 +1,3 @@
+# esbuild
+
+This is the wasip1 WAPI wasm binary for esbuild, a JavaScript bundler and minifier. See https://github.com/evanw/esbuild for details.

--- a/npm/@esbuild/wasip1-wasm/package.json
+++ b/npm/@esbuild/wasip1-wasm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@esbuild/wasm-wapi",
+  "version": "0.21.3",
+  "description": "The wasip1 WAPI wasm binary for esbuild, a JavaScript bundler.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/evanw/esbuild.git"
+  },
+  "license": "MIT",
+  "preferUnplugged": true,
+  "engines": {
+    "node": ">=12"
+  },
+  "os": [
+    "wasip1"
+  ],
+  "cpu": [
+    "wasm"
+  ]
+}


### PR DESCRIPTION
With Go supporting wasi (wasip1 os) now (as mentioned here: https://go.dev/blog/wasi & here https://github.com/evanw/esbuild/issues/3300), this PR adds a build option to the Makefile for a wasip1 wasm build.

Tested & runs prefectly fine with `wasmtime`:

```
wasmtime --dir=.::/ /npm/@esbuild/wasip1-wasm/bin/esbuild.wasm --help
```

^^ Heads up! In case of wasmtime, the `dir` arg needs exactly this content: `.::/` - which means `.` (local dir) maps to (`::`) `/` (root virtual filesystem).

The advantage of building wasi over the current wasm build (`platform-wasm`) is that the wasi build can run natively using CLI tools like `wasmtime`, and running in a node / JS environment is also compatible with several wasi browser runtimes. So: no need for the specific `esbuild-wasm` package, as one can execute the built `.wasm` with e.g. `@runno/wasi` or any other wasi implementation.

To run the same thing not on CLI but in a browser, all you need is this in a `<script type="module" ...`:

```javascript
import { WASI } from "@runno/wasi"

const esbuild_wasip1 = 'https://qkbtifg.dlvr.cloud/esbuild.wasm' // needs nginx mime type application/wasm wasm;

const result = WASI.start(fetch(esbuild_wasip1), {
  // env: { SOME_KEY: "some value" },
  args: ['esbuild', 'file.ts', '--bundle', '--minify', '--platform=browser', '--format=esm', '--target=es2017'],
  stdout: out => document.write(`<pre>${out}</pre>`),
  stderr: err => console.log("stderr:" + err),
  stdin: () => undefined,
  fs: {
    "/file.ts": {
      path: "/file.ts",
      timestamps: { access: new Date(), change: new Date(), modification: new Date(), },
      mode: "string",
      content: (`
        // Some TS content...
        const v: string = 'Trololo works like a charm!'
        console.log(v)
      `),
    },
  },
})
```