### PR TITLE
fix: windows replace access denied error to EPERM

### DIFF
--- a/internal/fs/fs_real.go
+++ b/internal/fs/fs_real.go
@@ -395,6 +395,13 @@ func (fs *realFS) canonicalizeError(err error) error {
 		err = syscall.ENOENT
 	}
 
+	// On Windows, attempting to access a folder without read permissions 
+	// results in an "Access denied." error instead of EPERM.  
+	// To ensure consistency, this error is replaced with EPERM.
+	if fs.fp.isWindows && os.IsPermission(err) {
+		err = syscall.EPERM
+	}
+
 	// Windows returns ENOTDIR here even though nothing we've done yet has asked
 	// for a directory. This really means ENOENT on Windows. Return ENOENT here
 	// so callers that check for ENOENT will successfully detect this file as


### PR DESCRIPTION
Fix #3783 #4017

On Windows, accessing a folder without read permissions results in an "access denied" error instead of EPERM. 
To ensure consistency across platforms, this error is now replaced with EPERM.

In restricted environments, users may not have permission to read the root folder of the disk.
![disk](https://github.com/user-attachments/assets/a8a9b7af-fdbf-4f36-8c6b-d4398b5038ef)

