### PR TITLE
feat: escape non-ASCII characters embedded in regular expressions

### DIFF
--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -6586,6 +6586,15 @@ func TestASCIIOnly(t *testing.T) {
 	expectPrintedASCII(t, "export var 𐀀", "export var \\u{10000};\n")
 	expectPrintedTargetASCII(t, 5, "export var π", "export var \\u03C0;\n")
 	expectParseErrorTargetASCII(t, 5, "export var 𐀀", es5)
+
+	expectPrinted(t, "/π/", "/π/;\n")
+	expectPrinted(t, "/𐀀/", "/𐀀/;\n")
+	expectPrintedASCII(t, "/π/", "new RegExp(\"\\u03C0\");\n")
+	expectPrintedASCII(t, "/𐀀/", "new RegExp(\"\\u{10000}\");\n")
+	expectPrintedASCII(t, "/𐀀/u", "new RegExp(\"\\u{10000}\", \"u\");\n")
+	expectPrintedTargetASCII(t, 5, "/π/", "new RegExp(\"\\u03C0\");\n")
+	expectPrintedTargetASCII(t, 5, "/𐀀/", "new RegExp(\"\\uD800\\uDC00\");\n")
+	expectPrintedTargetASCII(t, 5, "/𐀀/u", "new RegExp(\"\\uD800\\uDC00\", \"u\");\n")
 }
 
 func TestMangleCatch(t *testing.T) {


### PR DESCRIPTION
I choose to transform regular expression literals to `new RegExp` calls instead of only to replace the non-ASCII characters to escape sequence, because the latter will change the return value of `tostring` of the created regular expression.

```
> /π/.toString()
'/π/'
> /\u03C0/.toString()
'/\\u03C0/'
> new RegExp('\u03C0').toString()
'/π/'
```