### PR TITLE
fix: Handle non-awaited async generator

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -427,7 +427,14 @@ func Source(unsupportedJSFeatures compat.JSFeature) logger.Source {
 					q = Promise.resolve()
 					no(e)
 				}
-			}, method = k => it[k] = x => q = q.then(() => new Promise((yes, no) => resume(k, x, yes, no))), q = Promise.resolve(), it = {}
+			}, method = (k, call, wait, clear) => it[k] = x => (
+				call = new Promise((yes, no, run) => (
+					run = () => resume(k, x, yes, no), 
+					queue ? queue.then(run) : run())),
+				clear = () => queue === wait && (queue = void 0),
+				queue = wait = call.then(clear, clear),
+				call
+			), q, queue, it = {}
 			return generator = generator.apply(__this, __arguments),
 				it[__knownSymbol('asyncIterator')] = () => it,
 				method('next'),

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -823,6 +823,54 @@ for (const flags of [[], ['--target=es6', '--target=es2017', '--supported:async-
     }, { async: true }),
     test(['in.js', '--outfile=node.js', '--format=esm'].concat(flags), {
       'in.js': `
+        async function* f(order) {
+          order.push('before')
+          await Promise.resolve()
+          return yield 1
+        }
+        export let async = async () => {
+          let it, stateA, stateB, order = []
+          it = f(order)
+          stateA = it.next()
+          stateB = it.next(2)
+          order.push('after')
+
+          stateA = await stateA
+          stateB = await stateB
+
+          if (order[0] !== 'before' || order[1] !== 'after') throw 'fail: f: order: ' + JSON.stringify(order)
+          if (stateA.done !== false || stateA.value !== 1) throw 'fail: f: next'
+          if (stateB.done !== true || stateB.value !== 2) throw 'fail: f: done'
+        }
+      `,
+    }, { async: true }),
+    test(['in.js', '--outfile=node.js', '--format=esm'].concat(flags), {
+      'in.js': `
+        async function* f(order) {
+          yield 0
+          order.push('before')
+          await Promise.resolve()
+          return yield 1
+        }
+        export let async = async () => {
+          let it, stateA, stateB, order = []
+          it = f(order)
+          await it.next()
+          stateA = it.next()
+          order.push('after')
+          stateB = it.next(2)
+
+          stateA = await stateA
+          stateB = await stateB
+
+          if (order[0] !== 'before' || order[1] !== 'after') throw 'fail: f: order: ' + JSON.stringify(order)
+          if (stateA.done !== false || stateA.value !== 1) throw 'fail: f: next'
+          if (stateB.done !== true || stateB.value !== 2) throw 'fail: f: done'
+        }
+      `,
+    }, { async: true }),
+    test(['in.js', '--outfile=node.js', '--format=esm'].concat(flags), {
+      'in.js': `
         async function* f() {
           yield* {
             [Symbol.iterator]: () => ({ next: () => 123 }),


### PR DESCRIPTION
Add a queue to `__asyncGenerator` to preserve the order in which `.next` and other generator methods are called even when they are not awaited.

Fixes #4401.