### PR TITLE
fix: Handle non-awaited async yield*

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -414,13 +414,16 @@ func Source(unsupportedJSFeatures compat.JSFeature) logger.Source {
 			this[0] = promise
 			this[1] = isYieldStar
 		}
+		export var __yieldStarResult = function (result) {
+			this[0] = result
+		}
 		export var __asyncGenerator = (__this, __arguments, generator) => {
 			var resume = (k, v, yes, no) => {
 				try {
 					var x = generator[k](v), isAwait = (v = x.value) instanceof __await, done = x.done
 					Promise.resolve(isAwait ? v[0] : v)
 						.then(y => isAwait
-							? resume(k === 'return' ? k : 'next', v[1] ? { done: y.done, value: y.value } : y, yes, no)
+							? resume(k === 'return' ? k : 'next', v[1] ? new __yieldStarResult({ done: y.done, value: y.value }) : y, yes, no)
 							: yes({ value: y, done }))
 						.catch(e => resume('throw', e, yes, no))
 				} catch (e) {
@@ -435,19 +438,17 @@ func Source(unsupportedJSFeatures compat.JSFeature) logger.Source {
 				it
 		}
 		export var __yieldStar = value => {
-			var obj = value[__knownSymbol('asyncIterator')], isAwait = false, method, it = {}
+			var obj = value[__knownSymbol('asyncIterator')], method, it = {}
 			if (obj == null) {
 				obj = value[__knownSymbol('iterator')]()
 				method = k => it[k] = x => obj[k](x)
 			} else {
 				obj = obj.call(value)
 				method = k => it[k] = v => {
-					if (isAwait) {
-						isAwait = false
-						if (k === 'throw') throw v
-						return v
+					if (v instanceof __yieldStarResult) {
+						if (k === 'throw') throw v[0]
+						return v[0]
 					}
-					isAwait = true
 					return {
 						done: false,
 						value: new __await(new Promise(resolve => {

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -750,6 +750,32 @@ for (const flags of [[], ['--target=es6', '--target=es2017', '--supported:async-
     }, { async: true }),
     test(['in.js', '--outfile=node.js', '--format=esm'].concat(flags), {
       'in.js': `
+        async function* i() {
+          yield 1
+          yield 2
+        }
+        async function* f() {
+          yield* i()
+        }
+        export let async = async () => {
+          let it, stateA, stateB
+          it = f()
+          stateA = it.next()
+          stateB = it.next()
+
+          stateA = await stateA
+          stateB = await stateB
+
+          if (stateA.done !== false || stateA.value !== 1) throw 'fail: f: next A'
+          if (stateB.done !== false || stateB.value !== 2) throw 'fail: f: next B'
+
+          stateA = await it.next()
+          if (stateA.done !== true || stateA.value !== void 0) throw 'fail: f: done'
+        }
+      `,
+    }, { async: true }),
+    test(['in.js', '--outfile=node.js', '--format=esm'].concat(flags), {
+      'in.js': `
         async function* f() {
           yield* {
             [Symbol.iterator]: () => ({ next: () => 123 }),


### PR DESCRIPTION
This PR updates the `__asyncGenerator` and `__yieldStar` helpers to allow `.next()` calls that are not awaited.

Previously, the `method` in `__yieldStar` incorrectly assumed that, once invoked, it would not be called again until the `resume` callback in `__asyncGenerator` had resolved its promise.

The helper class `__yieldStarResult` is now used to mark the incoming value as already resolved.

For #4401.
