### PR TITLE
fix: install corepack from npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,10 +195,9 @@ jobs:
 
       - name: Yarn PnP tests
         run: |
-          # Note that Yarn recently deliberately broke "npm install -g yarn".
-          # They say you now have to run "corepack enable" to fix it. They have
-          # written about this here: https://yarnpkg.com/corepack
-          corepack enable
+          # Yarn recommends managing it's version though corepack.
+          # They have written about this here: https://yarnpkg.com/corepack
+          npm i -g corepack
 
           make test-yarnpnp
 


### PR DESCRIPTION
Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

This PR updates the command to globally installing corepack.