### PR TITLE
fix #4286: use `Uint8Array.fromBase64` if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
     console.log('size:', width + '\xD7' + height)
     ```
 
+* Use `Uint8Array.fromBase64` if available ([#4286](https://github.com/evanw/esbuild/issues/4286))
+
+    With this release, esbuild's `binary` loader will now use the new [`Uint8Array.fromBase64`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64) function unless it's unavailable in the configured target environment. If it's unavailable, esbuild's previous code for this will be used as a fallback.
+
 ## 0.25.10
 
 * Fix a panic in a minification edge case ([#4287](https://github.com/evanw/esbuild/issues/4287))

--- a/compat-table/src/index.ts
+++ b/compat-table/src/index.ts
@@ -53,6 +53,7 @@ export const jsFeatures = {
   ExportStarAs: true,
   ForAwait: true,
   ForOf: true,
+  FromBase64: true,
   FunctionNameConfigurable: true,
   FunctionOrClassPropertyAccess: true,
   Generator: true,

--- a/compat-table/src/mdn.ts
+++ b/compat-table/src/mdn.ts
@@ -18,6 +18,7 @@ const supportedEnvironments: Record<string, Engine> = {
 const jsFeatures: Partial<Record<JSFeature, string>> = {
   ClassStaticBlocks: 'javascript.classes.static.initialization_blocks',
   ExportStarAs: 'javascript.statements.export.namespace',
+  FromBase64: 'javascript.builtins.Uint8Array.fromBase64',
   ImportAssertions: 'javascript.statements.import.import_assertions',
   ImportAttributes: 'javascript.statements.import.import_attributes',
   ImportMeta: 'javascript.operators.import_meta',

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -307,7 +307,7 @@ func parseFile(args parseArgs) {
 		expr, ok := args.caches.JSONCache.Parse(args.log, source, js_parser.JSONOptions{
 			UnsupportedJSFeatures: args.options.UnsupportedJSFeatures,
 		})
-		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, "")
+		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, nil)
 		if loader == config.LoaderWithTypeJSON {
 			// The exports kind defaults to "none", in which case the linker picks
 			// either ESM or CommonJS depending on the situation. Dynamic imports
@@ -330,7 +330,7 @@ func parseFile(args parseArgs) {
 		source.Contents = strings.TrimPrefix(source.Contents, "\xEF\xBB\xBF") // Strip any UTF-8 BOM from the text
 		encoded := base64.StdEncoding.EncodeToString([]byte(source.Contents))
 		expr := js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(source.Contents)}}
-		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, "")
+		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, nil)
 		ast.URLForCSS = "data:text/plain;base64," + encoded
 		if pluginName != "" {
 			result.file.inputFile.SideEffects.Kind = graph.NoSideEffects_PureData_FromPlugin
@@ -344,7 +344,7 @@ func parseFile(args parseArgs) {
 		mimeType := guessMimeType(ext, source.Contents)
 		encoded := base64.StdEncoding.EncodeToString([]byte(source.Contents))
 		expr := js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(encoded)}}
-		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, "")
+		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, nil)
 		ast.URLForCSS = "data:" + mimeType + ";base64," + encoded
 		if pluginName != "" {
 			result.file.inputFile.SideEffects.Kind = graph.NoSideEffects_PureData_FromPlugin
@@ -357,9 +357,15 @@ func parseFile(args parseArgs) {
 	case config.LoaderBinary:
 		encoded := base64.StdEncoding.EncodeToString([]byte(source.Contents))
 		expr := js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(encoded)}}
-		helper := "__toBinary"
-		if args.options.Platform == config.PlatformNode {
-			helper = "__toBinaryNode"
+		var helper *js_parser.HelperCall
+		if args.options.UnsupportedJSFeatures.Has(compat.FromBase64) {
+			if args.options.Platform == config.PlatformNode {
+				helper = &js_parser.HelperCall{Runtime: "__toBinaryNode"}
+			} else {
+				helper = &js_parser.HelperCall{Runtime: "__toBinary"}
+			}
+		} else {
+			helper = &js_parser.HelperCall{Global: []string{"Uint8Array", "fromBase64"}}
 		}
 		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, helper)
 		ast.URLForCSS = "data:application/octet-stream;base64," + encoded
@@ -375,7 +381,7 @@ func parseFile(args parseArgs) {
 		mimeType := guessMimeType(ext, source.Contents)
 		url := helpers.EncodeStringAsShortestDataURL(mimeType, source.Contents)
 		expr := js_ast.Expr{Data: &js_ast.EString{Value: helpers.StringToUTF16(url)}}
-		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, "")
+		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, nil)
 		ast.URLForCSS = url
 		if pluginName != "" {
 			result.file.inputFile.SideEffects.Kind = graph.NoSideEffects_PureData_FromPlugin
@@ -392,7 +398,7 @@ func parseFile(args parseArgs) {
 			Value:             helpers.StringToUTF16(uniqueKeyPath),
 			ContainsUniqueKey: true,
 		}}
-		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, "")
+		ast := js_parser.LazyExportAST(args.log, source, js_parser.OptionsFromConfig(&args.options), expr, nil)
 		ast.URLForCSS = uniqueKeyPath
 		if pluginName != "" {
 			result.file.inputFile.SideEffects.Kind = graph.NoSideEffects_PureData_FromPlugin
@@ -1711,7 +1717,7 @@ func (s *scanner) preprocessInjectedFiles() {
 
 		// Generate the file inline here since it has already been parsed
 		expr := js_ast.Expr{Data: define.Data}
-		ast := js_parser.LazyExportAST(s.log, source, js_parser.OptionsFromConfig(&s.options), expr, "")
+		ast := js_parser.LazyExportAST(s.log, source, js_parser.OptionsFromConfig(&s.options), expr, nil)
 		result := parseResult{
 			ok: true,
 			file: scannerFile{
@@ -2599,7 +2605,7 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 										Repr: &graph.JSRepr{
 											// Note: The actual export object will be filled in by the linker
 											AST: js_parser.LazyExportAST(s.log, source,
-												js_parser.OptionsFromConfig(&s.options), js_ast.Expr{Data: js_ast.ENullShared}, ""),
+												js_parser.OptionsFromConfig(&s.options), js_ast.Expr{Data: js_ast.ENullShared}, nil),
 											CSSSourceIndex: ast.MakeIndex32(record.SourceIndex.GetIndex()),
 										},
 									},

--- a/internal/bundler_tests/snapshots/snapshots_loader.txt
+++ b/internal/bundler_tests/snapshots/snapshots_loader.txt
@@ -1167,7 +1167,7 @@ console.log(require_test());
 TestWithTypeBytesOverrideLoader
 ---------- /out.js ----------
 // foo.js
-var foo_default = __toBinary("ZXhwb3J0IGRlZmF1bHQgJ2pzJw==");
+var foo_default = Uint8Array.fromBase64("ZXhwb3J0IGRlZmF1bHQgJ2pzJw==");
 
 // entry.js
 console.log(foo_default);
@@ -1178,7 +1178,7 @@ TestWithTypeBytesOverrideLoaderGlob
 // foo.js
 var require_foo = __commonJS({
   "foo.js"(exports, module) {
-    module.exports = __toBinary("ZXhwb3J0IGRlZmF1bHQgJ2pzJw==");
+    module.exports = Uint8Array.fromBase64("ZXhwb3J0IGRlZmF1bHQgJ2pzJw==");
   }
 });
 

--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -86,6 +86,7 @@ const (
 	ExportStarAs
 	ForAwait
 	ForOf
+	FromBase64
 	FunctionNameConfigurable
 	FunctionOrClassPropertyAccess
 	Generator
@@ -149,6 +150,7 @@ var StringToJSFeature = map[string]JSFeature{
 	"export-star-as":                    ExportStarAs,
 	"for-await":                         ForAwait,
 	"for-of":                            ForOf,
+	"from-base64":                       FromBase64,
 	"function-name-configurable":        FunctionNameConfigurable,
 	"function-or-class-property-access": FunctionOrClassPropertyAccess,
 	"generator":                         Generator,
@@ -528,6 +530,14 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 		Node:    {{start: v{6, 5, 0}}},
 		Opera:   {{start: v{38, 0, 0}}},
 		Safari:  {{start: v{10, 0, 0}}},
+	},
+	FromBase64: {
+		Chrome:  {{start: v{140, 0, 0}}},
+		Edge:    {{start: v{140, 0, 0}}},
+		Firefox: {{start: v{133, 0, 0}}},
+		IOS:     {{start: v{18, 2, 0}}},
+		Opera:   {{start: v{124, 0, 0}}},
+		Safari:  {{start: v{18, 2, 0}}},
 	},
 	FunctionNameConfigurable: {
 		// Note: The latest version of "IE" failed this test: function "name" property: isn't writable, is configurable

--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -17818,7 +17818,12 @@ func Parse(log logger.Log, source logger.Source, options Options) (result js_ast
 	return
 }
 
-func LazyExportAST(log logger.Log, source logger.Source, options Options, expr js_ast.Expr, apiCall string) js_ast.AST {
+type HelperCall struct {
+	Global  []string
+	Runtime string
+}
+
+func LazyExportAST(log logger.Log, source logger.Source, options Options, expr js_ast.Expr, helperCall *HelperCall) js_ast.AST {
 	// Don't create a new lexer using js_lexer.NewLexer() here since that will
 	// actually attempt to parse the first token, which might cause a syntax
 	// error.
@@ -17826,9 +17831,21 @@ func LazyExportAST(log logger.Log, source logger.Source, options Options, expr j
 	p.prepareForVisitPass()
 
 	// Optionally call a runtime API function to transform the expression
-	if apiCall != "" {
+	if helperCall != nil {
 		p.symbolUses = make(map[ast.Ref]js_ast.SymbolUse)
-		expr = p.callRuntime(expr.Loc, apiCall, []js_ast.Expr{expr})
+		if len(helperCall.Global) > 0 {
+			ref := p.newSymbol(ast.SymbolUnbound, helperCall.Global[0])
+			p.recordUsage(ref)
+			target := js_ast.Expr{Data: &js_ast.EIdentifier{Ref: ref}}
+			kind := js_ast.NormalCall
+			for _, name := range helperCall.Global[1:] {
+				target.Data = &js_ast.EDot{Target: target, Name: name}
+				kind = js_ast.TargetWasOriginallyPropertyAccess
+			}
+			expr.Data = &js_ast.ECall{Target: target, Args: []js_ast.Expr{expr}, Kind: kind}
+		} else {
+			expr = p.callRuntime(expr.Loc, helperCall.Runtime, []js_ast.Expr{expr})
+		}
 	}
 
 	// Add an empty part for the namespace export that we can fill in later

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -7923,11 +7923,11 @@ for (const length of [0, 1, 2, 3, 4, 5, 6, 7, 8, 256]) {
   `
   const data = Buffer.from([...' '.repeat(length)].map((_, i) => i ^ 0x55))
   tests.push(
-    test(['entry.js', '--bundle', '--outfile=node.js', '--loader:.bin=binary', '--platform=browser'], {
+    test(['entry.js', '--bundle', '--outfile=node.js', '--loader:.bin=binary', '--platform=browser', '--supported:from-base64=false'], {
       'entry.js': code,
       'data.bin': data,
     }),
-    test(['entry.js', '--bundle', '--outfile=node.js', '--loader:.bin=binary', '--platform=node'], {
+    test(['entry.js', '--bundle', '--outfile=node.js', '--loader:.bin=binary', '--platform=node', '--supported:from-base64=false'], {
       'entry.js': code,
       'data.bin': data,
     }),

--- a/scripts/plugin-tests.js
+++ b/scripts/plugin-tests.js
@@ -1000,6 +1000,7 @@ let pluginTests = {
       bundle: true,
       outfile: output,
       format: 'cjs',
+      target: process.version.replace('v', 'node'),
       plugins: [{
         name: 'name',
         setup(build) {


### PR DESCRIPTION
With this change, esbuild's `binary` loader will now use the new [`Uint8Array.fromBase64`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64) function unless it's unavailable in the configured target environment. If it's unavailable, esbuild's previous code for this will be used as a fallback.

Fixes #4286