### PR TITLE
fix #4141: Avoid redundant `this` access during async function lowering

### DIFF
--- a/internal/bundler_tests/bundler_lower_test.go
+++ b/internal/bundler_tests/bundler_lower_test.go
@@ -786,6 +786,18 @@ func TestLowerAsync2016NoBundle(t *testing.T) {
 					return [this, arguments]
 				}
 				class Foo {async foo() {}}
+				new (class Bar extends class { } {
+					constructor() {
+						let x = 1;
+						(async () => {
+							console.log("before super", x);  // (1) Sync phase
+							await 1;
+							console.log("after super", x);   // (2) Async phase
+						})();
+						super();
+						x = 2;
+					}
+				})();
 				export default [
 					foo,
 					Foo,

--- a/internal/bundler_tests/snapshots/snapshots_lower.txt
+++ b/internal/bundler_tests/snapshots/snapshots_lower.txt
@@ -819,26 +819,39 @@ function foo(_0) {
 }
 class Foo {
   foo() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
     });
   }
 }
+new class Bar extends class {
+} {
+  constructor() {
+    let x = 1;
+    (() => __async(null, null, function* () {
+      console.log("before super", x);
+      yield 1;
+      console.log("after super", x);
+    }))();
+    super();
+    x = 2;
+  }
+}();
 export default [
   foo,
   Foo,
   function() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
     });
   },
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
   }),
   { foo() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
     });
   } },
   class {
     foo() {
-      return __async(this, null, function* () {
+      return __async(null, null, function* () {
       });
     }
   },
@@ -889,7 +902,7 @@ TestLowerAsyncArrowSuperES2016
 // foo1.js
 var foo1_default = class _foo1_default extends x {
   foo1() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return __superGet(_foo1_default.prototype, this, "foo").call(this, "foo1");
     });
   }
@@ -898,7 +911,7 @@ var foo1_default = class _foo1_default extends x {
 // foo2.js
 var foo2_default = class _foo2_default extends x {
   foo2() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return () => __superGet(_foo2_default.prototype, this, "foo").call(this, "foo2");
     });
   }
@@ -907,7 +920,7 @@ var foo2_default = class _foo2_default extends x {
 // foo3.js
 var foo3_default = class _foo3_default extends x {
   foo3() {
-    return () => () => __async(this, null, function* () {
+    return () => () => __async(null, null, function* () {
       return __superGet(_foo3_default.prototype, this, "foo").call(this, "foo3");
     });
   }
@@ -916,8 +929,8 @@ var foo3_default = class _foo3_default extends x {
 // foo4.js
 var foo4_default = class _foo4_default extends x {
   foo4() {
-    return () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superGet(_foo4_default.prototype, this, "foo").call(this, "foo4");
       });
     });
@@ -928,7 +941,7 @@ var foo4_default = class _foo4_default extends x {
 var bar1_default = class _bar1_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar1", () => __async(this, null, function* () {
+    __publicField(this, "bar1", () => __async(null, null, function* () {
       return __superGet(_bar1_default.prototype, this, "foo").call(this, "bar1");
     }));
   }
@@ -938,7 +951,7 @@ var bar1_default = class _bar1_default extends x {
 var bar2_default = class _bar2_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar2", () => __async(this, null, function* () {
+    __publicField(this, "bar2", () => __async(null, null, function* () {
       return () => __superGet(_bar2_default.prototype, this, "foo").call(this, "bar2");
     }));
   }
@@ -948,7 +961,7 @@ var bar2_default = class _bar2_default extends x {
 var bar3_default = class _bar3_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar3", () => () => __async(this, null, function* () {
+    __publicField(this, "bar3", () => () => __async(null, null, function* () {
       return __superGet(_bar3_default.prototype, this, "foo").call(this, "bar3");
     }));
   }
@@ -958,8 +971,8 @@ var bar3_default = class _bar3_default extends x {
 var bar4_default = class _bar4_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar4", () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    __publicField(this, "bar4", () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superGet(_bar4_default.prototype, this, "foo").call(this, "bar4");
       });
     }));
@@ -969,7 +982,7 @@ var bar4_default = class _bar4_default extends x {
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   baz1() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => __superGet(_baz1_default.prototype, this, "foo").call(this, "baz1");
     });
   }
@@ -978,7 +991,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   baz2() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => () => __superGet(_baz2_default.prototype, this, "foo").call(this, "baz2");
     });
   }
