### PR TITLE
Fix assigned TypeScript namespace aliases

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -17039,7 +17039,7 @@ func (p *parser) handleIdentifier(loc logger.Loc, e *js_ast.EIdentifier, opts id
 	}
 
 	// Substitute an EImportIdentifier now if this has a namespace alias
-	if opts.assignTarget == js_ast.AssignTargetNone && !opts.isDeleteTarget {
+	if !opts.isDeleteTarget {
 		symbol := &p.symbols[ref.InnerIndex]
 		if nsAlias := symbol.NamespaceAlias; nsAlias != nil {
 			data := p.dotOrMangledPropVisit(
@@ -17047,24 +17047,27 @@ func (p *parser) handleIdentifier(loc logger.Loc, e *js_ast.EIdentifier, opts id
 				symbol.OriginalName, loc)
 
 			// Handle references to namespaces or namespace members
-			if tsMemberData, ok := p.refToTSNamespaceMemberData[nsAlias.NamespaceRef]; ok {
-				if ns, ok := tsMemberData.(*js_ast.TSNamespaceMemberNamespace); ok {
-					if member, ok := ns.ExportedMembers[nsAlias.Alias]; ok {
-						switch m := member.Data.(type) {
-						case *js_ast.TSNamespaceMemberEnumNumber:
-							return p.wrapInlinedEnum(js_ast.Expr{Loc: loc, Data: &js_ast.ENumber{Value: m.Value}}, nsAlias.Alias)
+			if opts.assignTarget == js_ast.AssignTargetNone {
+				if tsMemberData, ok := p.refToTSNamespaceMemberData[nsAlias.NamespaceRef]; ok {
+					if ns, ok := tsMemberData.(*js_ast.TSNamespaceMemberNamespace); ok {
+						if member, ok := ns.ExportedMembers[nsAlias.Alias]; ok {
+							switch m := member.Data.(type) {
+							case *js_ast.TSNamespaceMemberEnumNumber:
+								return p.wrapInlinedEnum(js_ast.Expr{Loc: loc, Data: &js_ast.ENumber{Value: m.Value}}, nsAlias.Alias)
 
-						case *js_ast.TSNamespaceMemberEnumString:
-							return p.wrapInlinedEnum(js_ast.Expr{Loc: loc, Data: &js_ast.EString{Value: m.Value}}, nsAlias.Alias)
+							case *js_ast.TSNamespaceMemberEnumString:
+								return p.wrapInlinedEnum(js_ast.Expr{Loc: loc, Data: &js_ast.EString{Value: m.Value}}, nsAlias.Alias)
 
-						case *js_ast.TSNamespaceMemberNamespace:
-							p.tsNamespaceTarget = data
-							p.tsNamespaceMemberData = member.Data
+							case *js_ast.TSNamespaceMemberNamespace:
+								p.tsNamespaceTarget = data
+								p.tsNamespaceMemberData = member.Data
+							}
 						}
 					}
 				}
 			}
 
+			p.recordUsage(nsAlias.NamespaceRef)
 			return js_ast.Expr{Loc: loc, Data: data}
 		}
 	}

--- a/internal/js_parser/ts_parser_test.go
+++ b/internal/js_parser/ts_parser_test.go
@@ -1425,6 +1425,24 @@ func TestTSNamespaceExports(t *testing.T) {
 `)
 
 	expectPrintedTS(t, `
+		namespace A {
+			export var x = 0
+		}
+		namespace A {
+			console.log(x)
+			x = 0
+		}
+	`, `var A;
+((A) => {
+  A.x = 0;
+})(A || (A = {}));
+((A) => {
+  console.log(A.x);
+  A.x = 0;
+})(A || (A = {}));
+`)
+
+	expectPrintedTS(t, `
 		namespace ns {
 			export declare const L1
 			console.log(L1)


### PR DESCRIPTION
This fixes #4450.

TypeScript namespace alias lowering already rewrites reads from exported members in sibling namespace blocks, such as `console.log(x)` becoming `A.x`. The assignment target path was skipping the namespace alias rewrite, so `x = 0` stayed as a bare identifier.

This change keeps enum/namespace member inlining limited to read-only references, but still lowers assigned namespace aliases to property accesses. I also added a regression test for the sibling namespace assignment case from the issue.

Tests:

- `go test ./internal/js_parser -run TestTSNamespaceExports`
- `go test ./internal/js_parser`
- `go test ./internal/... ./pkg/...`
- `make test-go`