### PR TITLE
Fix emitting real mapping sources when null mapping comes first

### DIFF
--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -6963,13 +6963,13 @@ func (c *linkerContext) generateSourceMapForChunk(
 	items := make([]item, 0, len(results))
 	nextSourcesIndex := 0
 	for _, result := range results {
+		if result.isNullEntry {
+			continue
+		}
 		if _, ok := sourceIndexToSourcesIndex[result.sourceIndex]; ok {
 			continue
 		}
 		sourceIndexToSourcesIndex[result.sourceIndex] = nextSourcesIndex
-		if result.isNullEntry {
-			continue
-		}
 		file := &c.graph.Files[result.sourceIndex]
 
 		// Simple case: no nested source map
@@ -7057,7 +7057,10 @@ func (c *linkerContext) generateSourceMapForChunk(
 	for _, result := range results {
 		chunk := result.sourceMapChunk
 		offset := result.generatedOffset
-		sourcesIndex := sourceIndexToSourcesIndex[result.sourceIndex]
+		sourcesIndex, ok := sourceIndexToSourcesIndex[result.sourceIndex]
+		if !ok {
+			continue
+		}
 
 		// This should have already been checked earlier
 		if chunk.ShouldIgnore {

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -7059,7 +7059,13 @@ func (c *linkerContext) generateSourceMapForChunk(
 		offset := result.generatedOffset
 		sourcesIndex, ok := sourceIndexToSourcesIndex[result.sourceIndex]
 		if !ok {
-			continue
+			// If there's no sourcesIndex, then every mapping for this result's
+			// sourceIndex were null mappings. We still need to emit the null
+			// mapping, but its source index won't matter.
+			sourcesIndex = 0
+			if !result.isNullEntry {
+				panic("Internal error")
+			}
 		}
 
 		// This should have already been checked earlier


### PR DESCRIPTION
This fixes an ordering bug when a null mapping and a real mapping share the same `sourceIndex`. If a null mapping comes first, then we'll assign it a `sourceIndexToSourcesIndex` but skip recording its source files in the `items` array because of the `isNullEntry` check. When we find the real mapping later in `results`, we'll skip recording its source files because of the map-`ok` check.

The simplest fix I can think of is flipping the order just a bit. We'll skip assigning `sourceIndexToSourcesIndex` for null mappings, so that when a real mapping comes up we'll record its sources.

I'm not sure how to generate a unit test case for this, but it resolves the issue found in https://github.com/angular/angular-cli/issues/29465#issue-2807308693.

Fixes #4080
Fixes #4107