@@ -986,11 +999,11 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     class y extends z {
       constructor() {
         super(...arguments);
-        __publicField(this, "foo", () => __async(this, null, function* () {
+        __publicField(this, "foo", () => __async(null, null, function* () {
           return __superGet(y.prototype, this, "foo").call(this);
         }));
       }
@@ -1017,7 +1030,7 @@ TestLowerAsyncArrowSuperSetterES2016
 // foo1.js
 var foo1_default = class _foo1_default extends x {
   foo1() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return __superSet(_foo1_default.prototype, this, "foo", "foo1");
     });
   }
@@ -1026,7 +1039,7 @@ var foo1_default = class _foo1_default extends x {
 // foo2.js
 var foo2_default = class _foo2_default extends x {
   foo2() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return () => __superSet(_foo2_default.prototype, this, "foo", "foo2");
     });
   }
@@ -1035,7 +1048,7 @@ var foo2_default = class _foo2_default extends x {
 // foo3.js
 var foo3_default = class _foo3_default extends x {
   foo3() {
-    return () => () => __async(this, null, function* () {
+    return () => () => __async(null, null, function* () {
       return __superSet(_foo3_default.prototype, this, "foo", "foo3");
     });
   }
@@ -1044,8 +1057,8 @@ var foo3_default = class _foo3_default extends x {
 // foo4.js
 var foo4_default = class _foo4_default extends x {
   foo4() {
-    return () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superSet(_foo4_default.prototype, this, "foo", "foo4");
       });
     });
@@ -1056,7 +1069,7 @@ var foo4_default = class _foo4_default extends x {
 var bar1_default = class _bar1_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar1", () => __async(this, null, function* () {
+    __publicField(this, "bar1", () => __async(null, null, function* () {
       return __superSet(_bar1_default.prototype, this, "foo", "bar1");
     }));
   }
@@ -1066,7 +1079,7 @@ var bar1_default = class _bar1_default extends x {
 var bar2_default = class _bar2_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar2", () => __async(this, null, function* () {
+    __publicField(this, "bar2", () => __async(null, null, function* () {
       return () => __superSet(_bar2_default.prototype, this, "foo", "bar2");
     }));
   }
@@ -1076,7 +1089,7 @@ var bar2_default = class _bar2_default extends x {
 var bar3_default = class _bar3_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar3", () => () => __async(this, null, function* () {
+    __publicField(this, "bar3", () => () => __async(null, null, function* () {
       return __superSet(_bar3_default.prototype, this, "foo", "bar3");
     }));
   }
@@ -1086,8 +1099,8 @@ var bar3_default = class _bar3_default extends x {
 var bar4_default = class _bar4_default extends x {
   constructor() {
     super(...arguments);
-    __publicField(this, "bar4", () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    __publicField(this, "bar4", () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superSet(_bar4_default.prototype, this, "foo", "bar4");
       });
     }));
@@ -1097,7 +1110,7 @@ var bar4_default = class _bar4_default extends x {
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   baz1() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => __superSet(_baz1_default.prototype, this, "foo", "baz1");
     });
   }
@@ -1106,7 +1119,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   baz2() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => () => __superSet(_baz2_default.prototype, this, "foo", "baz2");
     });
   }
