### PR TITLE
fix #4010: allow `define` key to start with `import.`

### DIFF
--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -386,7 +386,7 @@ func validateSupported(log logger.Log, supported map[string]bool) (
 	return
 }
 
-func validateGlobalName(log logger.Log, text string, path string) []string {
+func validateGlobalName(log logger.Log, text string, path string, allowImportMeta bool) []string {
 	if text != "" {
 		source := logger.Source{
 			KeyPath:    logger.Path{Text: path},
@@ -394,7 +394,7 @@ func validateGlobalName(log logger.Log, text string, path string) []string {
 			Contents:   text,
 		}
 
-		if result, ok := js_parser.ParseGlobalName(log, source); ok {
+		if result, ok := js_parser.ParseGlobalName(log, source, allowImportMeta); ok {
 			return result
 		}
 	}
@@ -560,7 +560,7 @@ func validateDefines(
 
 	for _, key := range sortedKeys {
 		value := defines[key]
-		keyParts := validateGlobalName(log, key, "(define name)")
+		keyParts := validateGlobalName(log, key, "(define name)", true)
 		if keyParts == nil {
 			continue
 		}
@@ -669,7 +669,7 @@ func validateDefines(
 	}
 
 	for _, key := range pureFns {
-		keyParts := validateGlobalName(log, key, "(pure name)")
+		keyParts := validateGlobalName(log, key, "(pure name)", true)
 		if keyParts == nil {
 			continue
 		}
@@ -1271,7 +1271,7 @@ func validateBuildOptions(
 		ASCIIOnly:             validateASCIIOnly(buildOpts.Charset),
 		IgnoreDCEAnnotations:  buildOpts.IgnoreAnnotations,
 		TreeShaking:           validateTreeShaking(buildOpts.TreeShaking, buildOpts.Bundle, buildOpts.Format),
-		GlobalName:            validateGlobalName(log, buildOpts.GlobalName, "(global name)"),
+		GlobalName:            validateGlobalName(log, buildOpts.GlobalName, "(global name)", false),
 		CodeSplitting:         buildOpts.Splitting,
 		OutputFormat:          validateFormat(buildOpts.Format),
 		AbsOutputFile:         validatePath(log, realFS, buildOpts.Outfile, "outfile path"),
@@ -1715,7 +1715,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 		SourceRoot:            transformOpts.SourceRoot,
 		ExcludeSourcesContent: transformOpts.SourcesContent == SourcesContentExclude,
 		OutputFormat:          validateFormat(transformOpts.Format),
-		GlobalName:            validateGlobalName(log, transformOpts.GlobalName, "(global name)"),
+		GlobalName:            validateGlobalName(log, transformOpts.GlobalName, "(global name)", false),
 		MinifySyntax:          transformOpts.MinifySyntax,
 		MinifyWhitespace:      transformOpts.MinifyWhitespace,
 		MinifyIdentifiers:     transformOpts.MinifyIdentifiers,

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -6137,6 +6137,14 @@ class Foo {
     assert.strictEqual(code, `(() => {\n  const import_meta = {};\n  console.log(import_meta, import_meta.foo);\n})();\n`)
   },
 
+  async defineImportMetaAsIdentifier({ esbuild }) {
+    const { code: code1 } = await esbuild.transform(`console.log(import.meta); export {}`, { define: { 'import.meta': 'import_meta' }, format: 'esm' })
+    assert.strictEqual(code1, `console.log(import_meta);\n`)
+
+    const { code: code2 } = await esbuild.transform(`console.log(import.meta.aaa); export {}`, { define: { 'import.meta.aaa': 'import_meta_url' }, format: 'esm' })
+    assert.strictEqual(code2, `console.log(import_meta_url);\n`)
+  },
+
   async defineIdentifierVsStringWarningIssue466Transform({ esbuild }) {
     const { warnings } = await esbuild.transform(``, { define: { 'process.env.NODE_ENV': 'production' } })
     const formatted = await esbuild.formatMessages(warnings, { kind: 'warning' })
@@ -6180,6 +6188,9 @@ class Foo {
 
     const { code: code5 } = await esbuild.transform(`foo(x['y'].z, x.y['z'], x['y']['z'])`, { define: { 'x["y"][\'z\']': 'true' } })
     assert.strictEqual(code5, `foo(true, true, true);\n`)
+
+    const { code: code6 } = await esbuild.transform(`foo(import.meta['y'].z, import.meta.y['z'], import.meta['y']['z'])`, { define: { 'import.meta["y"].z': 'true' } })
+    assert.strictEqual(code6, `foo(true, true, true);\n`)
   },
 
   async defineQuotedPropertyNameBuild({ esbuild }) {
@@ -6523,6 +6534,14 @@ class Foo {
     assert.strictEqual(code1, `console.log(123, foo);\n`)
 
     const { code: code2 } = await esbuild.transform(`console.log(123, foo)`, { minifySyntax: true, pure: ['console.log'] })
+    assert.strictEqual(code2, `foo;\n`)
+  },
+
+  async pureImportMeta({ esbuild }) {
+    const { code: code1 } = await esbuild.transform(`import.meta.foo(123, foo)`, { minifySyntax: true, pure: [] })
+    assert.strictEqual(code1, `import.meta.foo(123, foo);\n`)
+
+    const { code: code2 } = await esbuild.transform(`import.meta.foo(123, foo)`, { minifySyntax: true, pure: ['import.meta.foo'] })
     assert.strictEqual(code2, `foo;\n`)
   },
 


### PR DESCRIPTION
fixes #4010 
fixes #4012

Added `import.*` handling for `ParseGlobalName` function to allow `import.*` to be used in `define` / `pure` options.
