### PR TITLE
feat(css): support var() in alpha channel when lowering rgb/hsl

### DIFF
--- a/internal/css_parser/css_decls_color.go
+++ b/internal/css_parser/css_decls_color.go
@@ -351,8 +351,11 @@ func (p *parser) lowerAndMinifyColor(token css_ast.Token, wouldClipColor *bool) 
 
 					// "rgb(1 2 3 / 4%)" => "rgba(1, 2, 3, 0.04)"
 					// "hsl(1 2% 3% / 4%)" => "hsla(1, 2%, 3%, 0.04)"
-					if args[0].Kind.IsNumeric() && args[1].Kind.IsNumeric() && args[2].Kind.IsNumeric() &&
-						args[3].Kind == css_lexer.TDelimSlash && args[4].Kind.IsNumeric() {
+					// "rgb(1 2 3 / var(--a))" => "rgba(1, 2, 3, var(--a))"
+					// "hsl(1 2% 3% / var(--a))" => "hsla(1, 2%, 3%, var(--a))"
+					if args[0].Kind.IsNumeric() && args[1].Kind.IsNumeric() &&
+						args[2].Kind.IsNumeric() && args[3].Kind == css_lexer.TDelimSlash &&
+						(args[4].Kind.IsNumeric() || (args[4].Kind == css_lexer.TFunction && strings.EqualFold(args[4].Text, "var"))) {
 						addAlpha = true
 						args[0].Whitespace = 0
 						args[1].Whitespace = 0

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -651,6 +651,7 @@ func TestColorRGBA(t *testing.T) {
 	expectPrintedLowerMangle(t, "a { color: rgba(1, 2, 3, 40%) }", "a {\n  color: rgba(1, 2, 3, .4);\n}\n", "")
 
 	expectPrintedLowerMangle(t, "a { color: rgb(var(--x) var(--y) var(--z)) }", "a {\n  color: rgb(var(--x) var(--y) var(--z));\n}\n", "")
+	expectPrintedLowerMangle(t, "a { color: rgb(1 2 3 / var(--a)) }", "a {\n  color: rgba(1, 2, 3, var(--a));\n}\n", "")
 }
 
 func TestColorHSLA(t *testing.T) {
@@ -670,6 +671,7 @@ func TestColorHSLA(t *testing.T) {
 	expectPrintedLowerMangle(t, "a { color: hsla(1, 2%, 3%, 40%) }", "a {\n  color: rgba(8, 8, 7, .4);\n}\n", "")
 
 	expectPrintedLowerMangle(t, "a { color: hsl(var(--x) var(--y) var(--z)) }", "a {\n  color: hsl(var(--x) var(--y) var(--z));\n}\n", "")
+	expectPrintedLowerMangle(t, "a { color: hsl(1 2% 3% / var(--a)) }", "a {\n  color: hsla(1, 2%, 3%, var(--a));\n}\n", "")
 }
 
 func TestLowerColor(t *testing.T) {


### PR DESCRIPTION

When lowering modern CSS color syntax (space-separated) to legacy syntax (comma-separated), esbuild previously failed to convert colors containing `var()` in the alpha channel. This PR fixes that behavior.

**Example:**
```css
/* source */
a { color: rgb(255 255 255 / 0.5); }
a { color: rgb(255 255 255 / var(--a)); }

/* before (esbuild failed to lower the second rule) */
a { color: rgba(255, 255, 255, 0.5); }
a { color: rgb(255 255 255 / var(--a)); }

/* after */
a { color: rgba(255, 255, 255, 0.5); }
a { color: rgba(255, 255, 255, var(--a)); }
```

This is particularly useful for Tailwind CSS (v3), which generates text colors using this pattern:

```css
.text-red-500 {
  --tw-text-opacity: 1;
  color: rgb(239 68 68 / var(--tw-text-opacity, 1));
}
```


See also:
- https://play.tailwindcss.com/iwGsSpx7Rj
- https://preset-env.cssdb.org/playground/#JTdCJTIyc291cmNlJTIyJTNBJTIyLnRleHQtcmVkLTUwMCUyMCU3QiU1Q24lMjAlMjAtLXR3LXRleHQtb3BhY2l0eSUzQSUyMDElM0IlNUNuJTIwJTIwY29sb3IlM0ElMjByZ2IoMjM5JTIwNjglMjA2OCUyMCUyRiUyMHZhcigtLXR3LXRleHQtb3BhY2l0eSUyQyUyMDEpKSUzQiU1Q24lN0QlNUNuJTIyJTJDJTIyY29uZmlnJTIyJTNBJTdCJTIyYnJvd3NlcnMlMjIlM0ElNUIlMjJjaHJvbWUlMjA2MCUyMiU1RCUyQyUyMm1pbmltdW1WZW5kb3JJbXBsZW1lbnRhdGlvbnMlMjIlM0EwJTJDJTIyc3RhZ2UlMjIlM0EyJTJDJTIyZW5hYmxlQ2xpZW50U2lkZVBvbHlmaWxscyUyMiUzQWZhbHNlJTJDJTIybG9naWNhbCUyMiUzQSU3QiUyMmlubGluZURpcmVjdGlvbiUyMiUzQSUyMmxlZnQtdG8tcmlnaHQlMjIlMkMlMjJibG9ja0RpcmVjdGlvbiUyMiUzQSUyMnRvcC10by1ib3R0b20lMjIlN0QlN0QlN0Q=
- https://esbuild.github.io/try/#YgAwLjI3LjAALS10YXJnZXQ9Y2hyb21lNjAAZQBlbnRyeS5jc3MALnRleHQtcmVkLTUwMCB7CiAgLS10dy10ZXh0LW9wYWNpdHk6IDE7CiAgY29sb3I6IHJnYigyMzkgNjggNjggLyB2YXIoLS10dy10ZXh0LW9wYWNpdHksIDEpKTsKfQ