### PR TITLE
compact metafile JSON blob

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -2419,7 +2419,7 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 		// Begin the metadata chunk
 		if s.options.NeedsMetafile {
 			sb.Write(helpers.QuoteForJSON(result.file.inputFile.Source.PrettyPaths.Select(s.options.MetafilePathStyle), s.options.ASCIIOnly))
-			sb.WriteString(fmt.Sprintf(": {\n      \"bytes\": %d,\n      \"imports\": [", len(result.file.inputFile.Source.Contents)))
+			sb.WriteString(fmt.Sprintf(":{\"bytes\":%d,\"imports\":[", len(result.file.inputFile.Source.Contents)))
 		}
 
 		// Don't try to resolve paths if we're not bundling
@@ -2435,17 +2435,16 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 				if s.options.NeedsMetafile {
 					if with := record.AssertOrWith; with != nil && with.Keyword == ast.WithKeyword && len(with.Entries) > 0 {
 						data := strings.Builder{}
-						data.WriteString(",\n          \"with\": {")
+						data.WriteString(",\"with\":{")
 						for i, entry := range with.Entries {
 							if i > 0 {
 								data.WriteByte(',')
 							}
-							data.WriteString("\n            ")
 							data.Write(helpers.QuoteForJSON(helpers.UTF16ToString(entry.Key), s.options.ASCIIOnly))
-							data.WriteString(": ")
+							data.WriteByte(':')
 							data.Write(helpers.QuoteForJSON(helpers.UTF16ToString(entry.Value), s.options.ASCIIOnly))
 						}
-						data.WriteString("\n          }")
+						data.WriteByte('}')
 						metafileWith = data.String()
 					}
 				}
