### PR TITLE
escape `<!--` and `-->` for inline-script safety

### DIFF
--- a/internal/js_parser/js_parser.go
+++ b/internal/js_parser/js_parser.go
@@ -13405,6 +13405,21 @@ func containsClosingScriptTag(text string) bool {
 	return false
 }
 
+// containsInlineScriptHazard reports whether text contains a character
+// sequence that the HTML parser's script data state machine treats specially
+// inside a <script> element: "</script" (closes the element), "<!--" (enters
+// the "script data escaped" state), or "-->" (exits an escaped state). When
+// such a sequence appears in a tagged template literal, the printer cannot
+// escape it because the raw template content is emitted verbatim, so the
+// template must be lowered into a regular call first (mirroring Terser's
+// inline_script option, which escapes these sequences in string output).
+func containsInlineScriptHazard(text string) bool {
+	if containsClosingScriptTag(text) {
+		return true
+	}
+	return strings.Contains(text, "<!--") || strings.Contains(text, "-->")
+}
+
 func (p *parser) isUnsupportedRegularExpression(loc logger.Loc, value string) (pattern string, flags string, isUnsupported bool) {
 	var what string
 	var r logger.Range
@@ -14175,14 +14190,14 @@ func (p *parser) visitExprInOut(expr js_ast.Expr, in exprIn) (js_ast.Expr, exprO
 			shouldLowerTemplateLiteral = true
 		}
 
-		// Lower tagged template literals that include "</script"
-		// since we won't be able to escape it without lowering it
+		// Lower tagged template literals that include "</script", "<!--", or "-->"
+		// since we won't be able to escape them without lowering it
 		if !shouldLowerTemplateLiteral && !p.options.unsupportedJSFeatures.Has(compat.InlineScript) && e.TagOrNil.Data != nil {
-			if containsClosingScriptTag(e.HeadRaw) {
+			if containsInlineScriptHazard(e.HeadRaw) {
 				shouldLowerTemplateLiteral = true
 			} else {
 				for _, part := range e.Parts {
-					if containsClosingScriptTag(part.TailRaw) {
+					if containsInlineScriptHazard(part.TailRaw) {
 						shouldLowerTemplateLiteral = true
 						break
 					}

--- a/internal/js_printer/js_printer.go
+++ b/internal/js_printer/js_printer.go
@@ -155,6 +155,33 @@ func (p *printer) printUnquotedUTF16(text []uint16, quote rune, flags printQuote
 			}
 			js = append(js, '/')
 
+		case '<':
+			// Avoid generating the sequence "<!--" in JS code. Per the HTML
+			// spec, "<!--" inside a script element puts the parser into the
+			// "script data escaped" state, where a later "<script" sequence
+			// would enter the "script data double escaped" state and prevent
+			// the closing "</script>" tag from ending the script element. Escape
+			// the "<" as "\x3c" to keep the string content inert, mirroring the
+			// inline_script option in Terser.
+			if !p.options.UnsupportedFeatures.Has(compat.InlineScript) && i+3 <= n &&
+				text[i] == '!' && text[i+1] == '-' && text[i+2] == '-' {
+				js = append(js, "\\x3c"...)
+			} else {
+				js = append(js, '<')
+			}
+
+		case '>':
+			// Avoid generating the sequence "-->" in JS code, which also
+			// participates in the HTML parser's script data state machine.
+			// Escape the ">" as "\x3e" to keep the string content inert,
+			// mirroring the inline_script option in Terser.
+			if !p.options.UnsupportedFeatures.Has(compat.InlineScript) && i >= 3 &&
+				text[i-2] == '-' && text[i-3] == '-' {
+				js = append(js, "\\x3e"...)
+			} else {
+				js = append(js, '>')
+			}
+
 		case '\'':
 			if quote == '\'' {
 				js = append(js, '\\')

--- a/internal/js_printer/js_printer_test.go
+++ b/internal/js_printer/js_printer_test.go
@@ -1074,12 +1074,49 @@ func TestAvoidSlashScript(t *testing.T) {
 	expectPrinted(t, "String.raw`</ScRiPt`",
 		"import { __template } from \"<runtime>\";\nvar _a;\nString.raw(_a || (_a = __template([\"<\\/ScRiPt\"])));\n")
 
+	// HTML comment sequences "<!--" and "-->" are escaped to avoid putting the
+	// surrounding HTML parser into the "script data escaped" / "script data
+	// double escaped" states, which would prevent "</script>" from ending the
+	// script element. This mirrors Terser's inline_script option.
+	expectPrinted(t, "x = '<!--'", "x = \"\\x3c!--\";\n")
+	expectPrinted(t, "x = `<!--`", "x = `\\x3c!--`;\n")
+	expectPrinted(t, "x = `${y}<!--`", "x = `${y}\\x3c!--`;\n")
+	expectPrinted(t, "x = `<!--${y}`", "x = `\\x3c!--${y}`;\n")
+	expectPrinted(t, "x = '-->'", "x = \"--\\x3e\";\n")
+	expectPrinted(t, "x = `-->`", "x = `--\\x3e`;\n")
+	expectPrinted(t, "x = `${y}-->`", "x = `${y}--\\x3e`;\n")
+	expectPrinted(t, "x = `-->${y}`", "x = `--\\x3e${y}`;\n")
+	expectPrinted(t, "x = '<!-- <script>'", "x = \"\\x3c!-- <script>\";\n")
+	expectPrinted(t, "x = '<!-- --> <script>'", "x = \"\\x3c!-- --\\x3e <script>\";\n")
+	expectPrinted(t, "x = '--->'", "x = \"---\\x3e\";\n")
+	// "<!--->" is "<!--" + "->" (six chars: '<','!','-','-','-', '>'); the '<'
+	// opens an HTML comment and the trailing "-->" closes it, so both ends must
+	// be escaped, leaving the three dashes between verbatim.
+	expectPrinted(t, "x = '<!--->'", "x = \"\\x3c!---\\x3e\";\n")
+	// String.raw preserves the raw string value; the '\x3c'/'\x3e' escapes only
+	// hide the literal sequence from the HTML parser in the generated source.
+	expectPrinted(t, "x = String.raw`<!--`",
+		"import { __template } from \"<runtime>\";\nvar _a;\nx = String.raw(_a || (_a = __template([\"\\x3c!--\"])));\n")
+	expectPrinted(t, "x = String.raw`-->`",
+		"import { __template } from \"<runtime>\";\nvar _a;\nx = String.raw(_a || (_a = __template([\"--\\x3e\"])));\n")
+
 	// Negative cases
 	expectPrinted(t, "x = '</'", "x = \"</\";\n")
 	expectPrinted(t, "x = '</ script'", "x = \"</ script\";\n")
 	expectPrinted(t, "x = '< /script'", "x = \"< /script\";\n")
 	expectPrinted(t, "x = '/script>'", "x = \"/script>\";\n")
 	expectPrinted(t, "x = '<script>'", "x = \"<script>\";\n")
+	expectPrinted(t, "x = '<!-'", "x = \"<!-\";\n")
+	expectPrinted(t, "x = '<!-a'", "x = \"<!-a\";\n")
+	expectPrinted(t, "x = '<!a'", "x = \"<!a\";\n")
+	expectPrinted(t, "x = '<a'", "x = \"<a\";\n")
+	expectPrinted(t, "x = '<'", "x = \"<\";\n")
+	expectPrinted(t, "x = '>'", "x = \">\";\n")
+	expectPrinted(t, "x = '->'", "x = \"->\";\n")
+	expectPrinted(t, "x = '-a>'", "x = \"-a>\";\n")
+	expectPrinted(t, "x = 'a-b>'", "x = \"a-b>\";\n")
+	expectPrinted(t, "x = '<--'", "x = \"<--\";\n")
+	expectPrinted(t, "x = '<!- --'", "x = \"<!- --\";\n")
 	expectPrintedMinify(t, "x = 1 < / script/.exec(y).length", "x=1</ script/.exec(y).length;")
 	expectPrintedMinify(t, "x = 1 << / script/.exec(y).length", "x=1<</ script/.exec(y).length;")
 }


### PR DESCRIPTION
Fixes #4494.

When the `inline-script` feature is enabled (the default), esbuild escapes `</script` in string/template literals so output can be embedded in an inline `<script>` tag. The HTML parser's script data state machine also treats `<!--` and `-->` specially:

- `<!--` enters the ["script data escaped"](https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-state) state
- a later `<script` in that state enters the ["script data double escaped"](https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-state) state, where `</script>` no longer ends the element
- `-->` exits the escaped state

So a string like `"<!-- <script>"` defeats the existing `</script` escaping. This PR escapes `<!--` as `\x3c!--` and `-->` as `--\x3e` in string/template content, mirroring [Terser's `inline_script` option](https://github.com/terser/terser), which the issue references:

```js
console.log("<!--", "<script>", "-->");
// Becomes:
console.log("\x3c!--","<script>","--\x3e");
```

`<script>` (without a slash) is left alone, matching Terser: it is only dangerous after a `<!--`, which is now escaped, and in the normal script-data state `<script` does nothing special.

Tagged template literals such as `String.raw\`...\`` emit raw content verbatim, so the printer cannot escape them in place. The existing `</script` lowering (which turns such templates into `__template` calls) is extended to also cover `<!--` and `-->`, letting the same escapes apply to the raw content while preserving the runtime value (the `\x3c`/`\x3e` escapes are source-level only; the string value stays `<!--`/`-->`, same as the existing `</script` handling).

Both the printer escaping and the tagged-template lowering are gated on `compat.InlineScript` being supported, consistent with the existing `</script` behavior.

```js
// in
console.log("<!-- <script>", "-->");
// out
console.log("\x3c!-- <script>", "--\x3e");
```

```js
// in
x = String.raw`<!--`;
// out
import { __template } from "<runtime>";
var _a;
x = String.raw(_a || (_a = __template(["\x3c!--"])));
```

`go build ./...` and `go test ./...` pass; `gofmt` and `go vet` clean on the touched files.