### PR TITLE
fix: escape dev server breadcrumb hrefs properly

### DIFF
--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -668,7 +668,7 @@ func respondWithDirList(queryPath string, dirEntries map[string]bool, fileEntrie
 	for i, part := range parts {
 		if i+1 < len(parts) {
 			html.WriteString("<a href=\"")
-			html.WriteString(escapeForHTML(strings.Join(parts[:i+1], "/")))
+			html.WriteString(escapeForAttribute(strings.Join(parts[:i+1], "/")))
 			html.WriteString("/\">")
 		}
 		html.WriteString(escapeForHTML(part))


### PR DESCRIPTION
The dev-server directory listing used to build breadcrumb links with `escapeForHTML`, which leaves quotes unescaped. A directory name containing `"` breaks out of the href attribute and can inject arbitrary html attributes, leading to XSS or unintended behavior.

This PR switches the breadcrumb link escaping to use the `escapeForAttribute` helper so quotes are properly encoded and attribute injection is no longer possible.