### PR TITLE
Add platform support for netbsd-arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,7 @@ platform-all:
 		platform-linux-riscv64 \
 		platform-linux-s390x \
 		platform-linux-x64 \
+		platform-netbsd-arm64 \
 		platform-netbsd-x64 \
 		platform-neutral \
 		platform-openbsd-arm64 \
@@ -360,6 +361,9 @@ platform-freebsd-x64:
 
 platform-freebsd-arm64:
 	@$(MAKE) --no-print-directory GOOS=freebsd GOARCH=arm64 NPMDIR=npm/@esbuild/freebsd-arm64 platform-unixlike
+
+platform-netbsd-arm64:
+	@$(MAKE) --no-print-directory GOOS=netbsd GOARCH=arm64 NPMDIR=npm/@esbuild/netbsd-x64 platform-unixlike
 
 platform-netbsd-x64:
 	@$(MAKE) --no-print-directory GOOS=netbsd GOARCH=amd64 NPMDIR=npm/@esbuild/netbsd-x64 platform-unixlike
@@ -446,6 +450,7 @@ publish-all: check-go-version
 		publish-freebsd-arm64 \
 		publish-openbsd-arm64 \
 		publish-openbsd-x64 \
+		publish-netbsd-arm64 \
 		publish-netbsd-x64
 
 	@echo Enter one-time password:
@@ -521,6 +526,9 @@ publish-freebsd-x64: platform-freebsd-x64
 
 publish-freebsd-arm64: platform-freebsd-arm64
 	test -n "$(OTP)" && cd npm/@esbuild/freebsd-arm64 && npm publish --otp="$(OTP)"
+
+publish-netbsd-arm64: platform-netbsd-arm64
+	test -n "$(OTP)" && cd npm/@esbuild/netbsd-arm64 && npm publish --otp="$(OTP)"
 
 publish-netbsd-x64: platform-netbsd-x64
 	test -n "$(OTP)" && cd npm/@esbuild/netbsd-x64 && npm publish --otp="$(OTP)"
@@ -619,6 +627,7 @@ validate-builds:
 	@$(MAKE) --no-print-directory TARGET=platform-linux-riscv64  SCOPE=@esbuild/ PACKAGE=linux-riscv64   SUBPATH=bin/esbuild  validate-build
 	@$(MAKE) --no-print-directory TARGET=platform-linux-s390x    SCOPE=@esbuild/ PACKAGE=linux-s390x     SUBPATH=bin/esbuild  validate-build
 	@$(MAKE) --no-print-directory TARGET=platform-linux-x64      SCOPE=@esbuild/ PACKAGE=linux-x64       SUBPATH=bin/esbuild  validate-build
+	@$(MAKE) --no-print-directory TARGET=platform-netbsd-arm64   SCOPE=@esbuild/ PACKAGE=netbsd-arm64    SUBPATH=bin/esbuild  validate-build
 	@$(MAKE) --no-print-directory TARGET=platform-netbsd-x64     SCOPE=@esbuild/ PACKAGE=netbsd-x64      SUBPATH=bin/esbuild  validate-build
 	@$(MAKE) --no-print-directory TARGET=platform-openbsd-arm64  SCOPE=@esbuild/ PACKAGE=openbsd-arm64   SUBPATH=bin/esbuild  validate-build
 	@$(MAKE) --no-print-directory TARGET=platform-openbsd-x64    SCOPE=@esbuild/ PACKAGE=openbsd-x64     SUBPATH=bin/esbuild  validate-build
@@ -655,6 +664,7 @@ clean:
 	rm -rf npm/@esbuild/linux-riscv64/bin
 	rm -rf npm/@esbuild/linux-s390x/bin
 	rm -rf npm/@esbuild/linux-x64/bin
+	rm -rf npm/@esbuild/netbsd-arm64/bin
 	rm -rf npm/@esbuild/netbsd-x64/bin
 	rm -rf npm/@esbuild/openbsd-arm64/bin
 	rm -rf npm/@esbuild/openbsd-x64/bin

--- a/lib/npm/node-platform.ts
+++ b/lib/npm/node-platform.ts
@@ -41,6 +41,7 @@ export const knownUnixlikePackages: Record<string, string> = {
   'linux s390x BE': '@esbuild/linux-s390x',
   'linux x64 LE': '@esbuild/linux-x64',
   'linux loong64 LE': '@esbuild/linux-loong64',
+  'netbsd arm64 LE': '@esbuild/netbsd-arm64',
   'netbsd x64 LE': '@esbuild/netbsd-x64',
   'openbsd arm64 LE': '@esbuild/openbsd-arm64',
   'openbsd x64 LE': '@esbuild/openbsd-x64',

--- a/npm/@esbuild/netbsd-arm64/README.md
+++ b/npm/@esbuild/netbsd-arm64/README.md
@@ -1,0 +1,3 @@
+# esbuild
+
+This is the NetBSD ARM 64-bit binary for esbuild, a JavaScript bundler and minifier. See https://github.com/evanw/esbuild for details.

--- a/npm/@esbuild/netbsd-arm64/package.json
+++ b/npm/@esbuild/netbsd-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@esbuild/netbsd-arm64",
+  "version": "0.24.0",
+  "description": "The NetBSD ARM 64-bit binary for esbuild, a JavaScript bundler.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/evanw/esbuild.git"
+  },
+  "license": "MIT",
+  "preferUnplugged": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "netbsd"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/esbuild/package.json
+++ b/npm/esbuild/package.json
@@ -35,6 +35,7 @@
     "@esbuild/linux-riscv64": "0.24.0",
     "@esbuild/linux-s390x": "0.24.0",
     "@esbuild/linux-x64": "0.24.0",
+    "@esbuild/netbsd-arm64": "0.24.0",
     "@esbuild/netbsd-x64": "0.24.0",
     "@esbuild/openbsd-arm64": "0.24.0",
     "@esbuild/openbsd-x64": "0.24.0",


### PR DESCRIPTION
This is largely the same as the existing netbsd-x64 support. Both platforms are fully supported by Go, so this should just work.