### PR TITLE
io/fs.FS for input files.

### DIFF
--- a/internal/fs/io_fs.go
+++ b/internal/fs/io_fs.go
@@ -1,0 +1,342 @@
+package fs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/evanw/esbuild/internal/io_fs"
+	"golang.org/x/sys/unix"
+)
+
+func FromFS(fs io_fs.FS) FS {
+	ret := &ioFS{FS: fs}
+	ret.fp.cwd = "."
+	ret.fp.pathSeparator = '/'
+	return ret
+}
+
+type ioFS struct {
+	io_fs.FS
+	fp goFilepath
+}
+
+func (fs *ioFS) ReadDirectory(dir string) (entries DirEntries, canonicalError error, originalError error) {
+	// Read the directory entries
+	dir = strings.TrimPrefix(dir, "/")
+	if dir == "" {
+		dir = "."
+	}
+
+	names, canonicalError, originalError := fs.readdir(dir)
+	entries = DirEntries{dir: dir, data: make(map[string]*Entry)}
+
+	// Unwrap to get the underlying error
+	if pathErr, ok := canonicalError.(*os.PathError); ok {
+		canonicalError = pathErr.Unwrap()
+	}
+
+	if canonicalError == nil {
+		for _, name := range names {
+			// Call "stat" lazily for performance. The "@material-ui/icons" package
+			// contains a directory with over 11,000 entries in it and running "stat"
+			// for each entry was a big performance issue for that package.
+			entries.data[strings.ToLower(name)] = &Entry{
+				dir:      dir,
+				base:     name,
+				needStat: true,
+			}
+		}
+	}
+
+	// Update the cache unconditionally. Even if the read failed, we don't want to
+	// retry again later. The directory is inaccessible so trying again is wasted.
+	if canonicalError != nil {
+		entries.data = nil
+	}
+	return entries, canonicalError, originalError
+}
+
+func (fs *ioFS) readdir(dirname string) (entries []string, canonicalError error, originalError error) {
+	BeforeFileOpen()
+	defer AfterFileClose()
+	f, originalError := fs.Open(dirname)
+	canonicalError = fs.canonicalizeError(originalError)
+
+	// Stop now if there was an error
+	if canonicalError != nil {
+		return nil, canonicalError, originalError
+	}
+
+	defer f.Close()
+
+	dir, ok := f.(io_fs.ReadDirFile)
+	if !ok {
+		return
+	}
+
+	dirEntries, originalError := dir.ReadDir(-1)
+	canonicalError = originalError
+
+	entries = make([]string, len(dirEntries))
+	for i, e := range dirEntries {
+		entries[i] = e.Name()
+	}
+
+	// Unwrap to get the underlying error
+	if syscallErr, ok := canonicalError.(*os.SyscallError); ok {
+		canonicalError = syscallErr.Unwrap()
+	}
+
+	// Don't convert ENOTDIR to ENOENT here. ENOTDIR is a legitimate error
+	// condition for Readdirnames() on non-Windows platforms.
+
+	// Go's WebAssembly implementation returns EINVAL instead of ENOTDIR if we
+	// call "readdir" on a file. Canonicalize this to ENOTDIR so esbuild's path
+	// resolution code continues traversing instead of failing with an error.
+	// https://github.com/golang/go/blob/2449bbb5e614954ce9e99c8a481ea2ee73d72d61/src/syscall/fs_js.go#L144
+	if pathErr, ok := canonicalError.(*os.PathError); ok && pathErr.Unwrap() == syscall.EINVAL {
+		canonicalError = syscall.ENOTDIR
+	}
+
+	return entries, canonicalError, originalError
+}
+
+func (fs *ioFS) canonicalizeError(err error) error {
+	// Unwrap to get the underlying error
+	if pathErr, ok := err.(*os.PathError); ok {
+		err = pathErr.Unwrap()
+	}
+
+	// Windows is much more restrictive than Unix about file names. If a file name
+	// is invalid, it will return ERROR_INVALID_NAME. Treat this as ENOENT (i.e.
+	// "the file does not exist") so that the resolver continues trying to resolve
+	// the path on this failure instead of aborting with an error.
+	if fs.fp.isWindows && is_ERROR_INVALID_NAME(err) {
+		err = syscall.ENOENT
+	}
+
+	// Windows returns ENOTDIR here even though nothing we've done yet has asked
+	// for a directory. This really means ENOENT on Windows. Return ENOENT here
+	// so callers that check for ENOENT will successfully detect this file as
+	// missing.
+	if err == syscall.ENOTDIR {
+		err = syscall.ENOENT
+	}
+
+	return err
+}
+
+func (fs *ioFS) ReadFile(name string) (contents string, canonicalError error, originalError error) {
+	name = strings.TrimPrefix(name, "/")
+	BeforeFileOpen()
+	defer AfterFileClose()
+	f, originalError := fs.Open(name)
+	canonicalError = fs.canonicalizeError(originalError)
+
+	// Stop now if there was an error
+	if canonicalError != nil {
+		return "", canonicalError, originalError
+	}
+
+	defer f.Close()
+
+	buffer, originalError := ioutil.ReadAll(f)
+	canonicalError = fs.canonicalizeError(originalError)
+	return string(buffer), canonicalError, originalError
+}
+
+type iofsOpenedFile struct {
+	handle io_fs.File
+	len    int
+}
+
+func (f *iofsOpenedFile) Len() int { return f.len }
+
+func (f *iofsOpenedFile) Read(start int, end int) ([]byte, error) {
+	bytes := make([]byte, end-start)
+	remaining := bytes
+
+	if r, ok := f.handle.(io.ReaderAt); ok {
+		for len(remaining) > 0 {
+			n, err := r.ReadAt(remaining, int64(start))
+			if err != nil && n <= 0 {
+				return nil, err
+			}
+			remaining = remaining[n:]
+			start += n
+		}
+		return bytes, nil
+	}
+
+	if s, ok := f.handle.(io.Seeker); !ok {
+		return nil, fmt.Errorf("file does not support random access")
+	} else if _, err := s.Seek(int64(start), io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	for len(remaining) > 0 {
+		n, err := f.handle.Read(remaining)
+		if err != nil && n <= 0 {
+			return nil, err
+		}
+		remaining = remaining[n:]
+	}
+
+	return bytes, nil
+}
+
+func (f *iofsOpenedFile) Close() error {
+	return f.handle.Close()
+}
+
+func (fs *ioFS) OpenFile(name string) (result OpenedFile, canonicalError error, originalError error) {
+	name = strings.TrimPrefix(name, "/")
+	BeforeFileOpen()
+	defer AfterFileClose()
+
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, fs.canonicalizeError(err), err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fs.canonicalizeError(err), err
+	}
+
+	return &iofsOpenedFile{f, int(info.Size())}, nil, nil
+}
+
+func (fs *ioFS) ModKey(name string) (ModKey, error) {
+	stat, err := fs.stat(name)
+	if err != nil {
+		return ModKey{}, err
+	}
+
+	// We can't detect changes if the file system zeros out the modification time
+	mtim := stat.ModTime()
+	mtim_sec, mtim_nsec := int64(mtim.Second()), int64(mtim.Nanosecond())
+	if mtim_sec == 0 && mtim_nsec == 0 {
+		return ModKey{}, modKeyUnusable
+	}
+
+	// Don't generate a modification key if the file is too new
+	now, err := unix.TimeToTimespec(time.Now())
+	if err != nil {
+		return ModKey{}, err
+	}
+	mtimeSec := mtim_sec + modKeySafetyGap
+	if mtimeSec > now.Sec || (mtimeSec == now.Sec && mtim_nsec > now.Nsec) {
+		return ModKey{}, modKeyUnusable
+	}
+
+	return ModKey{
+		size:       stat.Size(),
+		mtime_sec:  mtim_sec,
+		mtime_nsec: mtim_nsec,
+		mode:       uint32(stat.Mode()),
+	}, nil
+}
+
+func (fs *ioFS) stat(name string) (io_fs.FileInfo, error) {
+	name = strings.TrimPrefix(name, "/")
+	BeforeFileOpen()
+	defer AfterFileClose()
+
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return f.Stat()
+}
+
+func (fs *ioFS) IsAbs(p string) bool {
+	return fs.fp.isAbs(p)
+}
+
+func (fs *ioFS) Abs(p string) (string, bool) {
+	abs, err := fs.fp.abs(p)
+	return abs, err == nil
+}
+
+func (fs *ioFS) Dir(p string) string {
+	return fs.fp.dir(p)
+}
+
+func (fs *ioFS) Base(p string) string {
+	return fs.fp.base(p)
+}
+
+func (fs *ioFS) Ext(p string) string {
+	return fs.fp.ext(p)
+}
+
+func (fs *ioFS) Join(parts ...string) string {
+	return fs.fp.clean(fs.fp.join(parts))
+}
+
+func (fs *ioFS) Cwd() string {
+	return fs.fp.cwd
+}
+
+func (fs *ioFS) Rel(base string, target string) (string, bool) {
+	if rel, err := fs.fp.rel(base, target); err == nil {
+		return rel, true
+	}
+	return "", false
+}
+
+func (fs *ioFS) EvalSymlinks(path string) (string, bool) {
+	// TODO
+	return "", false
+}
+
+func (fs *ioFS) kind(dir string, base string) (symlink string, kind EntryKind) {
+	entryPath := fs.fp.join([]string{dir, base})
+
+	// Use "lstat" since we want information about symbolic links
+	stat, err := fs.stat(entryPath)
+	if err != nil {
+		return
+	}
+	mode := stat.Mode()
+
+	// Follow symlinks now so the cache contains the translation
+	if (mode & io_fs.ModeSymlink) != 0 {
+		link, ok := fs.EvalSymlinks(entryPath)
+		if !ok {
+			return // Skip over this entry
+		}
+
+		// Re-run "lstat" on the symlink target to see if it's a file or not
+		stat2, err2 := fs.stat(entryPath)
+		if err2 != nil {
+			return // Skip over this entry
+		}
+		mode = stat2.Mode()
+		if (mode & io_fs.ModeSymlink) != 0 {
+			return // This should no longer be a symlink, so this is unexpected
+		}
+		symlink = link
+	}
+
+	// We consider the entry either a directory or a file
+	if mode.IsDir() {
+		kind = DirEntry
+	} else {
+		kind = FileEntry
+	}
+	return
+}
+
+func (fs *ioFS) WatchData() WatchData {
+	return WatchData{}
+}

