### PR TITLE
fix #4378: visit lowerForAwaitLoop catch body refs

### DIFF
--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -1151,6 +1151,10 @@ func (p *parser) lowerForAwaitLoop(loc logger.Loc, loop *js_ast.SForOf, stmts []
 	awaitIterNext = p.maybeLowerAwait(awaitIterNext.Loc, &js_ast.EAwait{Value: awaitIterNext})
 	awaitTempCallIter = p.maybeLowerAwait(awaitTempCallIter.Loc, &js_ast.EAwait{Value: awaitTempCallIter})
 
+	// these refs are used in the catch body but the catch body AST won't be visited, so we record their usage here
+	p.recordUsage(tempRef)
+	p.recordUsage(errorRef)
+
 	return append(stmts, js_ast.Stmt{Loc: loc, Data: &js_ast.STry{
 		BlockLoc: loc,
 		Block: js_ast.SBlock{

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -831,6 +831,11 @@ func TestForAwait(t *testing.T) {
 			"<stdin>: NOTE: This file is considered to be an ECMAScript module because of the top-level \"await\" keyword here:\n")
 }
 
+func TestForAwaitCatchBindingNotElided(t *testing.T) {
+	expectPrintedMangleWithUnsupportedFeatures(t, compat.ForAwait|compat.AsyncAwait, "async function test() { for await (const item of y) {} }",
+		"function test() {\n  return __async(this, null, function* () {\n    try {\n      for (var iter = __forAwait(y), more, temp, error; more = !(temp = yield iter.next()).done; more = false) {\n        const item = temp.value;\n        ;\n      }\n    } catch (temp) {\n      error = [temp];\n    } finally {\n      try {\n        more && (temp = iter.return) && (yield temp.call(iter));\n      } finally {\n        if (error)\n          throw error[0];\n      }\n    }\n  });\n}\n")
+}
+
 func TestLowerAutoAccessors(t *testing.T) {
 	expectPrintedWithUnsupportedFeatures(t, compat.Decorators, "class Foo { accessor x }",
 		"class Foo {\n  #x;\n  get x() {\n    return this.#x;\n  }\n  set x(_) {\n    this.#x = _;\n  }\n}\n")

--- a/internal/js_parser/js_parser_test.go
+++ b/internal/js_parser/js_parser_test.go
@@ -124,6 +124,14 @@ func expectPrintedMangleTarget(t *testing.T, esVersion int, contents string, exp
 	})
 }
 
+func expectPrintedMangleWithUnsupportedFeatures(t *testing.T, unsupportedJSFeatures compat.JSFeature, contents string, expected string) {
+	t.Helper()
+	expectPrintedCommon(t, contents, expected, config.Options{
+		UnsupportedJSFeatures: unsupportedJSFeatures,
+		MinifySyntax:          true,
+	})
+}
+
 func expectPrintedASCII(t *testing.T, contents string, expected string) {
 	t.Helper()
 	expectPrintedCommon(t, contents, expected, config.Options{


### PR DESCRIPTION
Based on a similar example in `lowerObjectRestInCatchBinding`: https://github.com/evanw/esbuild/blob/main/internal/js_parser/js_parser_lower.go#L1370-L1373