### PR TITLE
fix: preserve parentheses around "or" in @media with type

### DIFF
--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -2739,6 +2739,14 @@ func TestLowerAtMediaRange(t *testing.T) {
 	expectPrintedLowerMangle(t, "@media not (2px > width > 1px) { a { color: red } }", "@media (min-width: 2px) or (max-width: 1px) {\n  a {\n    color: red;\n  }\n}\n", "")
 	expectPrintedLowerMangle(t, "@media not (1px <= width <= 2px) { a { color: red } }", "@media not ((min-width: 1px) and (max-width: 2px)) {\n  a {\n    color: red;\n  }\n}\n", "")
 	expectPrintedLowerMangle(t, "@media not (2px >= width >= 1px) { a { color: red } }", "@media not ((max-width: 2px) and (min-width: 1px)) {\n  a {\n    color: red;\n  }\n}\n", "")
+
+	// Parentheses must be preserved around "or" expressions after "<media-type> and"
+	expectPrinted(t, "@media screen and ((color) or (opacity)) { a { color: red } }", "@media screen and ((color) or (opacity)) {\n  a {\n    color: red;\n  }\n}\n", "")
+	expectPrintedMinify(t, "@media screen and ((color) or (opacity)) { a { color: red } }", "@media screen and ((color)or (opacity)){a{color:red}}", "")
+	expectPrintedMinify(t, "@media only screen and ((min-width: 10px) or (min-height: 10px)) { a { color: red } }", "@media only screen and ((min-width:10px)or (min-height:10px)){a{color:red}}", "")
+
+	// But "and" after "<media-type> and" should not get extra parentheses
+	expectPrintedMinify(t, "@media screen and (color) and (opacity) { a { color: red } }", "@media screen and (color)and (opacity){a{color:red}}", "")
 }
 
 func TestAtScope(t *testing.T) {


### PR DESCRIPTION
The CSS minifier was dropping necessary grouping parentheses around "or" expressions when they appeared after a media type with "and". For example:

```css
/* Input */
@media screen and ((min-width: 10px) or (min-height: 10px)) { color: blue; }

/* Before (invalid CSS - "and" and "or" mixed at same level) */
@media screen and (min-width:10px)or (min-height:10px){color:blue}

/* After (valid) */
@media screen and ((min-width:10px)or (min-height:10px)){color:blue}
```

Per the CSS spec, `<media-condition-without-or>` only allows `<media-in-parens> [and <media-in-parens>]*`, so an "or" group must be wrapped in parentheses. The printer was passing `flags=0` when printing the condition from `MQType`, so `MQBinary{Op: Or}` didn't get its outer parens. The fix passes `mqNeedsParens` when the condition is an "or" binary.

Verified that regular "and" chains after media types still produce minimal output without extra wrapping.

Tests pass:
```
go test ./... 
ok  github.com/evanw/esbuild/internal/css_parser    0.458s
ok  github.com/evanw/esbuild/pkg/api                2.718s
(all packages pass)
```

Fixes #4395