### PR TITLE
refactor: use strings.Builder

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -6,6 +6,7 @@ package ast
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/evanw/esbuild/internal/helpers"
 	"github.com/evanw/esbuild/internal/logger"
@@ -811,15 +812,16 @@ func (minifier NameMinifier) NumberToMinifiedName(i int) string {
 	n_tail := len(minifier.tail)
 
 	j := i % n_head
-	name := minifier.head[j : j+1]
+	var name strings.Builder
+	name.WriteString(minifier.head[j : j+1])
 	i = i / n_head
 
 	for i > 0 {
 		i--
 		j := i % n_tail
-		name += minifier.tail[j : j+1]
+		name.WriteString(minifier.tail[j : j+1])
 		i = i / n_tail
 	}
 
-	return name
+	return name.String()
 }

--- a/internal/bundler_tests/bundler_test.go
+++ b/internal/bundler_tests/bundler_test.go
@@ -34,11 +34,11 @@ func es(version int) compat.JSFeature {
 
 func assertLog(t *testing.T, msgs []logger.Msg, expected string) {
 	t.Helper()
-	text := ""
+	var text strings.Builder
 	for _, msg := range msgs {
-		text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+		text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 	}
-	test.AssertEqualWithDiff(t, text, expected)
+	test.AssertEqualWithDiff(t, text.String(), expected)
 }
 
 func hasErrors(msgs []logger.Msg) bool {
@@ -283,14 +283,14 @@ func (s *suite) updateSnapshots() {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	contents := ""
+	var contents strings.Builder
 	for i, key := range keys {
 		if i > 0 {
-			contents += snapshotSplitter
+			contents.WriteString(snapshotSplitter)
 		}
-		contents += fmt.Sprintf("%s\n%s", key, s.generatedSnapshots[key])
+		contents.WriteString(fmt.Sprintf("%s\n%s", key, s.generatedSnapshots[key]))
 	}
-	if err := ioutil.WriteFile(s.path, []byte(contents), 0644); err != nil {
+	if err := ioutil.WriteFile(s.path, []byte(contents.String()), 0644); err != nil {
 		panic(err)
 	}
 }

--- a/internal/css_lexer/css_lexer_test.go
+++ b/internal/css_lexer/css_lexer_test.go
@@ -1,6 +1,7 @@
 package css_lexer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/evanw/esbuild/internal/logger"
@@ -20,11 +21,11 @@ func lexToken(contents string) (T, string) {
 func lexerError(contents string) string {
 	log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 	Tokenize(log, test.SourceForTest(contents), Options{})
-	text := ""
+	var text strings.Builder
 	for _, msg := range log.Done() {
-		text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+		text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 	}
-	return text
+	return text.String()
 }
 
 func TestTokens(t *testing.T) {

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -2,6 +2,7 @@ package css_parser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/evanw/esbuild/internal/ast"
@@ -19,11 +20,11 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 		tree := Parse(log, test.SourceForTest(contents), OptionsFromConfig(loader, &options))
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqualWithDiff(t, text, expectedLog)
+		test.AssertEqualWithDiff(t, text.String(), expectedLog)
 		symbols := ast.NewSymbolMap(1)
 		symbols.SymbolsForSource[0] = tree.Symbols
 		result := css_printer.Print(tree, symbols, css_printer.Options{

--- a/internal/css_printer/css_printer_test.go
+++ b/internal/css_printer/css_printer_test.go
@@ -1,6 +1,7 @@
 package css_printer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/evanw/esbuild/internal/ast"
@@ -19,13 +20,13 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 			MinifyWhitespace: options.MinifyWhitespace,
 		}))
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
 			if msg.Kind == logger.Error {
-				text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+				text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 			}
 		}
-		test.AssertEqualWithDiff(t, text, "")
+		test.AssertEqualWithDiff(t, text.String(), "")
 		symbols := ast.NewSymbolMap(1)
 		symbols.SymbolsForSource[0] = tree.Symbols
 		result := Print(tree, symbols, options)

--- a/internal/js_lexer/js_lexer_test.go
+++ b/internal/js_lexer/js_lexer_test.go
@@ -53,11 +53,11 @@ func expectLexerError(t *testing.T, contents string, expected string) {
 			NewLexer(log, test.SourceForTest(contents), config.TSOptions{})
 		}()
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqual(t, text, expected)
+		test.AssertEqual(t, text.String(), expected)
 	})
 }
 
