### PR TITLE
fix #4484: actually skip writing the file when refusing to overwrite an input file

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -3103,6 +3103,7 @@ func (b *Bundle) Compile(log logger.Log, timer *helpers.Timer, mangleCache map[s
 					sourceAbsPaths[absPathKey] = sourceIndex
 				}
 			}
+			rejectedAbsPaths := make(map[string]bool)
 			for _, outputFile := range outputFiles {
 				absPathKey := canonicalFileSystemPathForWindows(outputFile.AbsPath)
 				if sourceIndex, ok := sourceAbsPaths[absPathKey]; ok {
@@ -3118,7 +3119,25 @@ func (b *Bundle) Compile(log logger.Log, timer *helpers.Timer, mangleCache map[s
 					log.AddError(nil, logger.Range{},
 						fmt.Sprintf("Refusing to overwrite input file %q%s",
 							b.files[sourceIndex].inputFile.Source.PrettyPaths.Select(options.LogPathStyle), hint))
+					rejectedAbsPaths[absPathKey] = true
 				}
+			}
+
+			// Drop rejected output files along with their associated source map
+			// and legal comment files, if present
+			if len(rejectedAbsPaths) > 0 {
+				end := 0
+				for _, outputFile := range outputFiles {
+					absPathKey := canonicalFileSystemPathForWindows(outputFile.AbsPath)
+					if rejectedAbsPaths[absPathKey] ||
+						rejectedAbsPaths[strings.TrimSuffix(absPathKey, ".map")] ||
+						rejectedAbsPaths[strings.TrimSuffix(absPathKey, ".legal.txt")] {
+						continue
+					}
+					outputFiles[end] = outputFile
+					end++
+				}
+				outputFiles = outputFiles[:end]
 			}
 		}
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,6 +1,8 @@
 package api_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/evanw/esbuild/internal/test"
@@ -318,4 +320,64 @@ func TestFormatMessages(t *testing.T) {
 
 `,
 	)
+}
+
+func TestNoOverwriteInputFile(t *testing.T) {
+	dir := t.TempDir()
+	entry := dir + "/entry.js"
+	contents := "/* @license MIT */ console.log(1 + 2)"
+	if err := os.WriteFile(entry, []byte(contents), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	result := api.Build(api.BuildOptions{
+		EntryPoints:      []string{entry},
+		Outfile:          entry,
+		MinifyWhitespace: true,
+		Sourcemap:        api.SourceMapLinked,
+		LegalComments:    api.LegalCommentsExternal,
+		Write:            true,
+		LogLevel:         api.LogLevelSilent,
+	})
+
+	if len(result.Errors) != 1 || !strings.Contains(result.Errors[0].Text, "Refusing to overwrite input file") {
+		t.Fatalf("Expected an error about refusing to overwrite an input file, got %v", result.Errors)
+	}
+
+	if len(result.OutputFiles) != 0 {
+		t.Fatalf("Output files must not include the input file %q", entry)
+	}
+
+	if observed, err := os.ReadFile(entry); err != nil || string(observed) != contents {
+		t.Fatalf("Input file %q was modified: %q", entry, observed)
+	}
+
+	if _, err := os.Stat(entry + ".map"); !os.IsNotExist(err) {
+		t.Fatalf("Source map for the input file %q must not be written", entry)
+	}
+
+	if _, err := os.Stat(entry + ".LEGAL.txt"); !os.IsNotExist(err) {
+		t.Fatalf("Legal comments for the input file %q must not be written", entry)
+	}
+
+	// An output file that just happens to be named like a companion file of an
+	// input file (e.g. "entry.js.map") should still be generated normally
+	result = api.Build(api.BuildOptions{
+		EntryPoints: []string{entry},
+		Outfile:     entry + ".map",
+		Write:       true,
+		LogLevel:    api.LogLevelSilent,
+	})
+
+	if len(result.Errors) != 0 {
+		t.Fatalf("Expected no errors, got %v", result.Errors)
+	}
+
+	if len(result.OutputFiles) != 1 {
+		t.Fatalf("Expected one output file, got %v", result.OutputFiles)
+	}
+
+	if _, err := os.Stat(entry + ".map"); err != nil {
+		t.Fatalf("Output file %q must be written: %v", entry+".map", err)
+	}
 }


### PR DESCRIPTION
Fixes #4484

When the output path resolves to an input file, esbuild logs "Refusing to overwrite input file" but writes the file anyway, so the input still gets clobbered. The error is raised inside Compile, and the write phase only checks for errors from before compilation, so the conflicting entry goes through.

This drops the conflicting entry from outputFiles at the point where the error is logged, using the same in-place compaction as the duplicate-output check below it. Companion outputs derived from the same path (.map and .LEGAL.txt, the only two appended by the linker) are dropped with it so they aren't written on their own. The suffixes are compared lowercase because canonicalFileSystemPathForWindows lowercases the keys on both sides.

Thanks to @noskill24 for the report and @cschanhniem for tracing the root cause.

The new test covers the sourcemap and legal comments cases and fails without the fix.
