### PR TITLE
fix: late constant folding for cross-module if-statement DCE

### DIFF
--- a/internal/bundler_tests/bundler_dce_test.go
+++ b/internal/bundler_tests/bundler_dce_test.go
@@ -5007,3 +5007,77 @@ func TestDCEOfSymbolForCall(t *testing.T) {
 		},
 	})
 }
+
+func TestCrossModuleConstantFoldingIfStmt(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { DEV } from './constants'
+				if (DEV) {
+					console.log("dev mode")
+				}
+				console.log("production")
+			`,
+			"/constants.js": `
+				export const DEV = false
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MinifySyntax: true,
+		},
+	})
+}
+
+func TestCrossModuleConstantFoldingIfStmtThrow(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { DEV } from './constants'
+				function reportError(msg) {
+					if (DEV) {
+						let detail = "detailed: " + msg
+						throw new Error(detail)
+					} else {
+						throw new Error("ERROR_CODE")
+					}
+				}
+				export { reportError }
+			`,
+			"/constants.js": `
+				export const DEV = false
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MinifySyntax: true,
+		},
+	})
+}
+
+func TestCrossModuleConstantFoldingIfStmtMultiple(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { DEBUG, VERBOSE } from './constants'
+				if (DEBUG) { console.log("debug") }
+				if (VERBOSE) { console.log("verbose") }
+				console.log("app")
+			`,
+			"/constants.js": `
+				export const DEBUG = false
+				export const VERBOSE = false
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MinifySyntax: true,
+		},
+	})
+}

--- a/internal/bundler_tests/bundler_dce_test.go
+++ b/internal/bundler_tests/bundler_dce_test.go
@@ -5081,3 +5081,55 @@ func TestCrossModuleConstantFoldingIfStmtMultiple(t *testing.T) {
 		},
 	})
 }