@@ -1114,11 +1127,11 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     class y extends z {
       constructor() {
         super(...arguments);
-        __publicField(this, "foo", () => __async(this, null, function* () {
+        __publicField(this, "foo", () => __async(null, null, function* () {
           return __superSet(y.prototype, this, "foo", "foo");
         }));
       }
@@ -1143,7 +1156,7 @@ export {
 TestLowerAsyncGenerator
 ---------- /out/entry.js ----------
 function foo() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1196,7 +1209,7 @@ function foo() {
   });
 }
 foo = function() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1249,7 +1262,7 @@ foo = function() {
   });
 };
 foo = { bar() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1303,7 +1316,7 @@ foo = { bar() {
 } };
 class Foo {
   bar() {
-    return __asyncGenerator(this, null, function* () {
+    return __asyncGenerator(null, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1358,7 +1371,7 @@ class Foo {
 }
 Foo = class {
   bar() {
-    return __asyncGenerator(this, null, function* () {
+    return __asyncGenerator(null, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1423,7 +1436,7 @@ async function bar() {
 TestLowerAsyncGeneratorNoAwait
 ---------- /out/entry.js ----------
 function foo() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1476,7 +1489,7 @@ function foo() {
   });
 }
 foo = function() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1529,7 +1542,7 @@ foo = function() {
   });
 };
 foo = { bar() {
-  return __asyncGenerator(this, null, function* () {
+  return __asyncGenerator(null, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1583,7 +1596,7 @@ foo = { bar() {
 } };
 class Foo {
   bar() {
-    return __asyncGenerator(this, null, function* () {
+    return __asyncGenerator(null, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1638,7 +1651,7 @@ class Foo {
 }
 Foo = class {
   bar() {
-    return __asyncGenerator(this, null, function* () {
+    return __asyncGenerator(null, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1692,7 +1705,7 @@ Foo = class {
   }
 };
 function bar() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     var _stack2 = [];
     try {
       const x = __using(_stack2, yield y, true);
@@ -1723,7 +1736,7 @@ TestLowerAsyncSuperES2016NoBundle
 ---------- /out.js ----------
 class Derived extends Base {
   test(key) {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       var _a, _b, _c, _d;
       return [
         yield __superGet(Derived.prototype, this, "foo"),
@@ -1756,7 +1769,7 @@ class Derived extends Base {
     });
   }
 }
-let fn = () => __async(this, null, function* () {
+let fn = () => __async(null, null, function* () {
   return class extends Base {
     constructor() {
       super(...arguments);
@@ -1774,7 +1787,7 @@ let fn = () => __async(this, null, function* () {
 class Derived2 extends Base {
   constructor() {
     super(...arguments);
-    __publicField(this, "b", () => __async(this, null, function* () {
+    __publicField(this, "b", () => __async(null, null, function* () {
       var _a;
       return _a = __superGet(Derived2.prototype, this, "foo"), class {
         constructor() {
@@ -1784,7 +1797,7 @@ class Derived2 extends Base {
     }));
   }
   a() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       var _a;
       return _a = __superGet(Derived2.prototype, this, "foo"), class {
         constructor() {
@@ -1803,7 +1816,7 @@ for (let i = 0; i < 3; i++) {
       }
     },
     bar() {
-      return __async(this, null, function* () {
+      return __async(null, null, function* () {
         return __superGet(_a, this, "foo").call(this);
       });
     }
@@ -1910,7 +1923,7 @@ export default require_entry();
 TestLowerAsyncThis2016ES6
 ---------- /out.js ----------
 // other.js
-var bar = () => __async(void 0, null, function* () {
+var bar = () => __async(null, null, function* () {
 });
 
 // entry.js
@@ -2038,7 +2051,7 @@ export { ns2 as sn };
 TestLowerForAwait2015
 ---------- /out.js ----------
 export default [
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         x = temp.value;
@@ -2055,7 +2068,7 @@ export default [
       }
     }
   }),
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         x.y = temp.value;
@@ -2072,7 +2085,7 @@ export default [
       }
     }
   }),
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         let x2 = temp.value;
@@ -2089,7 +2102,7 @@ export default [
       }
     }
   }),
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         const x2 = temp.value;
@@ -2106,7 +2119,7 @@ export default [
       }
     }
   }),
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       label: for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         const x2 = temp.value;
@@ -2123,7 +2136,7 @@ export default [
       }
     }
   }),
-  () => __async(void 0, null, function* () {
+  () => __async(null, null, function* () {
     try {
       label: for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {
         const x2 = temp.value;
@@ -3326,7 +3339,7 @@ TestLowerStaticAsyncArrowSuperES2016
 // foo1.js
 var foo1_default = class _foo1_default extends x {
   static foo1() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return __superGet(_foo1_default, this, "foo").call(this, "foo1");
     });
   }
@@ -3335,7 +3348,7 @@ var foo1_default = class _foo1_default extends x {
 // foo2.js
 var foo2_default = class _foo2_default extends x {
   static foo2() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return () => __superGet(_foo2_default, this, "foo").call(this, "foo2");
     });
   }
@@ -3344,7 +3357,7 @@ var foo2_default = class _foo2_default extends x {
 // foo3.js
 var foo3_default = class _foo3_default extends x {
   static foo3() {
-    return () => () => __async(this, null, function* () {
+    return () => () => __async(null, null, function* () {
       return __superGet(_foo3_default, this, "foo").call(this, "foo3");
     });
   }
@@ -3353,8 +3366,8 @@ var foo3_default = class _foo3_default extends x {
 // foo4.js
 var foo4_default = class _foo4_default extends x {
   static foo4() {
-    return () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superGet(_foo4_default, this, "foo").call(this, "foo4");
       });
     });
@@ -3364,7 +3377,7 @@ var foo4_default = class _foo4_default extends x {
 // bar1.js
 var _bar1_default = class _bar1_default extends x {
 };
-__publicField(_bar1_default, "bar1", () => __async(_bar1_default, null, function* () {
+__publicField(_bar1_default, "bar1", () => __async(null, null, function* () {
   return __superGet(_bar1_default, _bar1_default, "foo").call(this, "bar1");
 }));
 var bar1_default = _bar1_default;
@@ -3372,7 +3385,7 @@ var bar1_default = _bar1_default;
 // bar2.js
 var _bar2_default = class _bar2_default extends x {
 };
-__publicField(_bar2_default, "bar2", () => __async(_bar2_default, null, function* () {
+__publicField(_bar2_default, "bar2", () => __async(null, null, function* () {
   return () => __superGet(_bar2_default, _bar2_default, "foo").call(this, "bar2");
 }));
 var bar2_default = _bar2_default;
@@ -3380,7 +3393,7 @@ var bar2_default = _bar2_default;
 // bar3.js
 var _bar3_default = class _bar3_default extends x {
 };
-__publicField(_bar3_default, "bar3", () => () => __async(_bar3_default, null, function* () {
+__publicField(_bar3_default, "bar3", () => () => __async(null, null, function* () {
   return __superGet(_bar3_default, _bar3_default, "foo").call(this, "bar3");
 }));
 var bar3_default = _bar3_default;
@@ -3388,8 +3401,8 @@ var bar3_default = _bar3_default;
 // bar4.js
 var _bar4_default = class _bar4_default extends x {
 };
-__publicField(_bar4_default, "bar4", () => __async(_bar4_default, null, function* () {
-  return () => __async(_bar4_default, null, function* () {
+__publicField(_bar4_default, "bar4", () => __async(null, null, function* () {
+  return () => __async(null, null, function* () {
     return __superGet(_bar4_default, _bar4_default, "foo").call(this, "bar4");
   });
 }));
@@ -3398,7 +3411,7 @@ var bar4_default = _bar4_default;
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   static baz1() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => __superGet(_baz1_default, this, "foo").call(this, "baz1");
     });
   }
@@ -3407,7 +3420,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   static baz2() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => () => __superGet(_baz2_default, this, "foo").call(this, "baz2");
     });
   }
@@ -3415,10 +3428,10 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     const _y = class _y extends z {
     };
-    __publicField(_y, "foo", () => __async(_y, null, function* () {
+    __publicField(_y, "foo", () => __async(null, null, function* () {
       return __superGet(_y, _y, "foo").call(this);
     }));
     let y = _y;
@@ -3444,7 +3457,7 @@ TestLowerStaticAsyncArrowSuperSetterES2016
 // foo1.js
 var foo1_default = class _foo1_default extends x {
   static foo1() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return __superSet(_foo1_default, this, "foo", "foo1");
     });
   }
@@ -3453,7 +3466,7 @@ var foo1_default = class _foo1_default extends x {
 // foo2.js
 var foo2_default = class _foo2_default extends x {
   static foo2() {
-    return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
       return () => __superSet(_foo2_default, this, "foo", "foo2");
     });
   }
@@ -3462,7 +3475,7 @@ var foo2_default = class _foo2_default extends x {
 // foo3.js
 var foo3_default = class _foo3_default extends x {
   static foo3() {
-    return () => () => __async(this, null, function* () {
+    return () => () => __async(null, null, function* () {
       return __superSet(_foo3_default, this, "foo", "foo3");
     });
   }
@@ -3471,8 +3484,8 @@ var foo3_default = class _foo3_default extends x {
 // foo4.js
 var foo4_default = class _foo4_default extends x {
   static foo4() {
-    return () => __async(this, null, function* () {
-      return () => __async(this, null, function* () {
+    return () => __async(null, null, function* () {
+      return () => __async(null, null, function* () {
         return __superSet(_foo4_default, this, "foo", "foo4");
       });
     });
@@ -3482,7 +3495,7 @@ var foo4_default = class _foo4_default extends x {
 // bar1.js
 var _bar1_default = class _bar1_default extends x {
 };
-__publicField(_bar1_default, "bar1", () => __async(_bar1_default, null, function* () {
+__publicField(_bar1_default, "bar1", () => __async(null, null, function* () {
   return __superSet(_bar1_default, _bar1_default, "foo", "bar1");
 }));
 var bar1_default = _bar1_default;
@@ -3490,7 +3503,7 @@ var bar1_default = _bar1_default;
 // bar2.js
 var _bar2_default = class _bar2_default extends x {
 };
-__publicField(_bar2_default, "bar2", () => __async(_bar2_default, null, function* () {
+__publicField(_bar2_default, "bar2", () => __async(null, null, function* () {
   return () => __superSet(_bar2_default, _bar2_default, "foo", "bar2");
 }));
 var bar2_default = _bar2_default;
@@ -3498,7 +3511,7 @@ var bar2_default = _bar2_default;
 // bar3.js
 var _bar3_default = class _bar3_default extends x {
 };
-__publicField(_bar3_default, "bar3", () => () => __async(_bar3_default, null, function* () {
+__publicField(_bar3_default, "bar3", () => () => __async(null, null, function* () {
   return __superSet(_bar3_default, _bar3_default, "foo", "bar3");
 }));
 var bar3_default = _bar3_default;
@@ -3506,8 +3519,8 @@ var bar3_default = _bar3_default;
 // bar4.js
 var _bar4_default = class _bar4_default extends x {
 };
-__publicField(_bar4_default, "bar4", () => __async(_bar4_default, null, function* () {
-  return () => __async(_bar4_default, null, function* () {
+__publicField(_bar4_default, "bar4", () => __async(null, null, function* () {
+  return () => __async(null, null, function* () {
     return __superSet(_bar4_default, _bar4_default, "foo", "bar4");
   });
 }));
@@ -3516,7 +3529,7 @@ var bar4_default = _bar4_default;
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   static baz1() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => __superSet(_baz1_default, this, "foo", "baz1");
     });
   }
@@ -3525,7 +3538,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   static baz2() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       return () => () => __superSet(_baz2_default, this, "foo", "baz2");
     });
   }
@@ -3533,10 +3546,10 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     const _y = class _y extends z {
     };
-    __publicField(_y, "foo", () => __async(_y, null, function* () {
+    __publicField(_y, "foo", () => __async(null, null, function* () {
       return __superSet(_y, _y, "foo", "foo");
     }));
     let y = _y;
@@ -3561,7 +3574,7 @@ TestLowerStaticAsyncSuperES2016NoBundle
 ---------- /out.js ----------
 const _Derived = class _Derived extends Base {
 };
-__publicField(_Derived, "test", (key) => __async(_Derived, null, function* () {
+__publicField(_Derived, "test", (key) => __async(null, null, function* () {
   var _a, _b, _c, _d;
   return [
     yield __superGet(_Derived, _Derived, "foo"),
@@ -3593,7 +3606,7 @@ __publicField(_Derived, "test", (key) => __async(_Derived, null, function* () {
   ];
 }));
 let Derived = _Derived;
-let fn = () => __async(this, null, function* () {
+let fn = () => __async(null, null, function* () {
   var _a;
   return _a = class extends Base {
     static c() {
@@ -3606,7 +3619,7 @@ let fn = () => __async(this, null, function* () {
 });
 const _Derived2 = class _Derived2 extends Base {
   static a() {
-    return __async(this, null, function* () {
+    return __async(null, null, function* () {
       var _a;
       return _a = __superGet(_Derived2, this, "foo"), class {
         constructor() {
@@ -3616,7 +3629,7 @@ const _Derived2 = class _Derived2 extends Base {
     });
   }
 };
-__publicField(_Derived2, "b", () => __async(_Derived2, null, function* () {
+__publicField(_Derived2, "b", () => __async(null, null, function* () {
   var _a;
   return _a = __superGet(_Derived2, _Derived2, "foo"), class {
     constructor() {
@@ -4482,7 +4495,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     var _stack2 = [];
     try {
       const a = __using(_stack2, b);
@@ -4517,7 +4530,7 @@ function foo() {
   for (using a of b) c(() => a);
 }
 function bar() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     for (using a of b) c(() => a);
     for (var _d of e) {
       var _stack = [];
@@ -4543,7 +4556,7 @@ switch (foo) {
     using e = f;
 }
 function foo() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     using x2 = y;
     switch (foo) {
       case 0:
@@ -4592,7 +4605,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     var _stack2 = [];
     try {
       const a = __using(_stack2, b);
@@ -4657,7 +4670,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     for (var _a of b) {
       var _stack3 = [];
       try {
@@ -4686,7 +4699,7 @@ function bar() {
 
 ---------- /out/switch.js ----------
 function foo() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     var _stack5 = [];
     try {
       const x2 = __using(_stack5, y);

--- a/internal/bundler_tests/snapshots/snapshots_lower.txt
+++ b/internal/bundler_tests/snapshots/snapshots_lower.txt
@@ -819,7 +819,7 @@ function foo(_0) {
 }
 class Foo {
   foo() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
     });
   }
 }
@@ -840,18 +840,18 @@ export default [
   foo,
   Foo,
   function() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
     });
   },
   () => __async(null, null, function* () {
   }),
   { foo() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
     });
   } },
   class {
     foo() {
-      return __async(null, null, function* () {
+      return __async(this, null, function* () {
       });
     }
   },
@@ -982,7 +982,7 @@ var bar4_default = class _bar4_default extends x {
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   baz1() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => __superGet(_baz1_default.prototype, this, "foo").call(this, "baz1");
     });
   }
@@ -991,7 +991,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   baz2() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => () => __superGet(_baz2_default.prototype, this, "foo").call(this, "baz2");
     });
   }
@@ -999,7 +999,7 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     class y extends z {
       constructor() {
         super(...arguments);
@@ -1110,7 +1110,7 @@ var bar4_default = class _bar4_default extends x {
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   baz1() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => __superSet(_baz1_default.prototype, this, "foo", "baz1");
     });
   }
@@ -1119,7 +1119,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   baz2() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => () => __superSet(_baz2_default.prototype, this, "foo", "baz2");
     });
   }
@@ -1127,7 +1127,7 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     class y extends z {
       constructor() {
         super(...arguments);
@@ -1156,7 +1156,7 @@ export {
 TestLowerAsyncGenerator
 ---------- /out/entry.js ----------
 function foo() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1209,7 +1209,7 @@ function foo() {
   });
 }
 foo = function() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1262,7 +1262,7 @@ foo = function() {
   });
 };
 foo = { bar() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1316,7 +1316,7 @@ foo = { bar() {
 } };
 class Foo {
   bar() {
-    return __asyncGenerator(null, null, function* () {
+    return __asyncGenerator(this, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1371,7 +1371,7 @@ class Foo {
 }
 Foo = class {
   bar() {
-    return __asyncGenerator(null, null, function* () {
+    return __asyncGenerator(this, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1436,7 +1436,7 @@ async function bar() {
 TestLowerAsyncGeneratorNoAwait
 ---------- /out/entry.js ----------
 function foo() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1489,7 +1489,7 @@ function foo() {
   });
 }
 foo = function() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1542,7 +1542,7 @@ foo = function() {
   });
 };
 foo = { bar() {
-  return __asyncGenerator(null, null, function* () {
+  return __asyncGenerator(this, null, function* () {
     var _stack2 = [];
     try {
       yield;
@@ -1596,7 +1596,7 @@ foo = { bar() {
 } };
 class Foo {
   bar() {
-    return __asyncGenerator(null, null, function* () {
+    return __asyncGenerator(this, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1651,7 +1651,7 @@ class Foo {
 }
 Foo = class {
   bar() {
-    return __asyncGenerator(null, null, function* () {
+    return __asyncGenerator(this, null, function* () {
       var _stack2 = [];
       try {
         yield;
@@ -1705,7 +1705,7 @@ Foo = class {
   }
 };
 function bar() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     var _stack2 = [];
     try {
       const x = __using(_stack2, yield y, true);
@@ -1736,7 +1736,7 @@ TestLowerAsyncSuperES2016NoBundle
 ---------- /out.js ----------
 class Derived extends Base {
   test(key) {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       var _a, _b, _c, _d;
       return [
         yield __superGet(Derived.prototype, this, "foo"),
@@ -1797,7 +1797,7 @@ class Derived2 extends Base {
     }));
   }
   a() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       var _a;
       return _a = __superGet(Derived2.prototype, this, "foo"), class {
         constructor() {
@@ -1816,7 +1816,7 @@ for (let i = 0; i < 3; i++) {
       }
     },
     bar() {
-      return __async(null, null, function* () {
+      return __async(this, null, function* () {
         return __superGet(_a, this, "foo").call(this);
       });
     }
@@ -3411,7 +3411,7 @@ var bar4_default = _bar4_default;
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   static baz1() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => __superGet(_baz1_default, this, "foo").call(this, "baz1");
     });
   }
@@ -3420,7 +3420,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   static baz2() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => () => __superGet(_baz2_default, this, "foo").call(this, "baz2");
     });
   }
@@ -3428,7 +3428,7 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     const _y = class _y extends z {
     };
     __publicField(_y, "foo", () => __async(null, null, function* () {
@@ -3529,7 +3529,7 @@ var bar4_default = _bar4_default;
 // baz1.js
 var baz1_default = class _baz1_default extends x {
   static baz1() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => __superSet(_baz1_default, this, "foo", "baz1");
     });
   }
@@ -3538,7 +3538,7 @@ var baz1_default = class _baz1_default extends x {
 // baz2.js
 var baz2_default = class _baz2_default extends x {
   static baz2() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       return () => () => __superSet(_baz2_default, this, "foo", "baz2");
     });
   }
@@ -3546,7 +3546,7 @@ var baz2_default = class _baz2_default extends x {
 
 // outer.js
 var outer_default = function() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     const _y = class _y extends z {
     };
     __publicField(_y, "foo", () => __async(null, null, function* () {
@@ -3619,7 +3619,7 @@ let fn = () => __async(null, null, function* () {
 });
 const _Derived2 = class _Derived2 extends Base {
   static a() {
-    return __async(null, null, function* () {
+    return __async(this, null, function* () {
       var _a;
       return _a = __superGet(_Derived2, this, "foo"), class {
         constructor() {
@@ -4495,7 +4495,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     var _stack2 = [];
     try {
       const a = __using(_stack2, b);
@@ -4530,7 +4530,7 @@ function foo() {
   for (using a of b) c(() => a);
 }
 function bar() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     for (using a of b) c(() => a);
     for (var _d of e) {
       var _stack = [];
@@ -4556,7 +4556,7 @@ switch (foo) {
     using e = f;
 }
 function foo() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     using x2 = y;
     switch (foo) {
       case 0:
@@ -4605,7 +4605,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     var _stack2 = [];
     try {
       const a = __using(_stack2, b);
@@ -4670,7 +4670,7 @@ function foo() {
   }
 }
 function bar() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     for (var _a of b) {
       var _stack3 = [];
       try {
@@ -4699,7 +4699,7 @@ function bar() {
 
 ---------- /out/switch.js ----------
 function foo() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     var _stack5 = [];
     try {
       const x2 = __using(_stack5, y);

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -737,6 +737,9 @@ type fnOnlyDataVisit struct {
 	// has been shadowed and is now inaccessible.
 	isThisNested bool
 
+	// If true, this is used in current function scope.
+	hasThisUsage bool
+
 	// Do not warn about "this" being undefined for code that the TypeScript
 	// compiler generates that looks like this:
 	//
@@ -13231,6 +13234,8 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 	case *js_ast.EThis:
 		isDeleteTarget := e == p.deleteTarget
 		isCallTarget := e == p.callTarget
+
+		p.fnOnlyDataVisit.hasThisUsage = true
 
 		if value, ok := p.valueForThis(expr.Loc, true /* shouldLog */, in.assignTarget, isDeleteTarget, isCallTarget); ok {
 			return value, exprOut{}

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -737,7 +737,7 @@ type fnOnlyDataVisit struct {
 	// has been shadowed and is now inaccessible.
 	isThisNested bool
 
-	// If true, this is used in current function scope.
+	// If true, "this" is used in current function scope.
 	hasThisUsage bool
 
 	// Do not warn about "this" being undefined for code that the TypeScript

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -346,7 +346,7 @@ func (p *parser) lowerFunction(
 			false, /* isDeleteTarget */
 		)
 
-		if !p.fnOnlyDataVisit.hasThisUsage {
+		if isArrow && !p.fnOnlyDataVisit.hasThisUsage {
 			thisValue = js_ast.Expr{Loc: bodyLoc, Data: js_ast.ENullShared}
 		} else if !hasThisValue {
 			thisValue = js_ast.Expr{Loc: bodyLoc, Data: js_ast.EThisShared}

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -345,7 +345,10 @@ func (p *parser) lowerFunction(
 			false, /* isCallTarget */
 			false, /* isDeleteTarget */
 		)
-		if !hasThisValue {
+
+		if !p.fnOnlyDataVisit.hasThisUsage {
+			thisValue = js_ast.Expr{Loc: bodyLoc, Data: js_ast.ENullShared}
+		} else if !hasThisValue {
 			thisValue = js_ast.Expr{Loc: bodyLoc, Data: js_ast.EThisShared}
 		}
 

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -235,13 +235,13 @@ func TestLowerAsyncFunctions(t *testing.T) {
 	// Lowered non-arrow functions with argument evaluations should merely use
 	// "arguments" rather than allocating a new array when forwarding arguments
 	expectPrintedTarget(t, 2015, "async function foo(a, b = couldThrowErrors()) {console.log(a, b);}", `function foo(_0) {
-  return __async(this, arguments, function* (a, b = couldThrowErrors()) {
+  return __async(null, arguments, function* (a, b = couldThrowErrors()) {
     console.log(a, b);
   });
 }
 `)
 	// Skip forwarding altogether when parameter evaluation obviously cannot throw
-	expectPrintedTarget(t, 2015, "async (a, b = 123) => {console.log(a, b);}", `(a, b = 123) => __async(this, null, function* () {
+	expectPrintedTarget(t, 2015, "async (a, b = 123) => {console.log(a, b);}", `(a, b = 123) => __async(null, null, function* () {
   console.log(a, b);
 });
 `)

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -235,7 +235,7 @@ func TestLowerAsyncFunctions(t *testing.T) {
 	// Lowered non-arrow functions with argument evaluations should merely use
 	// "arguments" rather than allocating a new array when forwarding arguments
 	expectPrintedTarget(t, 2015, "async function foo(a, b = couldThrowErrors()) {console.log(a, b);}", `function foo(_0) {
-  return __async(null, arguments, function* (a, b = couldThrowErrors()) {
+  return __async(this, arguments, function* (a, b = couldThrowErrors()) {
     console.log(a, b);
   });
 }

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -1969,7 +1969,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 	// Check lowered use of "await"
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { @dec(await x) class Foo {} }",
 		`function foo() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     let Foo = class {
     };
     Foo = __decorateClass([
@@ -1980,7 +1980,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 `)
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { class Foo { @dec(await x) foo() {} } }",
 		`function foo() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     class Foo {
       foo() {
       }
@@ -1993,7 +1993,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 `)
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { class Foo { foo(@dec(await x) y) {} } }",
 		`function foo() {
-  return __async(this, null, function* () {
+  return __async(null, null, function* () {
     class Foo {
       foo(y) {
       }

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -1969,7 +1969,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 	// Check lowered use of "await"
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { @dec(await x) class Foo {} }",
 		`function foo() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     let Foo = class {
     };
     Foo = __decorateClass([
@@ -1980,7 +1980,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 `)
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { class Foo { @dec(await x) foo() {} } }",
 		`function foo() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     class Foo {
       foo() {
       }
@@ -1993,7 +1993,7 @@ func TestTSExperimentalDecorator(t *testing.T) {
 `)
 	expectPrintedTargetExperimentalDecoratorTS(t, 2015, "async function foo() { class Foo { foo(@dec(await x) y) {} } }",
 		`function foo() {
-  return __async(null, null, function* () {
+  return __async(this, null, function* () {
     class Foo {
       foo(y) {
       }

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -7282,6 +7282,27 @@ for (let flags of [[], ['--target=es2017'], ['--target=es6']]) {
         }
       `,
     }, { async: true }),
+
+    // https://github.com/evanw/esbuild/issues/4141
+    test(['in.js', '--outfile=node.js'].concat(flags), {
+      'in.js': `
+        exports.async = () => new Promise((resolve, reject) => {
+          new (class Foo extends class { } {
+            constructor() {
+              let x = 1;
+              (async () => {
+                if (x !== 1) reject('fail 1');  // (1) Sync phase
+                await 1;
+                if (x !== 2) reject('fail 2');  // (2) Async phase
+                resolve();
+              })();
+              super();
+              x = 2;
+            }
+          })();
+        })
+      `,
+    }, { async: true }),
   )
 }
 


### PR DESCRIPTION
- Fix: #4141