### PR TITLE
docs: fix typo `identitiy` → `identity` in bundler_lower_test.go

### DIFF
--- a/internal/bundler_tests/bundler_lower_test.go
+++ b/internal/bundler_tests/bundler_lower_test.go
@@ -86,7 +86,7 @@ func TestLowerExponentiationOperatorNoBundle(t *testing.T) {
 					13: a[123n] **= b,
 					14: a[this] **= b,
 
-					// These should need capturing (have object identitiy)
+					// These should need capturing (have object identity)
 					15: a[/x/] **= b,
 					16: a[{}] **= b,
 					17: a[[]] **= b,


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `internal/bundler_tests/bundler_lower_test.go` (line ~89)
- Change: `identitiy` → `identity`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
