### PR TITLE
docs: fix typo `unecessarily` → `unnecessarily` in js_table.go

### DIFF
--- a/internal/compat/js_table.go
+++ b/internal/compat/js_table.go
@@ -629,7 +629,7 @@ var jsTable = map[JSFeature]map[Engine][]versionRange{
 	InlineScript: {},
 	LogicalAssignment: {
 		// Note: The latest version of "IE" failed 9 tests including: Logical Assignment: &&= basic support
-		// Note: The latest version of "Rhino" failed 3 tests including: Logical Assignment: &&= setter not unecessarily invoked
+		// Note: The latest version of "Rhino" failed 3 tests including: Logical Assignment: &&= setter not unnecessarily invoked
 		Chrome:  {{start: v{85, 0, 0}}},
 		Deno:    {{start: v{1, 2, 0}}},
 		Edge:    {{start: v{85, 0, 0}}},


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `internal/compat/js_table.go` (line ~632)
- Change: `unecessarily` → `unnecessarily`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
