### PR TITLE
Fix computed constructor getters during class lowering

### DIFF
--- a/internal/bundler_tests/bundler_lower_test.go
+++ b/internal/bundler_tests/bundler_lower_test.go
@@ -1584,6 +1584,34 @@ func TestLowerPrivateSuperStaticBundleIssue2158(t *testing.T) {
 	})
 }
 
+// https://github.com/evanw/esbuild/issues/4495
+func TestLowerClassFieldComputedConstructorGetterIssue4495(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				class Foo extends Error {
+					field = 1
+					constructor() {
+						super("test")
+					}
+					get ["constructor"]() {
+						return Error
+					}
+				}
+				if (new Foo().field !== 1) throw "fail"
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode: config.ModeBundle,
+			UnsupportedJSFeatures: compat.UnsupportedJSFeatures(map[compat.Engine]compat.Semver{
+				compat.Node: {Parts: []int{10}},
+			}),
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
 func TestLowerClassField2020NoBundle(t *testing.T) {
 	lower_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler_tests/snapshots/snapshots_lower.txt
+++ b/internal/bundler_tests/snapshots/snapshots_lower.txt
@@ -1978,6 +1978,21 @@ __publicField(Foo, "s_foo", 123);
 __publicField(Foo, "s_bar");
 
 ================================================================================
+TestLowerClassFieldComputedConstructorGetterIssue4495
+---------- /out.js ----------
+// entry.js
+var Foo = class extends Error {
+  constructor() {
+    super("test");
+    __publicField(this, "field", 1);
+  }
+  get ["constructor"]() {
+    return Error;
+  }
+};
+if (new Foo().field !== 1) throw "fail";
+
+================================================================================
 TestLowerClassFieldNextNoBundle
 ---------- /out.js ----------
 class Foo {

--- a/internal/js_parser/js_parser_lower_class.go
+++ b/internal/js_parser/js_parser_lower_class.go
@@ -1064,7 +1064,11 @@ func (ctx *lowerClassContext) lowerMethod(p *parser, prop js_ast.Property, priva
 		return true
 	}
 
-	if key, ok := prop.Key.Data.(*js_ast.EString); ok && helpers.UTF16EqualsString(key.Value, "constructor") {
+	if key, ok := prop.Key.Data.(*js_ast.EString); ok &&
+		prop.Kind == js_ast.PropertyMethod &&
+		!prop.Flags.Has(js_ast.PropertyIsComputed) &&
+		!prop.Flags.Has(js_ast.PropertyIsStatic) &&
+		helpers.UTF16EqualsString(key.Value, "constructor") {
 		if fn, ok := prop.ValueOrNil.Data.(*js_ast.EFunction); ok {
 			// Remember where the constructor is for later
 			ctx.ctor = fn


### PR DESCRIPTION
Fixes #4495

A computed getter named `"constructor"` was being treated as the actual class constructor during class lowering. That put the generated `__super` helper in the getter instead of the constructor and produced invalid output for older targets such as Node 10.

This change only identifies non-static, non-computed methods as constructors and adds regression coverage for the computed getter case.

Tests:
- `env -u GOROOT go test -race ./cmd/... ./internal/... ./pkg/...`
- `env -u GOROOT go vet ./cmd/... ./internal/... ./pkg/...`