### PR TITLE
update go 1.22.5 => 1.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.23.0
         id: go
 
       - name: Setup Node.js environment
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.23.0
         id: go
 
       - name: Setup Node.js environment
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.23.0
         id: go
 
       - name: Setup Node.js environment
@@ -274,7 +274,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.23.0
         id: go
 
       # Make sure esbuild works with old versions of Deno. Note: It's important

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.23.0
         id: go
 
       - name: Validation checks

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-all:
 	@$(MAKE) --no-print-directory -j6 test-common test-deno ts-type-tests test-wasm-node test-wasm-browser lib-typecheck test-yarnpnp
 
 check-go-version:
-	@go version | grep ' go1\.22\.5 ' || (echo 'Please install Go version 1.22.5' && false)
+	@go version | grep ' go1\.23\.0 ' || (echo 'Please install Go version 1.23.0' && false)
 
 # Note: Don't add "-race" here by default. The Go race detector is currently
 # only supported on the following configurations:


### PR DESCRIPTION
In version of the go compiler prior to `1.23.0`, `esbuild-wasm` can crash with the following stack trace:

```
✘ [ERROR] panic: runtime error: slice bounds out of range [:-4294967295]
(while printing "<some module>")

  debug.Stack (runtime/debug/stack.go:24)
  helpers.PrettyPrintedStack (internal/helpers/stack.go:9)
  linker.(*linkerContext).recoverInternalError
(internal/linker/linker.go:7084)
  panic (runtime/panic.go:884)
  js_printer.(*printer).printNonNegativeFloat
(internal/js_printer/js_printer.go:3524)
  js_printer.(*printer).printNumber (internal/js_printer/js_printer.go:522)
  js_printer.(*printer).printExpr (internal/js_printer/js_printer.go:3030)
  js_printer.(*binaryExprVisitor).visitRightAndFinish
(internal/js_printer/js_printer.go:3381)
  js_printer.(*printer).printExpr (internal/js_printer/js_printer.go:3231)
  js_printer.(*binaryExprVisitor).visitRightAndFinish
(internal/js_printer/js_printer.go:3381)
  js_printer.(*printer).printExpr (internal/js_printer/js_printer.go:3206)
  js_printer.(*printer).printStmt (internal/js_printer/js_printer.go:4782)
  js_printer.(*printer).printBlock (internal/js_printer/js_printer.go:3662)
  js_printer.(*printer).printBody (internal/js_printer/js_printer.go:3644)
  js_printer.(*printer).printStmt (internal/js_printer/js_printer.go:4530)
  js_printer.(*printer).printBlock (internal/js_printer/js_printer.go:3662)
  js_printer.(*printer).printFn (internal/js_printer/js_printer.go:898)
  js_printer.(*printer).printStmt (internal/js_printer/js_printer.go:4045)
  js_printer.Print (internal/js_printer/js_printer.go:4888)
  linker.(*linkerContext).generateCodeForFileInChunkJS
(internal/linker/linker.go:4919)
  linker.(*linkerContext).generateChunkJS (internal/linker/linker.go:5546)
```

This was due to a bug in `memchr` which was incorrectly treating memory addresses as signed integers.

It's now fixed in Go `1.23.0`: https://github.com/golang/go/commit/90c6558b6acef5a9b9fb8f3c35cff58423c8b00e

Original issue on the golang repository https://github.com/golang/go/issues/65571