### PR TITLE
close #4039: throw when wasm init caught an error

### DIFF
--- a/lib/deno/wasm.ts
+++ b/lib/deno/wasm.ts
@@ -75,9 +75,10 @@ export const initialize: typeof types.initialize = async (options) => {
   let useWorker = options.worker !== false
   if (initializePromise) throw new Error('Cannot call "initialize" more than once')
   initializePromise = startRunningService(wasmURL || 'esbuild.wasm', wasmModule, useWorker)
-  initializePromise.catch(() => {
+  initializePromise.catch((error) => {
     // Let the caller try again if this fails
     initializePromise = void 0
+    throw error
   })
   await initializePromise
 }

--- a/lib/npm/browser.ts
+++ b/lib/npm/browser.ts
@@ -74,9 +74,10 @@ export const initialize: typeof types.initialize = options => {
   if (!wasmURL && !wasmModule) throw new Error('Must provide either the "wasmURL" option or the "wasmModule" option')
   if (initializePromise) throw new Error('Cannot call "initialize" more than once')
   initializePromise = startRunningService(wasmURL || '', wasmModule, useWorker)
-  initializePromise.catch(() => {
+  initializePromise.catch((error) => {
     // Let the caller try again if this fails
     initializePromise = void 0
+    throw error
   })
   return initializePromise
 }


### PR DESCRIPTION
Throw error to caller when esbuild-wasm initialize failed

The change is made to:
- `lib/deno/wasm.ts`
- `lib/npm/browser.ts`

### Note:

This may be a breaking change.
- Prior to this change, `initialize` will never throw error.
- After this change, `initialize` will throw error

## Motivation

close #4039

