### PR TITLE
docs: fix typo `overlayed` → `overlaid` in serve_other.go

### DIFF
--- a/pkg/api/serve_other.go
+++ b/pkg/api/serve_other.go
@@ -9,7 +9,7 @@ package api
 // esbuild will automatically generate a directory listing page with links for
 // each file in the directory. If there is a build configured that generates
 // output files, those output files are not written to disk but are instead
-// "overlayed" virtually on top of the real file system. The server responds to
+// "overlaid" virtually on top of the real file system. The server responds to
 // HTTP requests for output files from the build with the latest in-memory
 // build results.
 


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `pkg/api/serve_other.go` (line ~12)
- Change: `overlayed` → `overlaid`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
