### PR TITLE
Keep use strict inside IIFE wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Keep `"use strict"` inside the IIFE wrapper when bundling with the `iife` format ([#4505](https://github.com/evanw/esbuild/issues/4505))
+
 * Allow `es2026` as a target in `tsconfig.json`
 
     TypeScript is [adding `es2026`](https://github.com/microsoft/TypeScript/issues/63704) as a compilation target, so esbuild now supports this in the `target` field of `tsconfig.json` files, such as in the following configuration file:

--- a/internal/bundler_tests/bundler_default_test.go
+++ b/internal/bundler_tests/bundler_default_test.go
@@ -1418,6 +1418,23 @@ func TestHashbangBannerUseStrictOrder(t *testing.T) {
 	})
 }
 
+func TestUseStrictInsideIIFE(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				'use strict'
+				foo()
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			AbsOutputFile: "/out.js",
+			OutputFormat:  config.FormatIIFE,
+		},
+	})
+}
+
 func TestRequireFSBrowser(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler_tests/snapshots/snapshots_default.txt
+++ b/internal/bundler_tests/snapshots/snapshots_default.txt
@@ -1766,8 +1766,8 @@ TestHashbangBannerUseStrictOrder
 ---------- /out.js ----------
 #! in file
 #! from banner
-"use strict";
 (() => {
+  "use strict";
   // entry.js
   foo();
 })();
@@ -7063,8 +7063,8 @@ export {
 ================================================================================
 TestUseStrictDirectiveBundleIIFEIssue2264
 ---------- /out.js ----------
-"use strict";
 (() => {
+  "use strict";
   // entry.js
   var a = 1;
 })();
@@ -7099,6 +7099,15 @@ TestUseStrictDirectiveBundleIssue1837
 TestUseStrictDirectiveMinifyNoBundle
 ---------- /out.js ----------
 "use strict";"use loose";a,b;
+
+================================================================================
+TestUseStrictInsideIIFE
+---------- /out.js ----------
+(() => {
+  "use strict";
+  // entry.js
+  foo();
+})();
 
 ================================================================================
 TestVarRelocatingBundle

--- a/internal/bundler_tests/snapshots/snapshots_tsconfig.txt
+++ b/internal/bundler_tests/snapshots/snapshots_tsconfig.txt
@@ -40,15 +40,15 @@ console.log('this file should not start with "use strict"');
 ================================================================================
 TestTsconfigAlwaysStrictTrueEmitDirectiveBundleIIFE
 ---------- /Users/user/project/out/implicit.js ----------
-"use strict";
 (() => {
+  "use strict";
   // Users/user/project/src/implicit.ts
   console.log('this file should start with "use strict"');
 })();
 
 ---------- /Users/user/project/out/explicit.js ----------
-"use strict";
 (() => {
+  "use strict";
   // Users/user/project/src/explicit.ts
   console.log('this file should start with "use strict"');
 })();

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -5712,17 +5712,27 @@ func (c *linkerContext) generateChunkJS(chunkIndex int, chunkWaitGroup *sync.Wai
 		newlineBeforeComment = true
 	}
 
-	// Add the top-level directive if present (but omit "use strict" in ES
-	// modules because all ES modules are automatically in strict mode)
+	var entryPointDirectives []string
 	if chunk.isEntryPoint {
 		repr := c.graph.Files[chunk.sourceIndex].InputFile.Repr.(*graph.JSRepr)
-		for _, directive := range repr.AST.Directives {
-			if directive != "use strict" || c.options.OutputFormat != config.FormatESModule {
-				quoted := string(helpers.QuoteForJSON(directive, c.options.ASCIIOnly)) + ";" + newline
-				prevOffset.AdvanceString(quoted)
-				j.AddString(quoted)
-				newlineBeforeComment = true
-			}
+		entryPointDirectives = repr.AST.Directives
+	}
+	addDirective := func(directive string, indent string) {
+		quoted := string(helpers.QuoteForJSON(directive, c.options.ASCIIOnly)) + ";" + newline
+		if indent != "" && !c.options.MinifyWhitespace {
+			quoted = indent + quoted
+		}
+		prevOffset.AdvanceString(quoted)
+		j.AddString(quoted)
+	}
+
+	// Add the top-level directive if present (but omit "use strict" in ES
+	// modules because all ES modules are automatically in strict mode, and in
+	// IIFEs because it needs to be inside the IIFE)
+	for _, directive := range entryPointDirectives {
+		if directive != "use strict" || (c.options.OutputFormat != config.FormatESModule && c.options.OutputFormat != config.FormatIIFE) {
+			addDirective(directive, "")
+			newlineBeforeComment = true
 		}
 	}
 
@@ -5741,6 +5751,16 @@ func (c *linkerContext) generateChunkJS(chunkIndex int, chunkWaitGroup *sync.Wai
 		prevOffset.AdvanceString(text)
 		j.AddString(text)
 		newlineBeforeComment = false
+	}
+
+	// Put "use strict" inside the IIFE instead of before it
+	if c.options.OutputFormat == config.FormatIIFE {
+		for _, directive := range entryPointDirectives {
+			if directive == "use strict" {
+				addDirective(directive, indent)
+				newlineBeforeComment = false
+			}
+		}
 	}
 
 	// Put the cross-chunk prefix inside the IIFE


### PR DESCRIPTION
Fixes #4505.
This moves entry point `"use strict"` directives inside the generated IIFE wrapper instead of emitting them at the top level. This keeps strict mode scoped to the generated wrapper for platforms that concatenate scripts together.
Tests updated for both explicit entry point directives and `tsconfig.json` `alwaysStrict` output.
Tested with:
```
go test -count=1 ./...
```