### PR TITLE
feat: add `revert-rule` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+* Add support for the new [`revert-rule`](https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword) CSS-wide keyword ([#4312](https://github.com/evanw/esbuild/pull/4312))
+
+    The `revert-rule` keyword can be combined with `if()` to conditionally ignore a declaration:
+
+    ```css
+    div {
+      color: black;
+    }
+    .apply-sharp {
+      color: if(style(--theme: dark): white; else: revert-rule);
+    }
+    ```
+
+    This was contributed by [@yisibl](https://github.com/yisibl).
+
 * Add support for the new `@view-transition` CSS at rule ([#4313](https://github.com/evanw/esbuild/pull/4313))
 
     ```css

--- a/internal/css_parser/css_decls_font_family.go
+++ b/internal/css_parser/css_decls_font_family.go
@@ -31,6 +31,7 @@ var cssWideAndReservedKeywords = map[string]bool{
 	// CSS Cascading and Inheritance Level 5: https://drafts.csswg.org/css-cascade-5/#defaulting-keywords
 	"revert":       true, // Cascade-dependent keyword
 	"revert-layer": true, // Cascade-dependent keyword
+	"revert-rule":  true, // Cascade-dependent keyword
 }
 
 // Font family names that happen to be the same as a keyword value must be

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1749,6 +1749,16 @@ func TestAnimationName(t *testing.T) {
 	expectPrinted(t, "div { animation: 2s linear 'name 2', 3s infinite 'name 3' }", "div {\n  animation: 2s linear name\\ 2, 3s infinite name\\ 3;\n}\n", "")
 }
 
+func TestCSSWideKeywords(t *testing.T) {
+	expectPrinted(t, "div { color: inherit; }", "div {\n  color: inherit;\n}\n", "")
+	expectPrinted(t, "div { color: initial; }", "div {\n  color: initial;\n}\n", "")
+	expectPrinted(t, "div { color: unset; }", "div {\n  color: unset;\n}\n", "")
+	expectPrinted(t, "div { color: revert; }", "div {\n  color: revert;\n}\n", "")
+	expectPrinted(t, "div { color: revert-layer; }", "div {\n  color: revert-layer;\n}\n", "")
+	expectPrinted(t, "div { color: revert-rule; }", "div {\n  color: revert-rule;\n}\n", "")
+	expectPrinted(t, "div { color: if(style(--theme: dark): white; else: revert-rule) }", "div {\n  color: if(style(--theme: dark): white; else: revert-rule);\n}\n", "")
+}
+
 func TestAtRuleValidation(t *testing.T) {
 	expectPrinted(t, "a {} b {} c {} @charset \"UTF-8\";", "a {\n}\nb {\n}\nc {\n}\n@charset \"UTF-8\";\n",
 		"<stdin>: WARNING: \"@charset\" must be the first rule in the file\n"+
@@ -2706,6 +2716,7 @@ func TestFontFamily(t *testing.T) {
 	expectPrintedMangleMinify(t, "a {font-family: 'unset', serif;}", "a{font-family:\"unset\",serif}", "")
 	expectPrintedMangleMinify(t, "a {font-family: 'revert', serif;}", "a{font-family:\"revert\",serif}", "")
 	expectPrintedMangleMinify(t, "a {font-family: 'revert-layer', 'Segoe UI', serif;}", "a{font-family:\"revert-layer\",Segoe UI,serif}", "")
+	expectPrintedMangleMinify(t, "a {font-family: 'revert-rule', 'Segoe UI', serif;}", "a{font-family:\"revert-rule\",Segoe UI,serif}", "")
 	expectPrintedMangleMinify(t, "a {font-family: 'default', serif;}", "a{font-family:\"default\",serif}", "")
 }
 


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword
CSSWG PR: https://github.com/w3c/csswg-drafts/pull/12992
Blink CL: https://chromium-review.googlesource.com/c/chromium/src/+/6884901
Safari TP 240: https://webkit.org/blog/17896/release-notes-for-safari-technology-preview-240/#:~:text=Added%20support%20for%20the%20revert%2Drule