### PR TITLE
(CSS) Fix nesting lowering with complex sub selectors

### DIFF
--- a/internal/css_parser/css_nesting.go
+++ b/internal/css_parser/css_nesting.go
@@ -151,6 +151,15 @@ func (p *parser) lowerNestingInRuleWithContext(rule css_ast.Rule, context *lower
 				} else if commonLeadingCombinator.Byte != combinator.Byte {
 					canUseGroupDescendantCombinator = false
 				}
+
+				// If the complex selector contains multiple combinators (e.g., "& «COMBINATOR» «something» «COMBINATOR» «something»"),
+				// we cannot safely transform it into "parent :is(...selectors)". See https://github.com/evanw/esbuild/issues/3620.
+				for _, subSelector := range sel.Selectors[2:] {
+					if subSelector.Combinator.Byte != 0 {
+						canUseGroupDescendantCombinator = false
+						break
+					}
+				}
 			}
 
 			// Are all children of the form "&«something»"?

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1261,6 +1261,7 @@ func TestNestedSelector(t *testing.T) {
 	expectPrintedLowerUnsupported(t, nesting, ".demo { .lg { &.triangle, &.circle { color: red } } }", ".demo .lg:is(.triangle, .circle) {\n  color: red;\n}\n", "")
 	expectPrintedLowerUnsupported(t, nesting, ".demo { .lg { .triangle, .circle { color: red } } }", ".demo .lg :is(.triangle, .circle) {\n  color: red;\n}\n", "")
 	expectPrintedLowerUnsupported(t, nesting, ".card { .featured & & & { color: red } }", ".featured .card .card .card {\n  color: red;\n}\n", "")
+	expectPrintedLowerUnsupported(t, nesting, ".parent { > .a, > .b1 > .b2 { color: red } }", ".parent > .a,\n.parent > .b1 > .b2 {\n  color: red;\n}\n", "")
 
 	// These are invalid SASS-style nested suffixes
 	expectPrintedLower(t, ".card { &--header { color: red } }", ".card {\n  &--header {\n    color: red;\n  }\n}\n",


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/evanw/esbuild/issues/3620.

When nesting is lowered (for example when the target is Chrome 117) the current version of esbuild will transform this:
```css
.parent {
  > .a,
  > .b1 > .b2 {
    color: red;
  }
}
```
into this ([playground link](https://esbuild.github.io/try/#dAAwLjI0LjIALS1sb2FkZXI9Y3NzIC0tdGFyZ2V0PWNocm9tZTExNwAucGFyZW50IHsKICA+IC5hLAogID4gLmIxID4gLmIyIHsKICAgIGNvbG9yOiByZWQ7CiAgfQp9))
```css
.parent > :is(.a, .b1 > .b2) {
  color: red;
}
```
which is wrong because `.parent > :is(.b1 > .b2)` is semantically different from `.parent > .b1 > .b2`.

With the change in this PR the output will instead be this:
```css
.parent > .a,
.parent > .b1 > .b2 {
  color: red;
}
```

I have added a test for this as well. The fix is in the first pass of the `lowerNestingInRuleWithContext` method. When a nested complex selector is sufficiently complex (has another combinator) the transformation will be disabled.