### PR TITLE
Fix object rest temp name collisions

### DIFF
--- a/internal/bundler_tests/bundler_lower_test.go
+++ b/internal/bundler_tests/bundler_lower_test.go
@@ -1868,6 +1868,103 @@ func TestTSLowerObjectRest2018NoBundle(t *testing.T) {
 	})
 }
 
+func TestTSLowerObjectRestNameCollision(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { C } from './moduleA.js';
+				import { rest } from './moduleB.js';
+				console.log(C.make(), rest);
+			`,
+			"/moduleA.js": `
+				var _a;
+				export class C {
+					static make() {
+						return new _a();
+					}
+				}
+				_a = C;
+			`,
+			"/moduleB.js": `
+				const value = { a: 1, b: 2 };
+				export const { a, ...rest } = value;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:                  config.ModeBundle,
+			UnsupportedJSFeatures: es(2017),
+			AbsOutputFile:         "/out.js",
+		},
+	})
+}
+
+func TestTSLowerObjectRestNestedObjectNameCollision(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { C } from './moduleA.js';
+				import { rest } from './moduleB.js';
+				console.log(C.make(), rest);
+			`,
+			"/moduleA.js": `
+				var _a;
+				export class C {
+					static make() {
+						return new _a();
+					}
+				}
+				_a = C;
+			`,
+			"/moduleB.js": `
+				const value = { nested: { a: 1, b: 2 } };
+				export const { nested: { ...rest } } = value;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:                  config.ModeBundle,
+			UnsupportedJSFeatures: es(2017),
+			AbsOutputFile:         "/out.js",
+		},
+	})
+}
+
+func TestTSLowerObjectRestNestedArrayNameCollision(t *testing.T) {
+	lower_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				import { C } from './moduleA.js';
+				import { rest, tail } from './moduleB.js';
+				console.log(C.make(), C.value(), rest, tail);
+			`,
+			"/moduleA.js": `
+				var _a, _b;
+				export class C {
+					static make() {
+						return new _a();
+					}
+					static value() {
+						return _b;
+					}
+				}
+				_a = C;
+				_b = 42;
+			`,
+			"/moduleB.js": `
+				const value = [{ a: 1, b: 2 }, 3];
+				export const [{ ...rest }, tail] = value;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:                  config.ModeBundle,
+			UnsupportedJSFeatures: es(2017),
+			AbsOutputFile:         "/out.js",
+		},
+	})
+}
+
 func TestClassSuperThisIssue242NoBundle(t *testing.T) {
 	lower_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler_tests/snapshots/snapshots_lower.txt
+++ b/internal/bundler_tests/snapshots/snapshots_lower.txt
@@ -4847,6 +4847,68 @@ console.log({ x, ...xx } = { x });
 console.log({ x: { ...xx } } = { x });
 
 ================================================================================
+TestTSLowerObjectRestNameCollision
+---------- /out.js ----------
+// moduleA.js
+var _a;
+var C = class {
+  static make() {
+    return new _a();
+  }
+};
+_a = C;
+
+// moduleB.js
+var value = { a: 1, b: 2 };
+var _a2 = value, { a } = _a2, rest = __objRest(_a2, ["a"]);
+
+// entry.js
+console.log(C.make(), rest);
+
+================================================================================
+TestTSLowerObjectRestNestedArrayNameCollision
+---------- /out.js ----------
+// moduleA.js
+var _a;
+var _b;
+var C = class {
+  static make() {
+    return new _a();
+  }
+  static value() {
+    return _b;
+  }
+};
+_a = C;
+_b = 42;
+
+// moduleB.js
+var value = [{ a: 1, b: 2 }, 3];
+var [_a2, ..._b2] = value, rest = __objRest(_a2, []), [tail] = _b2;
+
+// entry.js
+console.log(C.make(), C.value(), rest, tail);
+
+================================================================================
+TestTSLowerObjectRestNestedObjectNameCollision
+---------- /out.js ----------
+// moduleA.js
+var _a;
+var C = class {
+  static make() {
+    return new _a();
+  }
+};
+_a = C;
+
+// moduleB.js
+var value = { nested: { a: 1, b: 2 } };
+var { nested: _a2 } = value, rest = __objRest(_a2, []);
+
+// entry.js
+console.log(C.make(), rest);
+
+================================================================================
 TestTSLowerPrivateFieldAndMethodAvoidNameCollision2015
 ---------- /out.js ----------
 // entry.ts

--- a/internal/js_parser/js_parser_lower.go
+++ b/internal/js_parser/js_parser_lower.go
@@ -1503,8 +1503,26 @@ func (p *parser) lowerObjectRestHelper(
 	// If there is at least one rest binding, lower the whole expression
 	var visit func(js_ast.Expr, js_ast.Expr, []func() js_ast.Expr)
 
-	captureIntoRef := func(expr js_ast.Expr) ast.Ref {
+	// These temporaries are declared explicitly in the lowered declaration list
+	// when "declare" is tempRefNoDeclare. Record them as declared symbols so the
+	// linker can rename them across modules.
+	generateObjectRestTempRef := func() ast.Ref {
 		ref := p.generateTempRef(declare, "")
+		if declare == tempRefNoDeclare {
+			scope := p.currentScope
+			for !scope.Kind.StopsHoisting() {
+				scope = scope.Parent
+			}
+			p.currentPart.DeclaredSymbols = append(p.currentPart.DeclaredSymbols, js_ast.DeclaredSymbol{
+				Ref:        ref,
+				IsTopLevel: scope == p.moduleScope,
+			})
+		}
+		return ref
+	}
+
+	captureIntoRef := func(expr js_ast.Expr) ast.Ref {
+		ref := generateObjectRestTempRef()
 		assign(js_ast.Expr{Loc: expr.Loc, Data: &js_ast.EIdentifier{Ref: ref}}, expr)
 		p.recordUsage(ref)
 		return ref
@@ -1554,7 +1572,7 @@ func (p *parser) lowerObjectRestHelper(
 		}
 
 		// Swap the binding with a temporary
-		splitRef := p.generateTempRef(declare, "")
+		splitRef := generateObjectRestTempRef()
 		deferredBinding := *binding
 		binding.Data = &js_ast.EIdentifier{Ref: splitRef}
 		items := append(before, split)
@@ -1563,7 +1581,7 @@ func (p *parser) lowerObjectRestHelper(
 		var tailExpr js_ast.Expr
 		var tailInit js_ast.Expr
 		if len(after) > 0 {
-			tailRef := p.generateTempRef(declare, "")
+			tailRef := generateObjectRestTempRef()
 			loc := after[0].Loc
 			tailExpr = js_ast.Expr{Loc: loc, Data: &js_ast.EArray{Items: after, IsSingleLine: isSingleLine}}
 			tailInit = js_ast.Expr{Loc: loc, Data: &js_ast.EIdentifier{Ref: tailRef}}
@@ -1605,7 +1623,7 @@ func (p *parser) lowerObjectRestHelper(
 		binding := &split.ValueOrNil
 
 		// Swap the binding with a temporary
-		splitRef := p.generateTempRef(declare, "")
+		splitRef := generateObjectRestTempRef()
 		deferredBinding := *binding
 		binding.Data = &js_ast.EIdentifier{Ref: splitRef}
 		p.recordUsage(splitRef)


### PR DESCRIPTION
Generated temporaries that are emitted directly in lowered object-rest declarations were not registered as declared symbols. The linker could therefore reuse a name from another bundled module and change runtime behavior.

This registers all such object-rest temporaries, including nested object and array splits, and adds bundler snapshots covering each collision path.

Validation:
- `go test ./...`
- `go vet ./...`
- `gofmt`
- issue reproduction executes successfully after bundling

Fixes #4520.