### PR TITLE
fix #4518: conditional css transform linear-gradient single-color-stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+* Added conditional CSS transform of single color stop linear gradient ([#4518](https://github.com/evanw/esbuild/issues/4518))
+
+    ```css
+    /* Original code */
+    a { background: linear-gradient(red); }
+
+    /* New output */
+    a { background: linear-gradient(red, red); }
+    ```
+
 * Allow `es2026` as a target in `tsconfig.json`
 
     TypeScript is [adding `es2026`](https://github.com/microsoft/TypeScript/issues/63704) as a compilation target, so esbuild now supports this in the `target` field of `tsconfig.json` files, such as in the following configuration file:

--- a/compat-table/src/index.ts
+++ b/compat-table/src/index.ts
@@ -96,6 +96,7 @@ export const cssFeatures = {
   GradientDoublePosition: true,
   GradientInterpolation: true,
   GradientMidpoints: true,
+  GradientSingleColorStop: true,
   HexRGBA: true,
   HWB: true,
   InlineStyle: true,

--- a/compat-table/src/mdn.ts
+++ b/compat-table/src/mdn.ts
@@ -61,6 +61,10 @@ const cssFeatures: Partial<Record<CSSFeature, string | string[]>> = {
     'css.types.gradient.repeating-linear-gradient.interpolation_hints',
     'css.types.gradient.repeating-radial-gradient.interpolation_hints',
   ],
+  GradientSingleColorStop: [
+    'css.types.gradient.linear-gradient.single_color_stop',
+    'css.types.gradient.repeating-linear-gradient.single_color_stop',
+  ],
   HexRGBA: 'css.types.color.rgb_hexadecimal_notation.alpha_hexadecimal_notation',
   HWB: 'css.types.color.hwb',
   InsetProperty: 'css.properties.inset',

--- a/internal/compat/css_table.go
+++ b/internal/compat/css_table.go
@@ -13,6 +13,7 @@ const (
 	GradientDoublePosition
 	GradientInterpolation
 	GradientMidpoints
+	GradientSingleColorStop
 	HWB
 	HexRGBA
 	InlineStyle
@@ -25,19 +26,20 @@ const (
 )
 
 var StringToCSSFeature = map[string]CSSFeature{
-	"color-functions":          ColorFunctions,
-	"gradient-double-position": GradientDoublePosition,
-	"gradient-interpolation":   GradientInterpolation,
-	"gradient-midpoints":       GradientMidpoints,
-	"hwb":                      HWB,
-	"hex-rgba":                 HexRGBA,
-	"inline-style":             InlineStyle,
-	"inset-property":           InsetProperty,
-	"is-pseudo-class":          IsPseudoClass,
-	"media-range":              MediaRange,
-	"modern-rgb-hsl":           Modern_RGB_HSL,
-	"nesting":                  Nesting,
-	"rebecca-purple":           RebeccaPurple,
+	"color-functions":            ColorFunctions,
+	"gradient-double-position":   GradientDoublePosition,
+	"gradient-interpolation":     GradientInterpolation,
+	"gradient-midpoints":         GradientMidpoints,
+	"gradient-single-color-stop": GradientSingleColorStop,
+	"hwb":                        HWB,
+	"hex-rgba":                   HexRGBA,
+	"inline-style":               InlineStyle,
+	"inset-property":             InsetProperty,
+	"is-pseudo-class":            IsPseudoClass,
+	"media-range":                MediaRange,
+	"modern-rgb-hsl":             Modern_RGB_HSL,
+	"nesting":                    Nesting,
+	"rebecca-purple":             RebeccaPurple,
 }
 
 func (features CSSFeature) Has(feature CSSFeature) bool {
@@ -80,6 +82,14 @@ var cssTable = map[CSSFeature]map[Engine][]versionRange{
 		IOS:     {{start: v{7, 0, 0}}},
 		Opera:   {{start: v{27, 0, 0}}},
 		Safari:  {{start: v{7, 0, 0}}},
+	},
+	GradientSingleColorStop: {
+		Chrome:  {{start: v{135, 0, 0}}},
+		Edge:    {{start: v{135, 0, 0}}},
+		Firefox: {{start: v{136, 0, 0}}},
+		IOS:     {{start: v{18, 4, 0}}},
+		Opera:   {{start: v{120, 0, 0}}},
+		Safari:  {{start: v{18, 4, 0}}},
 	},
 	HWB: {
 		Chrome:  {{start: v{101, 0, 0}}},

--- a/internal/css_parser/css_decls_gradient.go
+++ b/internal/css_parser/css_decls_gradient.go
@@ -176,6 +176,12 @@ func (p *parser) lowerAndMinifyGradient(token css_ast.Token, wouldClipColor *boo
 	lowerMidpoints := p.options.unsupportedCSSFeatures.Has(compat.GradientMidpoints)
 	lowerColorSpaces := p.options.unsupportedCSSFeatures.Has(compat.ColorFunctions)
 	lowerInterpolation := p.options.unsupportedCSSFeatures.Has(compat.GradientInterpolation)
+	lowerSingleColorStop := p.options.unsupportedCSSFeatures.Has(compat.GradientSingleColorStop)
+
+	// Older browsers require linear gradients to have at least two color stops
+	if lowerSingleColorStop && gradient.kind == linearGradient && len(gradient.colorStops) == 1 {
+		gradient.colorStops = []colorStop{gradient.colorStops[0], gradient.colorStops[0]}
+	}
 
 	// Assume that if the browser doesn't support color spaces in gradients, then
 	// it doesn't correctly interpolate non-sRGB colors even when a color space

--- a/internal/css_parser/css_parser_test.go
+++ b/internal/css_parser/css_parser_test.go
@@ -886,6 +886,22 @@ func TestGradient(t *testing.T) {
 	}
 }
 
+func TestGradientSingleColorStop(t *testing.T) {
+	code := "a { background: linear-gradient(red) }"
+	expectPrinted(t, code, "a {\n  background: linear-gradient(red);\n}\n", "")
+	expectPrintedLowerUnsupported(t, compat.GradientSingleColorStop, code,
+		"a {\n  background: linear-gradient(red, red);\n}\n", "")
+
+	code = "a { background: repeating-linear-gradient(red) }"
+	expectPrinted(t, code, "a {\n  background: repeating-linear-gradient(red);\n}\n", "")
+	expectPrintedLowerUnsupported(t, compat.GradientSingleColorStop, code,
+		"a {\n  background: repeating-linear-gradient(red, red);\n}\n", "")
+
+	code = "a { background: linear-gradient(to right, #abc 20%) }"
+	expectPrintedLowerUnsupported(t, compat.GradientSingleColorStop, code,
+		"a {\n  background:\n    linear-gradient(\n      to right,\n      #abc 20%,\n      #abc 20%);\n}\n", "")
+}
+
 func TestDeclaration(t *testing.T) {
 	expectPrinted(t, ".decl {}", ".decl {\n}\n", "")
 	expectPrinted(t, ".decl { a: b }", ".decl {\n  a: b;\n}\n", "")


### PR DESCRIPTION
Added conditional CSS transform of single color stop linear gradient ([#4518](https://github.com/evanw/esbuild/issues/4518))

    ```css
    /* Original code */
    a { background: linear-gradient(red); }

    /* New output */
    a { background: linear-gradient(red, red); }
    ```