@@ -437,11 +437,11 @@ func expectLexerErrorString(t *testing.T, contents string, expected string) {
 			lexer.StringLiteral()
 		}()
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqual(t, text, expected)
+		test.AssertEqual(t, text.String(), expected)
 	})
 }
 

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -5156,7 +5156,8 @@ func (p *parser) parseJSXTag() (logger.Range, string, js_ast.Expr) {
 	tag := js_ast.Expr{Loc: loc, Data: &js_ast.EIdentifier{Ref: p.storeNameInRef(tagName)}}
 
 	// Parse a member expression chain
-	chain := tagName.String
+	var chain strings.Builder
+	chain.WriteString(tagName.String)
 	for p.lexer.Token == js_lexer.TDot {
 		p.lexer.NextInsideJSXElement()
 		memberRange := p.lexer.Range()
@@ -5171,12 +5172,12 @@ func (p *parser) parseJSXTag() (logger.Range, string, js_ast.Expr) {
 			panic(js_lexer.LexerPanic{})
 		}
 
-		chain += "." + member.String
+		chain.WriteString("." + member.String)
 		tag = js_ast.Expr{Loc: loc, Data: p.dotOrMangledPropParse(tag, member, memberRange.Loc, js_ast.OptionalChainNone, wasOriginallyDot)}
 		tagRange.Len = memberRange.Loc.Start + memberRange.Len - tagRange.Loc.Start
 	}
 
-	return tagRange, chain, tag
+	return tagRange, chain.String(), tag
 }
 
 func (p *parser) parseJSXElement(loc logger.Loc) js_ast.Expr {

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -23,11 +23,11 @@ func expectParseErrorCommon(t *testing.T, contents string, expected string, opti
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 		Parse(log, test.SourceForTest(contents), OptionsFromConfig(&options))
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqualWithDiff(t, text, expected)
+		test.AssertEqualWithDiff(t, text.String(), expected)
 	})
 }
 
@@ -67,13 +67,13 @@ func expectPrintedCommon(t *testing.T, contents string, expected string, options
 		options.OmitRuntimeForTests = true
 		tree, ok := Parse(log, test.SourceForTest(contents), OptionsFromConfig(&options))
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
 			if msg.Kind != logger.Warning {
-				text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+				text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 			}
 		}
-		test.AssertEqualWithDiff(t, text, "")
+		test.AssertEqualWithDiff(t, text.String(), "")
 		if !ok {
 			t.Fatal("Parse error")
 		}

--- a/internal/js_parser/json_parser_test.go
+++ b/internal/js_parser/json_parser_test.go
@@ -2,6 +2,7 @@ package js_parser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/evanw/esbuild/internal/ast"
@@ -18,11 +19,11 @@ func expectParseErrorJSON(t *testing.T, contents string, expected string) {
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 		ParseJSON(log, test.SourceForTest(contents), JSONOptions{})
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqualWithDiff(t, text, expected)
+		test.AssertEqualWithDiff(t, text.String(), expected)
 	})
 }
 
