### PR TITLE
fix: allow subpath imports that start with `#/`

### DIFF
--- a/internal/bundler_tests/snapshots/snapshots_packagejson.txt
+++ b/internal/bundler_tests/snapshots/snapshots_packagejson.txt
@@ -811,6 +811,39 @@ console.log("c.js");
 console.log("d.js");
 
 ================================================================================
+TestPackageJsonImportsHashSlashExactMatch
+---------- /Users/user/project/out.js ----------
+// Users/user/project/src/index.js
+console.log("index.js");
+
+// Users/user/project/src/utils.js
+console.log("utils.js");
+
+================================================================================
+TestPackageJsonImportsHashSlashSymmetricWithExports
+---------- /Users/user/project/out.js ----------
+// Users/user/project/src/src/components/button.js
+console.log("button.js");
+
+// Users/user/project/src/src/utils/format.js
+console.log("format.js");
+
+================================================================================
+TestPackageJsonImportsHashSlashWithConditions
+---------- /Users/user/project/out.js ----------
+// Users/user/project/src/esm/lib.js
+console.log("esm/lib.js");
+
+================================================================================
+TestPackageJsonImportsHashSlashWithWildcard
+---------- /Users/user/project/out.js ----------
+// Users/user/project/src/src/foo.js
+console.log("foo.js");
+
+// Users/user/project/src/src/bar/baz.js
+console.log("bar/baz.js");
+
+================================================================================
 TestPackageJsonMain
 ---------- /Users/user/project/out.js ----------
 // Users/user/project/node_modules/demo-pkg/custom-main.js

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2255,10 +2255,10 @@ func (r resolverQuery) loadPackageImports(importPath string, dirInfoPackageJSON 
 	}
 
 	// Filter out invalid module specifiers now where we have more information for
-	// a better error message instead of later when we're inside the algorithm
-	if importPath == "#" || strings.HasPrefix(importPath, "#/") {
+	// a better error message instead of later when we're inside the algorithm.
+	if importPath == "#" {
 		if r.debugLogs != nil {
-			r.debugLogs.addNote(fmt.Sprintf("The path %q must not equal \"#\" and must not start with \"#/\".", importPath))
+			r.debugLogs.addNote(fmt.Sprintf("The path %q must not equal \"#\".", importPath))
 		}
 		tracker := logger.MakeLineColumnTracker(&packageJSON.source)
 		r.debugMeta.notes = append(r.debugMeta.notes, tracker.MsgData(packageJSON.importsMap.root.firstToken,


### PR DESCRIPTION
This aligns with the upcoming behavior in node that also started landing in other bundlers (Vite, webpack).

See: https://github.com/nodejs/node/pull/60864