### PR TITLE
build with golang 1.22.7 to address CVE-2024-34156

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.5
+          go-version: 1.22.7
         id: go
 
       - name: Setup Node.js environment


### PR DESCRIPTION
this high severity CVE was found in current release of esbuild as a result of being built with golang 1.22.5:

```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.22.5            │ 1.22.7, 1.23.1  │ encoding/gob: golang: Calling Decoder.Decode on a message   │
│         │                │          │        │                   │                 │ which contains deeply nested structures...                  │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-34156                  │
```

- [x] Bump golang to 1.22.7 in ci workflow (this PR)
- [ ] TODO: A follow up release / push to npm would be great after this is merge