### PR TITLE
fix #4508: preserve lowered assignment bindings

### DIFF
--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -849,6 +849,9 @@ func (p *parser) lowerAssignmentOperator(value js_ast.Expr, callback func(js_ast
 		}
 
 	case *js_ast.EIdentifier:
+		// The assignment target was already recorded as one usage when it was
+		// visited. Lowering it generates a second usage, so record that too.
+		p.recordUsage(left.Ref)
 		return callback(
 			js_ast.Expr{Loc: value.Loc, Data: &js_ast.EIdentifier{Ref: left.Ref}},
 			value,

--- a/internal/js_parser/js_parser_lower_test.go
+++ b/internal/js_parser/js_parser_lower_test.go
@@ -214,6 +214,12 @@ class Foo {
 _x = new WeakMap();
 `)
 
+	// Lowering generates an additional symbol use that must keep the declaration
+	expectPrintedMangleTarget(t, 2020, `let r;
+(P => (P[P.NOT_RECOGNIZED = 0] = "NOT_RECOGNIZED", P[P.SET = 1] = "SET"))(r ||= {});`, `let r;
+((P) => (P[P.NOT_RECOGNIZED = 0] = "NOT_RECOGNIZED", P[P.SET = 1] = "SET"))(r || (r = {}));
+`)
+
 	expectPrintedTarget(t, 2021, "a ||= b", "a ||= b;\n")
 	expectPrintedTarget(t, 2021, "a.b ||= c", "a.b ||= c;\n")
 	expectPrintedTarget(t, 2021, "a().b ||= c", "a().b ||= c;\n")


### PR DESCRIPTION
Fixes #4508.

Lowering an assignment operator duplicates an identifier into separate read and write nodes, but the generated second reference wasn't included in the symbol use count. When single-use inlining later simplified the read side of a lowered `||=`, it could also remove the declaration while leaving the write behind.

This change records the generated identifier use and adds a regression test for the enum-IIFE pattern from the issue.

Tests:
- `go test ./internal/... ./pkg/...`
- `go vet ./cmd/... ./internal/... ./pkg/...`
- `node scripts/plugin-tests.js`
- `node scripts/js-api-tests.js`
- `node scripts/register-test.js`
- `node scripts/node-unref-tests.js`