--- a/internal/io_fs/go_1_15.go
+++ b/internal/io_fs/go_1_15.go
@@ -1,0 +1,85 @@
+//go:build !go1.16
+// +build !go1.16
+
+package io_fs
+
+import (
+	"fmt"
+	"time"
+)
+
+// These are shims to allow esbuild to compile with older versions of Go. The
+// caller must use Go 1.16 or newer to be able to use FS.
+
+type FS interface {
+	Open(name string) (File, error)
+}
+
+type File interface {
+	Stat() (FileInfo, error)
+	Read([]byte) (int, error)
+	Close() error
+}
+
+type ReadDirFile interface {
+	File
+	ReadDir(n int) ([]DirEntry, error)
+}
+
+type DirEntry interface {
+	Name() string
+	IsDir() bool
+	Type() FileMode
+	Info() (FileInfo, error)
+}
+
+type FileInfo interface {
+	Name() string
+	Size() int64
+	Mode() FileMode
+	ModTime() time.Time
+	IsDir() bool
+	Sys() any
+}
+
+type FileMode uint32
+
+const (
+	ModeDir FileMode = 1 << (32 - 1 - iota)
+	ModeAppend
+	ModeExclusive
+	ModeTemporary
+	ModeSymlink
+	ModeDevice
+	ModeNamedPipe
+	ModeSocket
+	ModeSetuid
+	ModeSetgid
+	ModeCharDevice
+	ModeSticky
+	ModeIrregular
+
+	ModeType = ModeDir | ModeSymlink | ModeNamedPipe | ModeSocket | ModeDevice | ModeCharDevice | ModeIrregular
+
+	ModePerm FileMode = 0777
+)
+
+func (m FileMode) IsDir() bool {
+	return m&ModeDir != 0
+}
+
+func (m FileMode) IsRegular() bool {
+	return m&ModeType == 0
+}
+
+func (m FileMode) Perm() FileMode {
+	return m & ModePerm
+}
+
+func (m FileMode) Type() FileMode {
+	return m & ModeType
+}
+
+func (m FileMode) String() string {
+	return fmt.Sprint(m)
+}

