### PR TITLE
fix #2388: suppress type errors if lib.dom not enabled

### DIFF
--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -642,6 +642,7 @@ export interface InitializeOptions {
    * The URL of the "esbuild.wasm" file. This must be provided when running
    * esbuild in the browser.
    */
+  // @ts-ignore
   wasmURL?: string | URL
 
   /**
@@ -652,6 +653,7 @@ export interface InitializeOptions {
    * You can use this as an alternative to "wasmURL" for environments where it's
    * not possible to download the WebAssembly module.
    */
+  // @ts-ignore
   wasmModule?: WebAssembly.Module
 
   /**
@@ -681,25 +683,3 @@ export let version: string
 // killing it before the test ends, so you have to call this function (and
 // await the returned promise) in every Deno test that uses esbuild.
 export declare function stop(): Promise<void>
-
-// Note: These declarations exist to avoid type errors when you omit "dom" from
-// "lib" in your "tsconfig.json" file. TypeScript confusingly declares the
-// global "WebAssembly" type in "lib.dom.d.ts" even though it has nothing to do
-// with the browser DOM and is present in many non-browser JavaScript runtimes
-// (e.g. node and deno). Declaring it here allows esbuild's API to be used in
-// these scenarios.
-//
-// There's an open issue about getting this problem corrected (although these
-// declarations will need to remain even if this is fixed for backward
-// compatibility with older TypeScript versions):
-//
-//   https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/826
-//
-declare global {
-  namespace WebAssembly {
-    interface Module {
-    }
-  }
-  interface URL {
-  }
-}

--- a/scripts/ts-type-tests.js
+++ b/scripts/ts-type-tests.js
@@ -379,7 +379,11 @@ async function main() {
   const tsc = path.join(__dirname, 'node_modules', 'typescript', 'lib', 'tsc.js')
   const esbuild_d_ts = path.join(testDir, 'node_modules', 'esbuild', 'index.d.ts')
   fs.mkdirSync(path.dirname(esbuild_d_ts), { recursive: true })
-  fs.writeFileSync(esbuild_d_ts, types)
+  fs.writeFileSync(esbuild_d_ts, `
+    declare module 'esbuild' {
+      ${types.replace(/export declare/g, 'export')}
+    }
+  `)
   let allTestsPassed = true
 
   // Check tests without errors


### PR DESCRIPTION
Closes #2388
Supersedes #3679

![image](https://github.com/evanw/esbuild/assets/19991745/44ec84df-5908-4cb7-b27e-db05275b20cd)


Deno's VS Code extension pulls the URL type from the esbuild package, even with lib.dom enabled. This issue does not appear with VS Code's built-in TypeScript extension, but I can still see the definitions when I peek at type definitions, and it's confusing to see esbuild there.

To fix this, I added `// @ts-ignore` before the properties and removed global WebAssembly and URL types. This ensures that if lib.dom is available, the properties will have the correct types; otherwise, they default to any, avoiding type errors like in #2388.

/cc @remcohaszing 