### PR TITLE
Fix #4395: CSS minifier drops parentheses around nested or in @media rules

### DIFF
--- a/internal/css_printer/css_printer_test.go
+++ b/internal/css_printer/css_printer_test.go
@@ -370,6 +370,11 @@ func TestAtMedia(t *testing.T) {
 	expectPrintedMinify(t, "@media not ( (a) or (b) ) {div{color:red}}", "@media not ((a)or (b)){div{color:red}}")
 	expectPrintedMinify(t, "@media not ( (a) and (b) ) {div{color:red}}", "@media not ((a)and (b)){div{color:red}}")
 
+	// Nested "or" inside a media type must preserve outer parentheses (https://github.com/evanw/esbuild/issues/4395)
+	expectPrintedMinify(t, "@media only screen and ((min-width: 10px) or (min-height: 10px)) {div{color:red}}", "@media only screen and ((min-width:10px)or (min-height:10px)){div{color:red}}")
+	expectPrintedMinify(t, "@media screen and ((a) or (b)) {div{color:red}}", "@media screen and ((a)or (b)){div{color:red}}")
+	expectPrinted(t, "@media only screen and ((min-width: 10px) or (min-height: 10px)) { div { color: red } }", "@media only screen and ((min-width: 10px) or (min-height: 10px)) {\n  div {\n    color: red;\n  }\n}\n")
+
 	expectPrintedMinify(t, "@media (width < 2px) {div{color:red}}", "@media(width<2px){div{color:red}}")
 	expectPrintedMinify(t, "@media (1px < width) {div{color:red}}", "@media(1px<width){div{color:red}}")
 	expectPrintedMinify(t, "@media (1px < width < 2px) {div{color:red}}", "@media(1px<width<2px){div{color:red}}")


### PR DESCRIPTION
When minifying `@media only screen and ((min-width: 10px) or (min-height: 10px))`, the outer parentheses around the `or` condition were dropped, producing invalid CSS:

```css
/* Input */
@media only screen and ((min-width: 10px) or (min-height: 10px)) { color: blue }

/* Before (invalid) */
@media only screen and (min-width:10px)or (min-height:10px){color:blue}

/* After (correct) */
@media only screen and ((min-width:10px)or (min-height:10px)){color:blue}
```

The CSS spec requires `or` clauses to be parenthesized when used after a media type with `and`. Without the outer parens, browsers ignore the entire media query.

## Fix

In `css_printer.go`, when printing `MQType.AndOrNull`, pass `mqNeedsParens` if the inner query is an `MQBinary` with `Or` operator.

## Test

Added 3 test cases in `css_printer_test.go` for `TestAtMedia`:
- Minified: `only screen and ((min-width: 10px) or (min-height: 10px))` preserves outer parens
- Minified: `screen and ((a) or (b))` preserves outer parens
- Pretty-printed: same input preserves structure

All tests fail without the fix, pass with it. Full test suite passes on macOS ARM (Apple Silicon).

Fixes #4395