--- a/internal/io_fs/go_1_16.go
+++ b/internal/io_fs/go_1_16.go
@@ -1,0 +1,33 @@
+//go:build go1.16
+// +build go1.16
+
+package io_fs
+
+import "io/fs"
+
+type (
+	FS          = fs.FS
+	File        = fs.File
+	ReadDirFile = fs.ReadDirFile
+	DirEntry    = fs.DirEntry
+	FileInfo    = fs.FileInfo
+	FileMode    = fs.FileMode
+)
+
+const (
+	ModeDir        = fs.ModeDir
+	ModeAppend     = fs.ModeAppend
+	ModeExclusive  = fs.ModeExclusive
+	ModeTemporary  = fs.ModeTemporary
+	ModeSymlink    = fs.ModeSymlink
+	ModeDevice     = fs.ModeDevice
+	ModeNamedPipe  = fs.ModeNamedPipe
+	ModeSocket     = fs.ModeSocket
+	ModeSetuid     = fs.ModeSetuid
+	ModeSetgid     = fs.ModeSetgid
+	ModeCharDevice = fs.ModeCharDevice
+	ModeSticky     = fs.ModeSticky
+	ModeIrregular  = fs.ModeIrregular
+	ModeType       = fs.ModeType
+	ModePerm       = fs.ModePerm
+)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -79,6 +79,7 @@ package api
 import (
 	"time"
 
+	"github.com/evanw/esbuild/internal/io_fs"
 	"github.com/evanw/esbuild/internal/logger"
 )
 