@@ -41,11 +42,11 @@ func expectPrintedJSONWithWarning(t *testing.T, contents string, warning string,
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 		expr, ok := ParseJSON(log, test.SourceForTest(contents), JSONOptions{})
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqualWithDiff(t, text, warning)
+		test.AssertEqualWithDiff(t, text.String(), warning)
 		if !ok {
 			t.Fatal("Parse error")
 		}

--- a/internal/js_printer/js_printer_test.go
+++ b/internal/js_printer/js_printer_test.go
@@ -20,14 +20,14 @@ func expectPrintedCommon(t *testing.T, name string, contents string, expected st
 		log := logger.NewDeferLog(logger.DeferLogNoVerboseOrDebug, nil)
 		tree, ok := js_parser.Parse(log, test.SourceForTest(contents), js_parser.OptionsFromConfig(&options))
 		msgs := log.Done()
-		text := ""
+		var text strings.Builder
 		for _, msg := range msgs {
 			if msg.Kind != logger.Error {
 				continue
 			}
-			text += msg.String(logger.OutputOptions{}, logger.TerminalInfo{})
+			text.WriteString(msg.String(logger.OutputOptions{}, logger.TerminalInfo{}))
 		}
-		test.AssertEqualWithDiff(t, text, "")
+		test.AssertEqualWithDiff(t, text.String(), "")
 		if !ok {
 			t.Fatal("Parse error")
 		}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1208,23 +1208,24 @@ type OutputOptions struct {
 
 func (msg Msg) String(options OutputOptions, terminalInfo TerminalInfo) string {
 	// Format the message
-	text := msgString(options.IncludeSource, options.PathStyle, terminalInfo, msg.ID, msg.Kind, msg.Data, msg.PluginName)
+	var text strings.Builder
+	text.WriteString(msgString(options.IncludeSource, options.PathStyle, terminalInfo, msg.ID, msg.Kind, msg.Data, msg.PluginName))
 
 	// Format the notes
 	var oldData MsgData
 	for i, note := range msg.Notes {
 		if options.IncludeSource && (i == 0 || strings.IndexByte(oldData.Text, '\n') >= 0 || oldData.Location != nil) {
-			text += "\n"
+			text.WriteString("\n")
 		}
-		text += msgString(options.IncludeSource, options.PathStyle, terminalInfo, MsgID_None, Note, note, "")
+		text.WriteString(msgString(options.IncludeSource, options.PathStyle, terminalInfo, MsgID_None, Note, note, ""))
 		oldData = note
 	}
 
 	// Add extra spacing between messages if source code is present
 	if options.IncludeSource {
-		text += "\n"
+		text.WriteString("\n")
 	}
-	return text
+	return text.String()
 }
 
 // The number of margin characters in addition to the line number

--- a/internal/resolver/package_json.go
+++ b/internal/resolver/package_json.go
@@ -760,7 +760,7 @@ func parseImportsExportsMap(source logger.Source, log logger.Log, json js_ast.Ex
 				if helpers.IsInsideNodeModules(source.KeyPath.Text) {
 					kind = logger.Debug
 				}
-				var conditions string
+				var conditions strings.Builder
 				conditionWord := "condition"
 				itComesWord := "it comes"
 				if len(deadCondition.ranges) > 1 {
@@ -769,12 +769,12 @@ func parseImportsExportsMap(source logger.Source, log logger.Log, json js_ast.Ex
 				}
 				for i, r := range deadCondition.ranges {
 					if i > 0 {
-						conditions += " and "
+						conditions.WriteString(" and ")
 					}
-					conditions += source.TextForRange(r)
+					conditions.WriteString(source.TextForRange(r))
 				}
 				log.AddIDWithNotes(logger.MsgID_PackageJSON_DeadCondition, kind, &tracker, deadCondition.ranges[0],
-					fmt.Sprintf("The %s %s here will never be used as %s after %s", conditionWord, conditions, itComesWord, deadCondition.reason),
+					fmt.Sprintf("The %s %s here will never be used as %s after %s", conditionWord, conditions.String(), itComesWord, deadCondition.reason),
 					deadCondition.notes)
 			}
 


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.

More info: [golang/go#75190](https://github.com/golang/go/issues/75190)