### PR TITLE
Fix calc minification with typed multiplier

### DIFF
--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -2230,6 +2230,7 @@ func TestMangleCalc(t *testing.T) {
 	expectPrintedMangle(t, "a { b: calc(x / 4) }", "a {\n  b: calc(x / 4);\n}\n", "")
 	expectPrintedMangle(t, "a { b: calc(x * 0.25) }", "a {\n  b: calc(x / 4);\n}\n", "")
 	expectPrintedMangle(t, "a { b: calc(x / 0.25) }", "a {\n  b: calc(x * 4);\n}\n", "")
+	expectPrintedMangle(t, "a { b: calc(sibling-index() * 0.05s) }", "a {\n  b: calc(sibling-index() * .05s);\n}\n", "")
 
 	// Test operator precedence
 	expectPrintedMangle(t, "a { b: calc((a + b) + c) }", "a {\n  b: calc(a + b + c);\n}\n", "")

--- a/internal/css_parser/css_reduce_calc.go
+++ b/internal/css_parser/css_reduce_calc.go
@@ -396,7 +396,7 @@ func (c *calcProduct) partiallySimplify() calcTerm {
 
 	// ALGORITHM DEVIATION: Divide instead of multiply if the reciprocal is shorter
 	for i := 1; i < len(terms); i++ {
-		if numeric, ok := terms[i].data.(*calcNumeric); ok {
+		if numeric, ok := terms[i].data.(*calcNumeric); ok && numeric.unit == "" {
 			reciprocal := 1 / numeric.number
 			if multiply, ok := floatToStringForCalc(numeric.number); ok {
 				if divide, ok := floatToStringForCalc(reciprocal); ok && len(divide) < len(multiply) {


### PR DESCRIPTION
Fixes #4515

This keeps esbuild's reciprocal-shortening optimization limited to unitless numeric terms. Unit-bearing terms such as `0.05s` should stay multipliers, since serializing them as a divisor produces invalid CSS like `/20s`.

Tests:
- `go test ./internal/css_parser -run TestMangleCalc -count=1`
- `go test ./internal/css_parser -count=1`
- `git diff --check`