@@ -274,6 +275,8 @@ type BuildOptions struct {
 	LogLimit    int                 // Documentation: https://esbuild.github.io/api/#log-limit
 	LogOverride map[string]LogLevel // Documentation: https://esbuild.github.io/api/#log-override
 
+	InputFS io_fs.FS // Read files from an [io/fs.FS]
+
 	Sourcemap      SourceMap      // Documentation: https://esbuild.github.io/api/#sourcemap
 	SourceRoot     string         // Documentation: https://esbuild.github.io/api/#source-root
 	SourcesContent SourcesContent // Documentation: https://esbuild.github.io/api/#sources-content
@@ -389,7 +392,7 @@ func Build(options BuildOptions) BuildResult {
 	// Print a summary of the generated files to stderr. Except don't do
 	// this if the terminal is already being used for something else.
 	if ctx.args.logOptions.LogLevel <= logger.LevelInfo && !ctx.args.options.WriteToStdout {
-		printSummary(ctx.args.logOptions.Color, result.OutputFiles, start)
+		printSummary(ctx.args.logOptions.Color, ctx.realFS, result.OutputFiles, start)
 	}
 
 	ctx.Dispose()

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -877,20 +877,27 @@ func contextImpl(buildOpts BuildOptions) (*internalContext, []Message) {
 		Overrides:     validateLogOverrides(buildOpts.LogOverride),
 	}
 
-	// Validate that the current working directory is an absolute path
 	absWorkingDir := buildOpts.AbsWorkingDir
-	realFS, err := fs.RealFS(fs.RealFSOptions{
-		AbsWorkingDir: absWorkingDir,
 
-		// This is a long-lived file system object so do not cache calls to
-		// ReadDirectory() (they are normally cached for the duration of a build
-		// for performance).
-		DoNotCache: true,
-	})
-	if err != nil {
-		log := logger.NewStderrLog(logOptions)
-		log.AddError(nil, logger.Range{}, err.Error())
-		return nil, convertMessagesToPublic(logger.Error, log.Done())
+	var realFS fs.FS
+	if buildOpts.InputFS != nil {
+		realFS = fs.FromFS(buildOpts.InputFS)
+	} else {
+		// Validate that the current working directory is an absolute path
+		var err error
+		realFS, err = fs.RealFS(fs.RealFSOptions{
+			AbsWorkingDir: absWorkingDir,
+
+			// This is a long-lived file system object so do not cache calls to
+			// ReadDirectory() (they are normally cached for the duration of a build
+			// for performance).
+			DoNotCache: true,
+		})
+		if err != nil {
+			log := logger.NewStderrLog(logOptions)
+			log.AddError(nil, logger.Range{}, err.Error())
+			return nil, convertMessagesToPublic(logger.Error, log.Done())
+		}
 	}
 
 	// Do not re-evaluate plugins when rebuilding. Also make sure the working
@@ -934,6 +941,7 @@ func contextImpl(buildOpts BuildOptions) (*internalContext, []Message) {
 		mangleCache:        buildOpts.MangleCache,
 		absWorkingDir:      absWorkingDir,
 		write:              buildOpts.Write,
+		realFS:             realFS,
 	}
 
 	return &internalContext{
@@ -1178,30 +1186,26 @@ func prettyPrintByteCount(n int) string {
 	return size
 }
 
-func printSummary(color logger.UseColor, outputFiles []OutputFile, start time.Time) {
+func printSummary(color logger.UseColor, realFS fs.FS, outputFiles []OutputFile, start time.Time) {
 	if len(outputFiles) == 0 {
 		return
 	}
 
 	var table logger.SummaryTable = make([]logger.SummaryTableEntry, len(outputFiles))
 
-	if cwd, err := os.Getwd(); err == nil {
-		if realFS, err := fs.RealFS(fs.RealFSOptions{AbsWorkingDir: cwd}); err == nil {
-			for i, file := range outputFiles {
-				path, ok := realFS.Rel(realFS.Cwd(), file.Path)
-				if !ok {
-					path = file.Path
-				}
-				base := realFS.Base(path)
-				n := len(file.Contents)
-				table[i] = logger.SummaryTableEntry{
-					Dir:         path[:len(path)-len(base)],
-					Base:        base,
-					Size:        prettyPrintByteCount(n),
-					Bytes:       n,
-					IsSourceMap: strings.HasSuffix(base, ".map"),
-				}
-			}
+	for i, file := range outputFiles {
+		path, ok := realFS.Rel(realFS.Cwd(), file.Path)
+		if !ok {
+			path = file.Path
+		}
+		base := realFS.Base(path)
+		n := len(file.Contents)
+		table[i] = logger.SummaryTableEntry{
+			Dir:         path[:len(path)-len(base)],
+			Base:        base,
+			Size:        prettyPrintByteCount(n),
+			Bytes:       n,
+			IsSourceMap: strings.HasSuffix(base, ".map"),
 		}
 	}
 
@@ -1440,6 +1444,7 @@ type rebuildArgs struct {
 	mangleCache        map[string]interface{}
 	absWorkingDir      string
 	write              bool
+	realFS             fs.FS
 }
 
 type rebuildState struct {
@@ -1457,13 +1462,17 @@ func rebuildImpl(args rebuildArgs, oldHashes map[string]string) (rebuildState, m
 	}
 
 	// Convert and validate the buildOpts
-	realFS, err := fs.RealFS(fs.RealFSOptions{
-		AbsWorkingDir: args.absWorkingDir,
-		WantWatchData: args.options.WatchMode,
-	})
-	if err != nil {
-		// This should already have been checked by the caller
-		panic(err.Error())
+	realFS := args.realFS
+	if realFS == nil {
+		var err error
+		realFS, err = fs.RealFS(fs.RealFSOptions{
+			AbsWorkingDir: args.absWorkingDir,
+			WantWatchData: args.options.WatchMode,
+		})
+		if err != nil {
+			// This should already have been checked by the caller
+			panic(err.Error())
+		}
 	}
 
 	var result BuildResult


### PR DESCRIPTION
Closes #3954. Adds `InputFS io/fs.FS` which allows the caller to provide a filesystem that input files will be read from.

Though it actually uses `internal/io_fs` because importing `io/fs` would break compatibility with versions earlier than Go 1.16. The shim for earlier versions is not intended to be implementable; if a caller wishes to pass in an `io/fs.FS`, that caller should use Go 1.16 or newer.