### PR TITLE
fix: handle `__proto__` as a computed property in exports and add tests for special names

### DIFF
--- a/internal/bundler_tests/bundler_default_test.go
+++ b/internal/bundler_tests/bundler_default_test.go
@@ -1673,6 +1673,44 @@ func TestExportWildcardFSNodeCommonJS(t *testing.T) {
 	})
 }
 
+func TestExportSpecialName(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.mjs": `
+			export const __proto__ = 123;
+			`,
+		},
+		entryPaths: []string{"/entry.mjs"},
+		options: config.Options{
+			Mode:          config.ModeConvertFormat,
+			OutputFormat:  config.FormatCommonJS,
+			AbsOutputFile: "/out.js",
+			Platform:      config.PlatformNode,
+		},
+	})
+}
+
+func TestExportSpecialNameBundle(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				const lib = require('./lib.mjs');
+				console.log(lib.__proto__);
+			`,
+			"/lib.mjs": `
+				export const __proto__ = 123;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			OutputFormat:  config.FormatCommonJS,
+			AbsOutputFile: "/out.js",
+			Platform:      config.PlatformNode,
+		},
+	})
+}
+
 // https://github.com/evanw/esbuild/issues/3544
 func TestNodeAnnotationFalsePositiveIssue3544(t *testing.T) {
 	default_suite.expectBundled(t, bundled{

--- a/internal/bundler_tests/snapshots/snapshots_default.txt
+++ b/internal/bundler_tests/snapshots/snapshots_default.txt
@@ -1564,6 +1564,39 @@ export default class o {
 }
 
 ================================================================================
+TestExportSpecialName
+---------- /out.js ----------
+var entry_exports = {};
+__export(entry_exports, {
+  ["__proto__"]: () => __proto__
+});
+module.exports = __toCommonJS(entry_exports);
+const __proto__ = 123;
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  __proto__
+});
+
+================================================================================
+TestExportSpecialNameBundle
+---------- /out.js ----------
+// lib.mjs
+var lib_exports = {};
+__export(lib_exports, {
+  ["__proto__"]: () => __proto__
+});
+var __proto__;
+var init_lib = __esm({
+  "lib.mjs"() {
+    __proto__ = 123;
+  }
+});
+
+// entry.js
+var lib = (init_lib(), __toCommonJS(lib_exports));
+console.log(lib.__proto__);
+
+================================================================================
 TestExportWildcardFSNodeCommonJS
 ---------- /out.js ----------
 // entry.js

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -2293,10 +2293,20 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 		} else {
 			getter = js_ast.Expr{Data: &js_ast.EArrow{PreferExpr: true, Body: body}}
 		}
-		properties = append(properties, js_ast.Property{
-			Key:        js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(alias)}},
-			ValueOrNil: getter,
-		})
+
+		// Special case for __proto__ property - use computed property name to avoid it being treated as the object's prototype
+		if alias == "__proto__" {
+			properties = append(properties, js_ast.Property{
+				Flags:      js_ast.PropertyIsComputed,
+				Key:        js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(alias)}},
+				ValueOrNil: getter,
+			})
+		} else {
+			properties = append(properties, js_ast.Property{
+				Key:        js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(alias)}},
+				ValueOrNil: getter,
+			})
+		}
 		nsExportSymbolUses[export.Ref] = js_ast.SymbolUse{CountEstimate: 1}
 
 		// Make sure the part that declares the export is included


### PR DESCRIPTION
- Closes: #4162 