@@ -2456,11 +2455,10 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 					if s.options.NeedsMetafile {
 						if isFirstImport {
 							isFirstImport = false
-							sb.WriteString("\n        ")
 						} else {
-							sb.WriteString(",\n        ")
+							sb.WriteByte(',')
 						}
-						sb.WriteString(fmt.Sprintf("{\n          \"path\": %s,\n          \"kind\": %s,\n          \"external\": true%s\n        }",
+						sb.WriteString(fmt.Sprintf("{\"path\":%s,\"kind\":%s,\"external\":true%s}",
 							helpers.QuoteForJSON(record.Path.Text, s.options.ASCIIOnly),
 							helpers.QuoteForJSON(record.Kind.StringForMetafile(), s.options.ASCIIOnly),
 							metafileWith))
@@ -2493,11 +2491,10 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 				if s.options.NeedsMetafile {
 					if isFirstImport {
 						isFirstImport = false
-						sb.WriteString("\n        ")
 					} else {
-						sb.WriteString(",\n        ")
+						sb.WriteByte(',')
 					}
-					sb.WriteString(fmt.Sprintf("{\n          \"path\": %s,\n          \"kind\": %s,\n          \"original\": %s%s\n        }",
+					sb.WriteString(fmt.Sprintf("{\"path\":%s,\"kind\":%s,\"original\":%s%s}",
 						helpers.QuoteForJSON(otherFile.inputFile.Source.PrettyPaths.Select(s.options.MetafilePathStyle), s.options.ASCIIOnly),
 						helpers.QuoteForJSON(record.Kind.StringForMetafile(), s.options.ASCIIOnly),
 						helpers.QuoteForJSON(record.Path.Text, s.options.ASCIIOnly),
@@ -2668,33 +2665,29 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 
 		// End the metadata chunk
 		if s.options.NeedsMetafile {
-			if !isFirstImport {
-				sb.WriteString("\n      ")
-			}
 			if repr, ok := result.file.inputFile.Repr.(*graph.JSRepr); ok &&
 				(repr.AST.ExportsKind == js_ast.ExportsCommonJS || repr.AST.ExportsKind == js_ast.ExportsESM) {
 				format := "cjs"
 				if repr.AST.ExportsKind == js_ast.ExportsESM {
 					format = "esm"
 				}
-				sb.WriteString(fmt.Sprintf("],\n      \"format\": %q", format))
+				sb.WriteString(fmt.Sprintf("],\"format\":%q", format))
 			} else {
 				sb.WriteString("]")
 			}
 			if attrs := result.file.inputFile.Source.KeyPath.ImportAttributes.DecodeIntoArray(); len(attrs) > 0 {
-				sb.WriteString(",\n      \"with\": {")
+				sb.WriteString(",\"with\":{")
 				for i, attr := range attrs {
 					if i > 0 {
 						sb.WriteByte(',')
 					}
-					sb.WriteString(fmt.Sprintf("\n        %s: %s",
-						helpers.QuoteForJSON(attr.Key, s.options.ASCIIOnly),
-						helpers.QuoteForJSON(attr.Value, s.options.ASCIIOnly),
-					))
+					sb.Write(helpers.QuoteForJSON(attr.Key, s.options.ASCIIOnly))
+					sb.WriteByte(':')
+					sb.Write(helpers.QuoteForJSON(attr.Value, s.options.ASCIIOnly))
 				}
-				sb.WriteString("\n      }")
+				sb.WriteByte('}')
 			}
-			sb.WriteString("\n    }")
+			sb.WriteByte('}')
 		}
 
 		result.file.jsonMetadataChunk = sb.String()
@@ -2763,17 +2756,17 @@ func (s *scanner) processScannedFiles(entryPointMeta []graph.EntryPoint) []scann
 			// Optionally add metadata about the file
 			var jsonMetadataChunk string
 			if s.options.NeedsMetafile {
-				inputs := fmt.Sprintf("{\n        %s: {\n          \"bytesInOutput\": %d\n        }\n      }",
+				inputs := fmt.Sprintf("{%s:{\"bytesInOutput\":%d}}",
 					helpers.QuoteForJSON(result.file.inputFile.Source.PrettyPaths.Select(s.options.MetafilePathStyle), s.options.ASCIIOnly),
 					len(bytes),
 				)
 				entryPointJSON := ""
 				if isEntryPoint {
-					entryPointJSON = fmt.Sprintf("\"entryPoint\": %s,\n      ",
+					entryPointJSON = fmt.Sprintf("\"entryPoint\":%s,",
 						helpers.QuoteForJSON(result.file.inputFile.Source.PrettyPaths.Select(s.options.MetafilePathStyle), s.options.ASCIIOnly))
 				}
 				jsonMetadataChunk = fmt.Sprintf(
-					"{\n      \"imports\": [],\n      \"exports\": [],\n      %s\"inputs\": %s,\n      \"bytes\": %d\n    }",
+					"{\"imports\":[],\"exports\":[],%s\"inputs\":%s,\"bytes\":%d}",
 					entryPointJSON,
 					inputs,
 					len(bytes),
@@ -3259,7 +3252,7 @@ func (b *Bundle) computeDataForSourceMapsInParallel(options *config.Options, rea
 
 func (b *Bundle) generateMetadataJSON(results []graph.OutputFile, allReachableFiles []uint32, asciiOnly bool) string {
 	sb := strings.Builder{}
-	sb.WriteString("{\n  \"inputs\": {")
+	sb.WriteString("{\"inputs\":{")
 
 	// Write inputs
 	isFirst := true
@@ -3270,15 +3263,14 @@ func (b *Bundle) generateMetadataJSON(results []graph.OutputFile, allReachableFi
 		if file := &b.files[sourceIndex]; len(file.jsonMetadataChunk) > 0 {
 			if isFirst {
 				isFirst = false
-				sb.WriteString("\n    ")
 			} else {
-				sb.WriteString(",\n    ")
+				sb.WriteByte(',')
 			}
 			sb.WriteString(file.jsonMetadataChunk)
 		}
 	}
 
-	sb.WriteString("\n  },\n  \"outputs\": {")
+	sb.WriteString("},\"outputs\":{")
 
 	// Write outputs
 	isFirst = true
@@ -3293,17 +3285,17 @@ func (b *Bundle) generateMetadataJSON(results []graph.OutputFile, allReachableFi
 			}
 			if isFirst {
 				isFirst = false
-				sb.WriteString("\n    ")
 			} else {
-				sb.WriteString(",\n    ")
+				sb.WriteByte(',')
 			}
 			pathMap[path] = struct{}{}
-			sb.WriteString(fmt.Sprintf("%s: ", helpers.QuoteForJSON(path, asciiOnly)))
+			sb.Write(helpers.QuoteForJSON(path, asciiOnly))
+			sb.WriteByte(':')
 			sb.WriteString(result.JSONMetadataChunk)
 		}
 	}
 
-	sb.WriteString("\n  }\n}\n")
+	sb.WriteString("}}")
 	return sb.String()
 }
 

--- a/internal/css_printer/css_printer.go
+++ b/internal/css_printer/css_printer.go
@@ -93,9 +93,9 @@ func (p *printer) recordImportPathForMetafile(importRecordIndex uint32) {
 		record := p.importRecords[importRecordIndex]
 		external := ""
 		if (record.Flags & ast.ShouldNotBeExternalInMetafile) == 0 {
-			external = ",\n          \"external\": true"
+			external = ",\"external\":true"
 		}
-		p.jsonMetadataImports = append(p.jsonMetadataImports, fmt.Sprintf("\n        {\n          \"path\": %s,\n          \"kind\": %s%s\n        }",
+		p.jsonMetadataImports = append(p.jsonMetadataImports, fmt.Sprintf("{\"path\":%s,\"kind\":%s%s}",
 			helpers.QuoteForJSON(record.Path.Text, p.options.ASCIIOnly),
 			helpers.QuoteForJSON(record.Kind.StringForMetafile(), p.options.ASCIIOnly),
 			external))

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -3936,9 +3936,9 @@ func (p *printer) printPath(importRecordIndex uint32, importKind ast.ImportKind)
 	if p.options.NeedsMetafile {
 		external := ""
 		if (record.Flags & ast.ShouldNotBeExternalInMetafile) == 0 {
-			external = ",\n          \"external\": true"
+			external = ",\"external\":true"
 		}
-		p.jsonMetadataImports = append(p.jsonMetadataImports, fmt.Sprintf("\n        {\n          \"path\": %s,\n          \"kind\": %s%s\n        }",
+		p.jsonMetadataImports = append(p.jsonMetadataImports, fmt.Sprintf("{\"path\":%s,\"kind\":%s%s}",
 			helpers.QuoteForJSON(record.Path.Text, p.options.ASCIIOnly),
 			helpers.QuoteForJSON(importKind.StringForMetafile(), p.options.ASCIIOnly),
 			external))


### PR DESCRIPTION
- Closes https://github.com/evanw/esbuild/issues/4329

This PR is compacting the metafile JSON blob contents to cut down the size and stay under the 512MiB string size limit in Node.js.

The tests have been extended to ensure that the metafile is properly compacted. The test snapshots use a pretty-printed blob for easier debugging.

See https://github.com/evanw/esbuild/issues/4329#issuecomment-3602112443 for alternatives considered.