### PR TITLE
fix CORS with live reloading

### DIFF
--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -383,6 +383,7 @@ func (h *apiHandler) serveEventStream(start time.Time, req *http.Request, res ht
 			res.Header().Set("Content-Type", "text/event-stream")
 			res.Header().Set("Connection", "keep-alive")
 			res.Header().Set("Cache-Control", "no-cache")
+			res.Header().Set("Access-Control-Allow-Origin", "*")
 			go h.notifyRequest(time.Since(start), req, http.StatusOK)
 			res.WriteHeader(http.StatusOK)
 			res.Write([]byte("retry: 500\n"))


### PR DESCRIPTION
Just add the permissive header to allow cross origin request, so live reloading works when serving files with another http server.

Use case : a Go application with an http server, serving static files (including JS files) and esbuild server for watching files modification. If the JS file is not served by the esbuild server, requests to /esbuild are blocked with "CORS Missing Allow Origin".

I presume allowing this in development mode may be acceptable.