### PR TITLE
bugfix: Ensure proper handling of empty metafile buffers

### DIFF
--- a/lib/shared/common.ts
+++ b/lib/shared/common.ts
@@ -1861,6 +1861,10 @@ function jsRegExpToGoRegExp(regexp: RegExp): string {
 }
 
 function parseJSON(bytes: Uint8Array): any {
+  // An empty buffer isn't valid JSON (`Unexpected end of JSON input`)
+  // it generally means the value is absent.
+  if (bytes.length === 0) return void 0;
+
   let text: string
   try {
     // This may fail in V8 with the error "Cannot create a string longer than


### PR DESCRIPTION
## Fix: Handle empty `Uint8Array` in `parseJSON()`
**Backport → 0.27.4**

### Problem
When an optional JSON field was sent as an empty buffer, `parseJSON()` would decode the `Uint8Array(0)` into an empty string and pass it straight to `JSON.parse("")` — which unconditionally throws:

```
SyntaxError: Unexpected end of JSON input
```

### Solution

`parseJSON()` now short-circuits on empty input, returning `undefined` before any decoding or parsing occurs. As a related change, `parseJSON()` is no longer called for an empty metafile buffer — `result.metafile` stays `undefined` when no metafile payload is present.

```ts
function parseJSON(bytes: Uint8Array): any {
  if (bytes.length === 0) return void 0; // absent, not malformed
  // ...
}
```

Fixes #4420.