### PR TITLE
fix #4497: preserve nested ampersands during minification

### DIFF
--- a/internal/css_parser/css_parser_selector.go
+++ b/internal/css_parser/css_parser_selector.go
@@ -252,8 +252,11 @@ const (
 func analyzeLeadingAmpersand(sel css_ast.ComplexSelector, isDeclarationContext bool) leadingAmpersand {
 	if len(sel.Selectors) > 1 {
 		if first := sel.Selectors[0]; first.IsSingleAmpersand() {
-			if second := sel.Selectors[1]; second.Combinator.Byte == 0 && len(second.NestingSelectorLocs) > 0 {
+			second := sel.Selectors[1]
+			rest := css_ast.ComplexSelector{Selectors: sel.Selectors[1:]}
+			if second.Combinator.Byte == 0 && rest.ContainsNestingCombinator() {
 				// ".foo { & &.bar {} }" => ".foo { & &.bar {} }"
+				// ".foo { & .bar:not(& .baz) {} }" => ".foo { & .bar:not(& .baz) {} }"
 			} else if second.Combinator.Byte != 0 || second.TypeSelector == nil || !isDeclarationContext {
 				// "& + div {}" => "+ div {}"
 				// "& div {}" => "div {}"

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -1137,6 +1137,9 @@ func TestNestedSelector(t *testing.T) {
 	expectPrintedMangle(t, "a { @media screen { & div { color: red } } }", "a {\n  @media screen {\n    & div {\n      color: red;\n    }\n  }\n}\n", "")
 	expectPrintedMangle(t, "a { :has(& b) { color: red } }", "a {\n  :has(& b) {\n    color: red;\n  }\n}\n", "")
 	expectPrintedMangle(t, "a { :has(& + b) { color: red } }", "a {\n  :has(& + b) {\n    color: red;\n  }\n}\n", "")
+	expectPrintedMangle(t, "a { & .b:not(& .c) { color: red } }", "a {\n  & .b:not(& .c) {\n    color: red;\n  }\n}\n", "")
+	expectPrintedMangle(t, "a { & .b:is(.c &) { color: red } }", "a {\n  & .b:is(.c &) {\n    color: red;\n  }\n}\n", "")
+	expectPrintedMangle(t, "a { & + .b:not(& .c) { color: red } }", "a {\n  + .b:not(& .c) {\n    color: red;\n  }\n}\n", "")
 
 	// Reorder selectors to enable removing "&"
 	expectPrintedMangle(t, "reorder { & first, .second { color: red } }", "reorder {\n  .second,\n  first {\n    color: red;\n  }\n}\n", "")


### PR DESCRIPTION
Fixes #4497.

The leading-ampersand minification check only inspected NestingSelectorLocs on the next compound selector. That misses nesting selectors inside functional pseudo-classes such as :not(), so an explicit leading ampersand could be removed even though another ampersand still made the complex selector non-relative.

This uses the existing recursive ContainsNestingCombinator() traversal on the remainder of the selector before removing the leading ampersand. It preserves the explicit anchor when a descendant selector contains another nesting selector, while keeping the existing minification for selectors that start with an explicit combinator such as +.

Regression coverage includes nested ampersand references inside :not() and :is(), plus the explicit-combinator case.

Tests:
- go test ./internal/... ./pkg/... (with WT_SESSION set for the expected Windows Terminal glyph mode)
- go vet ./cmd/... ./internal/... ./pkg/...
- The complete reproduction from #4497 through the local CLI

AI assistance disclosure: OpenAI Codex was used to reproduce the issue, inspect the parser and AST, implement the change and regression tests, run local verification, and assist with this PR description.