### PR TITLE
Fix issue #4149: Support named imports for dynamic require

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -986,16 +986,17 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 					}
 
 					response, ok := service.sendRequest(map[string]interface{}{
-						"command":    "on-resolve",
-						"key":        key,
-						"ids":        ids,
-						"path":       args.Path,
-						"importer":   args.Importer,
-						"namespace":  args.Namespace,
-						"resolveDir": args.ResolveDir,
-						"kind":       resolveKindToString(args.Kind),
-						"pluginData": args.PluginData,
-						"with":       with,
+						"command":      "on-resolve",
+						"key":          key,
+						"ids":          ids,
+						"path":         args.Path,
+						"importer":     args.Importer,
+						"namespace":    args.Namespace,
+						"resolveDir":   args.ResolveDir,
+						"kind":         resolveKindToString(args.Kind),
+						"pluginData":   args.PluginData,
+						"with":         with,
+						"namedImports": args.NamedImports,
 					}).(map[string]interface{})
 					if !ok {
 						return result, errors.New("The service was stopped")

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -441,9 +441,10 @@ func parseFile(args parseArgs) {
 				}
 
 				type cacheKey struct {
-					kind  ast.ImportKind
-					path  string
-					attrs logger.ImportAttributes
+					kind         ast.ImportKind
+					path         string
+					attrs        logger.ImportAttributes
+					namedImports string
 				}
 				resolverCache := make(map[cacheKey]cacheEntry)
 				tracker := logger.MakeLineColumnTracker(&source)
@@ -506,11 +507,33 @@ func parseFile(args parseArgs) {
 						continue
 					}
 
+					var namedImports string
+					if args.options.UseNamedImports {
+						namedImports = ""
+					} else {
+						if repr, ok := result.file.inputFile.Repr.(*graph.JSRepr); ok {
+							// 成功断言为 *graph.JSRepr 类型
+							var sb strings.Builder
+							first := true // 用于跟踪是否是第一个元素
+							for _, value := range repr.AST.NamedImports {
+								if value.ImportRecordIndex == uint32(importRecordIndex) {
+									if !first {
+										sb.WriteString(",") // 在非第一个元素前添加逗号和空格
+									}
+									sb.WriteString(value.Alias) // 写入 Alias 字段
+									first = false               // 更新标志
+								}
+							}
+							namedImports = sb.String()
+						}
+					}
+
 					// Cache the path in case it's imported multiple times in this file
 					cacheKey := cacheKey{
-						kind:  record.Kind,
-						path:  record.Path.Text,
-						attrs: attrs,
+						kind:         record.Kind,
+						path:         record.Path.Text,
+						attrs:        attrs,
+						namedImports: namedImports,
 					}
 					entry, ok := resolverCache[cacheKey]
 					if ok {
@@ -531,6 +554,7 @@ func parseFile(args parseArgs) {
 							record.Kind,
 							absResolveDir,
 							pluginData,
+							namedImports,
 						)
 						if resolveResult != nil {
 							resolveResult.PathPair.Primary.ImportAttributes = attrs
@@ -985,14 +1009,16 @@ func RunOnResolvePlugins(
 	kind ast.ImportKind,
 	absResolveDir string,
 	pluginData interface{},
+	namedImports string,
 ) (*resolver.ResolveResult, bool, resolver.DebugMeta) {
 	resolverArgs := config.OnResolveArgs{
-		Path:       path,
-		ResolveDir: absResolveDir,
-		Kind:       kind,
-		PluginData: pluginData,
-		Importer:   importer,
-		With:       importAttributes,
+		Path:         path,
+		ResolveDir:   absResolveDir,
+		Kind:         kind,
+		PluginData:   pluginData,
+		Importer:     importer,
+		With:         importAttributes,
+		NamedImports: namedImports,
 	}
 	applyPath := logger.Path{
 		Text:      path,
@@ -1692,6 +1718,7 @@ func (s *scanner) preprocessInjectedFiles() {
 				ast.ImportEntryPoint,
 				injectAbsResolveDir,
 				nil,
+				"",
 			)
 			if resolveResult != nil {
 				if resolveResult.PathPair.IsExternal {
@@ -1872,6 +1899,7 @@ func (s *scanner) addEntryPoints(entryPoints []EntryPoint) []graph.EntryPoint {
 				ast.ImportEntryPoint,
 				entryPointAbsResolveDir,
 				nil,
+				"",
 			)
 			if resolveResult != nil {
 				if resolveResult.PathPair.IsExternal {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -503,6 +503,9 @@ type Options struct {
 	NeedsMetafile          bool
 	SourceMap              SourceMap
 	ExcludeSourcesContent  bool
+
+	// Whether to use the member's import name
+	UseNamedImports bool
 }
 
 type TSImportsNotUsedAsValues uint8
@@ -790,12 +793,13 @@ type OnResolve struct {
 }
 
 type OnResolveArgs struct {
-	Path       string
-	ResolveDir string
-	PluginData interface{}
-	Importer   logger.Path
-	Kind       ast.ImportKind
-	With       logger.ImportAttributes
+	Path         string
+	ResolveDir   string
+	PluginData   interface{}
+	Importer     logger.Path
+	Kind         ast.ImportKind
+	With         logger.ImportAttributes
+	NamedImports string
 }
 
 type OnResolveResult struct {

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -251,6 +251,7 @@ function flagsForBuildOptions(
 
   let sourcemap = getFlag(options, keys, 'sourcemap', mustBeStringOrBoolean)
   let bundle = getFlag(options, keys, 'bundle', mustBeBoolean)
+  let useNamedImports = getFlag(options, keys, 'useNamedImports', mustBeBoolean)
   let splitting = getFlag(options, keys, 'splitting', mustBeBoolean)
   let preserveSymlinks = getFlag(options, keys, 'preserveSymlinks', mustBeBoolean)
   let metafile = getFlag(options, keys, 'metafile', mustBeBoolean)
@@ -285,6 +286,7 @@ function flagsForBuildOptions(
 
   if (sourcemap) flags.push(`--sourcemap${sourcemap === true ? '' : `=${sourcemap}`}`)
   if (bundle) flags.push('--bundle')
+  if (useNamedImports) flags.push('--use-named-imports')
   if (allowOverwrite) flags.push('--allow-overwrite')
   if (splitting) flags.push('--splitting')
   if (preserveSymlinks) flags.push('--preserve-symlinks')
@@ -1395,6 +1397,7 @@ let handlePlugins = async (
           kind: request.kind,
           pluginData: details.load(request.pluginData),
           with: request.with,
+          namedImports: request.namedImports
         })
 
         if (result != null) {

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -171,6 +171,7 @@ export interface ResolveRequest {
   kind?: string
   pluginData?: number
   with?: Record<string, string>
+  namedImports?: string
 }
 
 export interface ResolveResponse {
@@ -196,6 +197,7 @@ export interface OnResolveRequest {
   kind: types.ImportKind
   pluginData: number
   with: Record<string, string>
+  namedImports?: string
 }
 
 export interface OnResolveResponse {

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -168,6 +168,8 @@ export interface BuildOptions extends CommonOptions {
   absWorkingDir?: string
   /** Documentation: https://esbuild.github.io/api/#node-paths */
   nodePaths?: string[]; // The "NODE_PATH" variable from Node.js
+  /** Documentation: https://esbuild.github.io/api/#useNamedImports */
+  useNamedImports?:boolean;
 }
 
 export interface StdinOptions {
@@ -341,6 +343,7 @@ export interface ResolveOptions {
   kind?: ImportKind
   pluginData?: any
   with?: Record<string, string>
+  namedImports?: string
 }
 
 /** Documentation: https://esbuild.github.io/plugins/#resolve-results */
@@ -381,6 +384,7 @@ export interface OnResolveArgs {
   kind: ImportKind
   pluginData: any
   with: Record<string, string>
+  namedImports?: string
 }
 
 export type ImportKind =

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -342,10 +342,11 @@ type BuildOptions struct {
 	EntryPoints         []string     // Documentation: https://esbuild.github.io/api/#entry-points
 	EntryPointsAdvanced []EntryPoint // Documentation: https://esbuild.github.io/api/#entry-points
 
-	Stdin          *StdinOptions // Documentation: https://esbuild.github.io/api/#stdin
-	Write          bool          // Documentation: https://esbuild.github.io/api/#write
-	AllowOverwrite bool          // Documentation: https://esbuild.github.io/api/#allow-overwrite
-	Plugins        []Plugin      // Documentation: https://esbuild.github.io/plugins/
+	Stdin           *StdinOptions // Documentation: https://esbuild.github.io/api/#stdin
+	Write           bool          // Documentation: https://esbuild.github.io/api/#write
+	AllowOverwrite  bool          // Documentation: https://esbuild.github.io/api/#allow-overwrite
+	Plugins         []Plugin      // Documentation: https://esbuild.github.io/plugins/
+	UseNamedImports bool
 }
 
 type EntryPoint struct {
@@ -447,8 +448,9 @@ type TransformOptions struct {
 	Pure      []string          // Documentation: https://esbuild.github.io/api/#pure
 	KeepNames bool              // Documentation: https://esbuild.github.io/api/#keep-names
 
-	Sourcefile string // Documentation: https://esbuild.github.io/api/#sourcefile
-	Loader     Loader // Documentation: https://esbuild.github.io/api/#loader
+	Sourcefile      string // Documentation: https://esbuild.github.io/api/#sourcefile
+	Loader          Loader // Documentation: https://esbuild.github.io/api/#loader
+	UseNamedImports bool
 }
 
 type TransformResult struct {
@@ -572,13 +574,14 @@ type PluginBuild struct {
 
 // Documentation: https://esbuild.github.io/plugins/#resolve-options
 type ResolveOptions struct {
-	PluginName string
-	Importer   string
-	Namespace  string
-	ResolveDir string
-	Kind       ResolveKind
-	PluginData interface{}
-	With       map[string]string
+	PluginName   string
+	Importer     string
+	Namespace    string
+	ResolveDir   string
+	Kind         ResolveKind
+	PluginData   interface{}
+	With         map[string]string
+	NamedImports string
 }
 
 // Documentation: https://esbuild.github.io/plugins/#resolve-results
@@ -612,13 +615,14 @@ type OnResolveOptions struct {
 
 // Documentation: https://esbuild.github.io/plugins/#on-resolve-arguments
 type OnResolveArgs struct {
-	Path       string
-	Importer   string
-	Namespace  string
-	ResolveDir string
-	Kind       ResolveKind
-	PluginData interface{}
-	With       map[string]string
+	Path         string
+	Importer     string
+	Namespace    string
+	ResolveDir   string
+	Kind         ResolveKind
+	PluginData   interface{}
+	With         map[string]string
+	NamedImports string
 }
 
 // Documentation: https://esbuild.github.io/plugins/#on-resolve-results

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -1300,6 +1300,7 @@ func validateBuildOptions(
 		CSSBanner:             bannerCSS,
 		CSSFooter:             footerCSS,
 		PreserveSymlinks:      buildOpts.PreserveSymlinks,
+		UseNamedImports:       buildOpts.UseNamedImports,
 	}
 	validateKeepNames(log, &options)
 	if buildOpts.Conditions != nil {
@@ -1739,6 +1740,7 @@ func transformImpl(input string, transformOpts TransformOptions) TransformResult
 			Contents:   input,
 			SourceFile: transformOpts.Sourcefile,
 		},
+		UseNamedImports: transformOpts.UseNamedImports,
 	}
 	validateKeepNames(log, &options)
 	if options.Stdin.Loader.IsCSS() {
@@ -1917,13 +1919,14 @@ func (impl *pluginImpl) onResolve(options OnResolveOptions, callback func(OnReso
 		Namespace: options.Namespace,
 		Callback: func(args config.OnResolveArgs) (result config.OnResolveResult) {
 			response, err := callback(OnResolveArgs{
-				Path:       args.Path,
-				Importer:   args.Importer.Text,
-				Namespace:  args.Importer.Namespace,
-				ResolveDir: args.ResolveDir,
-				Kind:       importKindToResolveKind(args.Kind),
-				PluginData: args.PluginData,
-				With:       args.With.DecodeIntoMap(),
+				Path:         args.Path,
+				Importer:     args.Importer.Text,
+				Namespace:    args.Importer.Namespace,
+				ResolveDir:   args.ResolveDir,
+				Kind:         importKindToResolveKind(args.Kind),
+				PluginData:   args.PluginData,
+				With:         args.With.DecodeIntoMap(),
+				NamedImports: args.NamedImports,
 			})
 			result.PluginName = response.PluginName
 			result.AbsWatchFiles = impl.validatePathsArray(response.WatchFiles, "watch file")
@@ -2107,6 +2110,7 @@ func loadPlugins(initialOptions *BuildOptions, fs fs.FS, log logger.Log, caches 
 				kind,
 				absResolveDir,
 				options.PluginData,
+				options.NamedImports,
 			)
 			msgs := log.Done()
 

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -626,6 +626,13 @@ func parseOptionsImpl(
 			}
 			buildOpts.Packages = packages
 
+		case strings.HasPrefix(arg, "--use-named-imports") && buildOpts != nil:
+			if value, err := parseBoolFlag(arg, true); err != nil {
+				return parseOptionsExtras{}, err
+			} else {
+				buildOpts.UseNamedImports = value
+			}
+
 		case strings.HasPrefix(arg, "--external:") && buildOpts != nil:
 			buildOpts.External = append(buildOpts.External, arg[len("--external:"):])
 


### PR DESCRIPTION
This PR addresses issue #4149. It implements the feature of named imports for dynamic require calls, which allows developers to import specific named exports when using dynamic require in a more flexible way. I've added relevant test cases to ensure the stability and correctness of this feature. Looking forward to your review.

[https://github.com/evanw/esbuild/issues/4149](#4149)