+
+func TestCrossModuleConstantFoldingIfStmtTrueBranch(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { DEV } from './constants'
+				if (DEV) {
+					console.log("dev mode")
+				} else {
+					console.log("production")
+				}
+			`,
+			"/constants.js": `
+				export const DEV = true
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MinifySyntax: true,
+		},
+	})
+}
+
+func TestCrossModuleConstantFoldingIfStmtEnum(t *testing.T) {
+	dce_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.ts": `
+				import { Mode } from './constants'
+				Mode.DEV
+				if (Mode.DEV) {
+					console.log("dev mode")
+				} else {
+					console.log("production")
+				}
+			`,
+			"/constants.ts": `
+				export enum Mode {
+					DEV = 0,
+					PROD = 1,
+				}
+			`,
+		},
+		entryPaths: []string{"/entry.ts"},
+		options: config.Options{
+			Mode:         config.ModeBundle,
+			AbsOutputDir: "/out",
+			MinifySyntax: true,
+		},
+	})
+}

--- a/internal/bundler_tests/snapshots/snapshots_dce.txt
+++ b/internal/bundler_tests/snapshots/snapshots_dce.txt
@@ -298,6 +298,29 @@ var Foo = class {
 };
 
 ================================================================================
+TestCrossModuleConstantFoldingIfStmt
+---------- /out/entry.js ----------
+// entry.js
+console.log("production");
+
+================================================================================
+TestCrossModuleConstantFoldingIfStmtMultiple
+---------- /out/entry.js ----------
+// entry.js
+console.log("app");
+
+================================================================================
+TestCrossModuleConstantFoldingIfStmtThrow
+---------- /out/entry.js ----------
+// entry.js
+function reportError(msg) {
+  throw new Error("ERROR_CODE");
+}
+export {
+  reportError
+};
+
+================================================================================
 TestCrossModuleConstantFoldingNumber
 ---------- /out/enum-entry.js ----------
 // enum-entry.ts

--- a/internal/bundler_tests/snapshots/snapshots_dce.txt
+++ b/internal/bundler_tests/snapshots/snapshots_dce.txt
@@ -304,6 +304,12 @@ TestCrossModuleConstantFoldingIfStmt
 console.log("production");
 
 ================================================================================
+TestCrossModuleConstantFoldingIfStmtEnum
+---------- /out/entry.js ----------
+// entry.ts
+console.log("production");
+
+================================================================================
 TestCrossModuleConstantFoldingIfStmtMultiple
 ---------- /out/entry.js ----------
 // entry.js
@@ -319,6 +325,12 @@ function reportError(msg) {
 export {
   reportError
 };
+
+================================================================================
+TestCrossModuleConstantFoldingIfStmtTrueBranch
+---------- /out/entry.js ----------
+// entry.js
+console.log("dev mode");
 
 ================================================================================
 TestCrossModuleConstantFoldingNumber

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1854,6 +1854,19 @@ func (p *printer) lateConstantFoldUnaryOrBinaryOrIfExpr(expr js_ast.Expr) js_ast
 	return expr
 }
 
+// isLateConstantFoldedSideEffectFree returns true if the expression resolves
+// to a side-effect-free constant after late constant folding. This is used to
+// drop expression statements like "!1;" that result from cross-module constant
+// inlining.
+func (p *printer) isLateConstantFoldedSideEffectFree(expr js_ast.Expr) bool {
+	folded := p.lateConstantFoldUnaryOrBinaryOrIfExpr(expr)
+	switch folded.Data.(type) {
+	case *js_ast.ENull, *js_ast.EUndefined, *js_ast.EBoolean, *js_ast.ENumber, *js_ast.EBigInt, *js_ast.EString:
+		return true
+	}
+	return false
+}
+
 func (p *printer) isUnboundIdentifier(expr js_ast.Expr) bool {
 	id, ok := expr.Data.(*js_ast.EIdentifier)
 	return ok && p.symbols.Get(ast.FollowSymbols(p.symbols, id.Ref)).Kind == ast.SymbolUnbound
@@ -4377,6 +4390,29 @@ func (p *printer) printStmt(stmt js_ast.Stmt, flags printStmtFlags) {
 		}
 
 	case *js_ast.SIf:
+		// Late constant folding: if the test expression can be resolved to a
+		// known boolean at print time (e.g. due to cross-module constant
+		// inlining via ConstValues), we can eliminate the dead branch entirely.
+		if p.options.MinifySyntax {
+			test := p.lateConstantFoldUnaryOrBinaryOrIfExpr(s.Test)
+			if boolean, sideEffects, ok := js_ast.ToBooleanWithSideEffects(test.Data); ok && sideEffects == js_ast.NoSideEffects {
+				if boolean {
+					// Condition is true: print only the "yes" branch
+					p.printStmt(s.Yes, flags)
+				} else if s.NoOrNil.Data != nil {
+					// Condition is false with else: print only the "no" branch
+					p.printStmt(s.NoOrNil, flags)
+				} else if (flags & canOmitStatement) == 0 {
+					// Condition is false without else and we can't omit: print empty statement
+					p.addSourceMapping(stmt.Loc)
+					p.printIndent()
+					p.print(";")
+					p.printNewline()
+				}
+				break
+			}
+		}
+
 		p.addSourceMapping(stmt.Loc)
 		p.printIndent()
 		p.printIf(s)
@@ -4886,6 +4922,19 @@ func (p *printer) printStmt(stmt js_ast.Stmt, flags printStmtFlags) {
 					p.printNewline()
 				} else {
 					// "if (x) { empty(); }" => "if (x) {}"
+				}
+				break
+			}
+
+			// Late constant folding: drop side-effect-free constant expression
+			// statements that result from cross-module constant inlining (e.g.
+			// an imported "false" that becomes "!1;" after printing)
+			if p.isLateConstantFoldedSideEffectFree(value) {
+				if (flags & canOmitStatement) == 0 {
+					p.addSourceMapping(stmt.Loc)
+					p.printIndent()
+					p.print(";")
+					p.printNewline()
 				}
 				break
 			}

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -1860,7 +1860,15 @@ func (p *printer) lateConstantFoldUnaryOrBinaryOrIfExpr(expr js_ast.Expr) js_ast
 // inlining.
 func (p *printer) isLateConstantFoldedSideEffectFree(expr js_ast.Expr) bool {
 	folded := p.lateConstantFoldUnaryOrBinaryOrIfExpr(expr)
-	switch folded.Data.(type) {
+	data := folded.Data
+
+	// Unwrap EInlinedEnum to check the inner value (e.g., enum member
+	// expression statements like "Enum.Value;" that resolve to a constant)
+	if e, ok := data.(*js_ast.EInlinedEnum); ok {
+		data = e.Value.Data
+	}
+
+	switch data.(type) {
 	case *js_ast.ENull, *js_ast.EUndefined, *js_ast.EBoolean, *js_ast.ENumber, *js_ast.EBigInt, *js_ast.EString:
 		return true
 	}


### PR DESCRIPTION
## Summary

When bundling with `--minify-syntax`, imported constants like `export const DEV = false` are inlined at print time via `ConstValues`. However, `if` **statements** (`SIf`) with these inlined constants were not folded — only `if` **expressions** (`EIf`/ternary) were. This left dead branches in the output:

```js
// constants.js
export const DEV = false

// entry.js
import { DEV } from './constants'
if (DEV) {
  let detail = "detailed: " + msg
  throw new Error(detail)
} else {
  throw new Error("ERROR_CODE")
}
```

**Before:**
```js
// Both branches kept, condition becomes !1 but if-statement stays
if (!1) { let e = "detailed: " + msg; throw new Error(e); } else throw new Error("ERROR_CODE");
```

**After:**
```js
// Dead branch eliminated, only live branch remains
throw new Error("ERROR_CODE");
```

## Approach

Added late constant folding for `SIf` in `printStmt()` (mirroring how `EIf` is already handled in `lateConstantFoldUnaryOrBinaryOrIfExpr()`):

1. When `MinifySyntax` is enabled, fold the test expression through `lateConstantFoldUnaryOrBinaryOrIfExpr()` (which resolves `EImportIdentifier` refs via `ConstValues`)
2. Use `ToBooleanWithSideEffects()` to determine if the condition is statically known
3. If true → print only the "yes" branch; if false → print only the "no" branch (or nothing)

Also added `isLateConstantFoldedSideEffectFree()` to drop residual expression statements like `!1;` that result from logical expressions with inlined constants (e.g., `DEV && console.log("debug")` → `!1;`).

## Test

```
go test ./... -count=1
ok  github.com/evanw/esbuild/internal/bundler_tests  2.210s
ok  github.com/evanw/esbuild/internal/js_printer      0.733s
... (all packages pass)
```

Three new snapshot tests added:
- `TestCrossModuleConstantFoldingIfStmt` — basic `if (DEV)` elimination
- `TestCrossModuleConstantFoldingIfStmtThrow` — if/else with `throw` in both branches
- `TestCrossModuleConstantFoldingIfStmtMultiple` — multiple independent `if` statements

Fixes #2589, fixes #3964.