### PR TITLE
feat: Add Prepend field to OnLoadResult for zero-cost text prepending

### DIFF
--- a/cmd/esbuild/service.go
+++ b/cmd/esbuild/service.go
@@ -1130,6 +1130,10 @@ func (service *serviceType) convertPlugins(key int, jsPlugins interface{}, activ
 						contents := string(value.([]byte))
 						result.Contents = &contents
 					}
+					if value, ok := response["prepend"]; ok {
+						prepend := string(value.([]byte))
+						result.Prepend = &prepend
+					}
 					if value, ok := response["resolveDir"]; ok {
 						result.ResolveDir = value.(string)
 					}

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -1196,6 +1196,7 @@ func runOnLoadPlugins(
 		PluginData: pluginData,
 	}
 	tracker := logger.MakeLineColumnTracker(importSource)
+	var prependParts []string
 
 	// Apply loader plugins in order until one succeeds
 	for _, plugin := range plugins {
@@ -1229,12 +1230,21 @@ func runOnLoadPlugins(
 				return loaderPluginResult{}, false
 			}
 
+			// Collect any Prepend text from this callback
+			if result.Prepend != nil && *result.Prepend != "" {
+				prependParts = append(prependParts, *result.Prepend)
+			}
+
 			// Otherwise, continue on to the next loader if this loader didn't succeed
 			if result.Contents == nil {
 				continue
 			}
 
-			source.Contents = *result.Contents
+			if len(prependParts) > 0 {
+				source.Contents = strings.Join(prependParts, "") + *result.Contents
+			} else {
+				source.Contents = *result.Contents
+			}
 			loader := result.Loader
 			if loader == config.LoaderNone {
 				loader = config.LoaderJS
@@ -1262,7 +1272,11 @@ func runOnLoadPlugins(
 	// Read normal modules from disk
 	if source.KeyPath.Namespace == "file" {
 		if contents, err, _ := fsCache.ReadFile(fs, source.KeyPath.Text); err == nil {
-			source.Contents = contents
+			if len(prependParts) > 0 {
+				source.Contents = strings.Join(prependParts, "") + contents
+			} else {
+				source.Contents = contents
+			}
 			return loaderPluginResult{
 				loader:        config.LoaderDefault,
 				absResolveDir: fs.Dir(source.KeyPath.Text),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -837,6 +837,7 @@ type OnLoadResult struct {
 	PluginName string
 
 	Contents      *string
+	Prepend       *string
 	AbsResolveDir string
 	PluginData    interface{}
 

--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1435,6 +1435,7 @@ let handlePlugins = async (
 
   requestCallbacks['on-load'] = async (id, request: protocol.OnLoadRequest) => {
     let response: protocol.OnLoadResponse = {}, name = '', callback, note
+    let prependParts: string[] = []
     for (let id of request.ids) {
       try {
         ({ name, callback, note } = onLoadCallbacks[id])
@@ -1451,6 +1452,7 @@ let handlePlugins = async (
           let keys: OptionKeys = {}
           let pluginName = getFlag(result, keys, 'pluginName', mustBeString)
           let contents = getFlag(result, keys, 'contents', mustBeStringOrUint8Array)
+          let prepend = getFlag(result, keys, 'prepend', mustBeString)
           let resolveDir = getFlag(result, keys, 'resolveDir', mustBeString)
           let pluginData = getFlag(result, keys, 'pluginData', canBeAnything)
           let loader = getFlag(result, keys, 'loader', mustBeString)
@@ -1459,6 +1461,13 @@ let handlePlugins = async (
           let watchFiles = getFlag(result, keys, 'watchFiles', mustBeArrayOfStrings)
           let watchDirs = getFlag(result, keys, 'watchDirs', mustBeArrayOfStrings)
           checkForInvalidFlags(result, keys, `from onLoad() callback in plugin ${quote(name)}`)
+
+          // Collect prepend text from this callback
+          if (prepend != null) prependParts.push(prepend)
+
+          // If this callback only provided prepend without contents, continue
+          // to the next callback so multiple plugins can each prepend text
+          if (contents == null && prepend != null) continue
 
           response.id = id
           if (pluginName != null) response.pluginName = pluginName
@@ -1478,6 +1487,7 @@ let handlePlugins = async (
         break
       }
     }
+    if (prependParts.length > 0) response.prepend = protocol.encodeUTF8(prependParts.join(''))
     sendResponse(id, response as any)
   }
 

--- a/lib/shared/stdio_protocol.ts
+++ b/lib/shared/stdio_protocol.ts
@@ -238,6 +238,7 @@ export interface OnLoadResponse {
   warnings?: types.PartialMessage[]
 
   contents?: Uint8Array
+  prepend?: Uint8Array
   resolveDir?: string
   loader?: string
   pluginData?: number

--- a/lib/shared/types.ts
+++ b/lib/shared/types.ts
@@ -450,6 +450,7 @@ export interface OnLoadResult {
   warnings?: PartialMessage[]
 
   contents?: string | Uint8Array
+  prepend?: string
   resolveDir?: string
   loader?: Loader
   pluginData?: any

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -692,6 +692,7 @@ type OnLoadResult struct {
 	Warnings []Message
 
 	Contents   *string
+	Prepend    *string
 	ResolveDir string
 	Loader     Loader
 	PluginData interface{}

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -2055,6 +2055,7 @@ func (impl *pluginImpl) onLoad(options OnLoadOptions, callback func(OnLoadArgs) 
 			}
 
 			result.Contents = response.Contents
+			result.Prepend = response.Prepend
 			result.Loader = validateLoader(response.Loader)
 			result.PluginData = response.PluginData
 			pathKind := fmt.Sprintf("resolve directory path for plugin %q", impl.plugin.Name)


### PR DESCRIPTION
Add a Prepend *string field to both the public and internal OnLoadResult structs. When set, the text is prepended to the final file contents without requiring the plugin to read the file from disk. Multiple plugins can set Prepend and they concatenate in plugin order.

Similar to the banner option, but it instead allows you to add a banner or other text to a file that is specific to the file.

Also eliminates redundant os.ReadFile calls in plugins that only need to prepend text (like dirname), since esbuild already reads the file internally.