### PR TITLE
Make __esm helper preserve init errors across calls

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -170,10 +170,23 @@ func Source(unsupportedJSFeatures compat.JSFeature) logger.Source {
 		// This is for lazily-initialized ESM code. This has two implementations, a
 		// compact one for minified code and a verbose one that generates friendly
 		// names in V8's profiler and in stack traces.
-		export var __esm = (fn, res) => function __init() {
-			return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res
+		//
+		// A thrown init error is captured and re-thrown on every later call, so a
+		// failed cold-start surfaces the real cause on subsequent requests instead
+		// of being silently replaced with "Cannot read properties of undefined" on
+		// long-lived runtimes (Workers, Deno Deploy, Lambda warm starts, a Node
+		// server). Re-running an init that threw is rarely safe; side effects may
+		// have run.
+		export var __esm = (fn, res, err) => function __init() {
+			if (err) throw err
+			if (fn) try { res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0) } catch (e) { err = e; throw e }
+			return res
 		}
-		export var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+		export var __esmMin = (fn, res, err) => () => {
+			if (err) throw err
+			if (fn) try { res = fn(fn = 0) } catch (e) { err = e; throw e }
+			return res
+		}
 
 		// Wraps a CommonJS closure and returns a require() function. This has two
 		// implementations, a compact one for minified code and a verbose one that


### PR DESCRIPTION
Closes #4461.

The `__esm` helper sequenced `fn = 0` before the call to the underlying init function:

```js
var __esm = (fn, res) => function __init() {
  return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res
}
```

If init threw, `fn` was already 0 by then. Subsequent calls hit the `fn && ...` short-circuit and returned the still-unset `res` (`undefined`). The real init error was visible on the first call only; every later call returned `undefined` silently, and downstream code threw a misleading `TypeError: Cannot read properties of undefined (reading '<some-export>')`.

Reproducer (vanilla `esbuild@0.25.x`):

```js
// boom.js
console.log("evaluating boom.js");
throw new Error("init failed (the real cause)");
export const value = 42;

// entry.js
let logs = [];
async function callOnce(label) {
  try { logs.push(label + ": value=" + (await import("./boom.js")).value); }
  catch (e) { logs.push(label + ": error=" + e.message); }
}
(async () => { await callOnce("call1"); await callOnce("call2"); await callOnce("call3"); console.log(logs.join("\n")); })();
```

```
$ esbuild entry.js --bundle --format=cjs --target=es2022 --outfile=out.js
$ node out.js
evaluating boom.js
call1: error=init failed (the real cause)
call2: value=undefined
call3: value=undefined
```

After this change `call2` and `call3` re-throw the same `Error: init failed (the real cause)`.

This matters on long-lived single-isolate runtimes (Workers, Deno Deploy, Lambda warm starts, a Node server). One isolate handles many requests; a cold-start init failure produces one log line with the real cause, then N log lines with a `Cannot read properties of undefined` downstream symptom. Short log retention or reactive (rather than always-on) tailing means the real cause is unrecoverable without a redeploy. OpenNext / `@opennextjs/cloudflare` users are particularly exposed because their middleware bundle wraps the `_ENTRIES` registry through `__esm`.

Fix: capture the thrown error in a closure variable and re-throw on every later call.

```js
var __esm = (fn, res, err) => function __init() {
  if (err) throw err
  if (fn) try { res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0) } catch (e) { err = e; throw e }
  return res
}
```

Behavior change: a failed init is now permanently sticky on the same module instance. Re-running an init that threw is rarely safe because side effects (top-level statements that ran before the throw) may have already executed, so re-throwing is the spec-correct surface — matches what the V8/SpiderMonkey-emitted ESM `state === errored` does for native modules.

Same change applied to `__esmMin` for parity. `__esmMin` stays compact (one `if` per line, no extra braces beyond what the catch needs).

Verified:
- The vanilla 0.25.x output reproduces the bug; the patched output throws the original error on every call.
- `go test ./internal/runtime/... ./internal/bundler_tests/...` — both packages clean.
- No bundler snapshots change (helpers aren't snapshotted in this repo's `internal/bundler_tests/snapshots/`).

Not changed in this PR (separate, related shape): `__commonJS` assigns `mod = {exports: {}}` *before* the underlying `cb` runs, so a thrown CJS init similarly produces an empty `mod.exports` on later calls. Happy to follow up if you'd like.
