### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/cmd/esbuild/main_wasm.go
+++ b/cmd/esbuild/main_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package main
 

--- a/internal/fs/error_wasm+windows.go
+++ b/internal/fs/error_wasm+windows.go
@@ -1,5 +1,4 @@
 //go:build (js && wasm) || windows
-// +build js,wasm windows
 
 package fs
 

--- a/internal/fs/iswin_wasm.go
+++ b/internal/fs/iswin_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package fs
 

--- a/internal/fs/iswin_windows.go
+++ b/internal/fs/iswin_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package fs
 

--- a/internal/fs/modkey_other.go
+++ b/internal/fs/modkey_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !freebsd && !linux
-// +build !darwin,!freebsd,!linux
 
 package fs
 

--- a/internal/logger/logger_linux.go
+++ b/internal/logger/logger_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package logger
 

--- a/internal/logger/logger_other.go
+++ b/internal/logger/logger_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !linux && !windows
-// +build !darwin,!linux,!windows
 
 package logger
 

--- a/internal/logger/logger_windows.go
+++ b/internal/logger/logger_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package logger
 

--- a/pkg/api/serve_wasm.go
+++ b/pkg/api/serve_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package api
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild