### PR TITLE
Fix tsconfig target resolution for ES2024

### DIFF
--- a/internal/resolver/tsconfig_json.go
+++ b/internal/resolver/tsconfig_json.go
@@ -221,7 +221,7 @@ func ParseTSConfigJSON(
 				switch lowerValue {
 				case "es3", "es5", "es6", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021":
 					result.Settings.Target = config.TSTargetBelowES2022
-				case "es2022", "es2023", "esnext":
+				case "es2022", "es2023", "es2024", "esnext":
 					result.Settings.Target = config.TSTargetAtOrAboveES2022
 				default:
 					ok = false


### PR DESCRIPTION
See https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#support-for---target-es2024-and---lib-es2024

ESBuild already supports ES2024 as a build target, but its tsconfig `target` resolution is missing that case. This means that the following TS config:

```json
{
  "compilerOptions": {
    "target": "ES2024"
  }
}
```

Will cause ESBuild to error with:

```
Unrecognized target environment "ES2024"
```