### PR TITLE
Fix MP3 data URL MIME type

### DIFF
--- a/internal/bundler_tests/bundler_loader_test.go
+++ b/internal/bundler_tests/bundler_loader_test.go
@@ -232,8 +232,9 @@ func TestAutoDetectMimeTypeFromExtension(t *testing.T) {
 	loader_suite.expectBundled(t, bundled{
 		files: map[string]string{
 			"/entry.js": `
-				console.log(require('./test.svg'))
+				console.log(require('./test.svg'), require('./test.mp3'))
 			`,
+			"/test.mp3": "a\x00b\x80c\xFFd",
 			"/test.svg": "a\x00b\x80c\xFFd",
 		},
 		entryPaths: []string{"/entry.js"},
@@ -241,6 +242,7 @@ func TestAutoDetectMimeTypeFromExtension(t *testing.T) {
 			Mode:          config.ModeBundle,
 			AbsOutputFile: "/out.js",
 			ExtensionToLoader: map[string]config.Loader{
+				".mp3": config.LoaderDataURL,
 				".js":  config.LoaderJS,
 				".svg": config.LoaderDataURL,
 			},

--- a/internal/bundler_tests/snapshots/snapshots_loader.txt
+++ b/internal/bundler_tests/snapshots/snapshots_loader.txt
@@ -7,8 +7,15 @@ var require_test = __commonJS({
   }
 });
 
+// test.mp3
+var require_test2 = __commonJS({
+  "test.mp3"(exports, module) {
+    module.exports = "data:audio/mpeg;base64,YQBigGP/ZA==";
+  }
+});
+
 // entry.js
-console.log(require_test());
+console.log(require_test(), require_test2());
 
 ================================================================================
 TestEmptyLoaderCSS

--- a/internal/helpers/mime.go
+++ b/internal/helpers/mime.go
@@ -24,6 +24,9 @@ var builtinTypesLower = map[string]string{
 	".svg":  "image/svg+xml",
 	".webp": "image/webp",
 
+	// Audio
+	".mp3": "audio/mpeg",
+
 	// Fonts
 	".eot":   "application/vnd.ms-fontobject",
 	".otf":   "font/otf",


### PR DESCRIPTION
Summary:
- Add the built-in MIME type for .mp3 files as audio/mpeg.
- Cover .mp3 dataurl imports in the existing extension-based MIME snapshot test.

Tests:
- go test ./internal/bundler_tests
- git diff --check

Fixes #4485