### PR TITLE
fix(cli): --watch normalisation with=true

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -222,11 +222,11 @@ func main() {
 			// This may be a reasonable thing to do in a short-lived VM where all
 			// processes in the VM are only started once and then the VM is killed
 			// when the processes are no longer needed.
-			if arg == "--watch" {
-				isWatch = true
-			} else if arg == "--watch=forever" {
+			if arg == "--watch=forever" {
 				arg = "--watch"
 				isWatchForever = true
+			} else if strings.HasPrefix(arg, "--watch") {
+				isWatch = true
 			}
 
 			// Strip any arguments that were handled above
@@ -300,7 +300,7 @@ func main() {
 			for _, arg := range osArgs {
 				if !strings.HasPrefix(arg, "-") {
 					nonFlagCount++
-				} else if arg == "--serve" || arg == "--watch" || strings.HasPrefix(arg, "--serve=") {
+				} else if arg == "--watch" || strings.HasPrefix(arg, "--watch=") || arg == "--serve" || strings.HasPrefix(arg, "--serve=") {
 					isServeOrWatch = true
 				}
 			}


### PR DESCRIPTION
This aligns it with how the internal CLI parser accepts `--watch=true` which was implemented in https://github.com/evanw/esbuild/commit/ce04765e63fda0ec8d39dc0265970a8396abecdd.

Before `--watch=true` was not correctly identified as "Watch Mode" and disabled the GC as a drive by. This caused memory leaks.

Resolves https://github.com/evanw/esbuild/issues/4131